### PR TITLE
Add the examples to demo listing/creating pods

### DIFF
--- a/examples/create_pod/Makefile
+++ b/examples/create_pod/Makefile
@@ -1,0 +1,8 @@
+INCLUDE:=-I../../kubernetes/include -I../../kubernetes/model -I../../kubernetes/api
+LIBS:=-L../../kubernetes/build -lkubernetes -lcurl -lpthread -lssl -lz
+CFLAGS:=-g
+
+all:
+	gcc main.c $(CFLAGS) $(INCLUDE) $(LIBS) -o create_pod_bin
+clean:
+	rm ./create_pod_bin

--- a/examples/create_pod/main.c
+++ b/examples/create_pod/main.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-#define K8S_APISERVER_BASEPATH "https://9.111.254.254:6443"
+#define K8S_APISERVER_BASEPATH "https://your.server.here"
 #define K8S_TOKEN_FILE_IN_CLUSTER "/var/run/secrets/kubernetes.io/serviceaccount/token"
 #define K8S_TOKEN_BUF_SIZE 1024
 #define K8S_AUTH_KEY "Authorization"
@@ -59,14 +59,10 @@ loadK8sConfigInCluster(char *token, int token_buf_size)
 
     if (fp == NULL) {
         if (errno == ENOENT) {
-            printf("\
-%s: The file %s does not exist.",
-            fname, K8S_TOKEN_FILE_IN_CLUSTER);
+            printf("%s: The file %s does not exist.", fname, K8S_TOKEN_FILE_IN_CLUSTER);
             return (-1);
         } else {
-            printf("\
-%s: Failed to open file %s (%m).",
-            fname, K8S_TOKEN_FILE_IN_CLUSTER);
+            printf("%s: Failed to open file %s.", fname, K8S_TOKEN_FILE_IN_CLUSTER);
             return (-1);
         }
     }
@@ -89,16 +85,11 @@ init_k8s_connector(const char *token_out_of_cluster)
     apiKeys = list_create();
 
     char *keyToken = strdup(K8S_AUTH_KEY);
-    char token_in_cluster[K8S_TOKEN_BUF_SIZE];
-    memset(token_in_cluster, 0, sizeof(token_in_cluster));
-
-    //loadK8sConfigInCluster(token_in_cluster, K8S_TOKEN_BUF_SIZE); // in cluster
-
+    
     char valueToken[K8S_TOKEN_BUF_SIZE];
     memset(valueToken, 0, sizeof(valueToken));
-    //sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token); // in cluster
     
-    sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token_out_of_cluster); // out of cluster
+    sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token_out_of_cluster);
 
     keyValuePair_t *keyPairToken = keyValuePair_create(keyToken, valueToken);
     list_addElement(apiKeys, keyPairToken);

--- a/examples/create_pod/main.c
+++ b/examples/create_pod/main.c
@@ -1,0 +1,118 @@
+#include <apiClient.h>
+#include <CoreV1API.h>
+#include <malloc.h>
+#include <stdio.h>
+#include <errno.h>
+
+#define K8S_APISERVER_BASEPATH "https://9.111.254.254:6443"
+#define K8S_TOKEN_FILE_IN_CLUSTER "/var/run/secrets/kubernetes.io/serviceaccount/token"
+#define K8S_TOKEN_BUF_SIZE 1024
+#define K8S_AUTH_KEY "Authorization"
+#define K8S_AUTH_VALUE_TEMPLATE "Bearer %s"
+
+apiClient_t *g_k8sAPIConnector;
+
+void create_a_pod(apiClient_t *apiClient)
+{
+    char *namespace = "default";
+
+    v1_pod_t * podinfo = calloc(1, sizeof(v1_pod_t));
+    podinfo->api_version = strdup("v1");
+    podinfo->kind = strdup("Pod");
+    podinfo->spec = calloc(1, sizeof(v1_pod_spec_t));
+
+    podinfo->metadata = calloc(1, sizeof(v1_object_meta_t));
+    podinfo->metadata->name = strdup("test-pod-6");
+
+    list_t *containerlist = list_create();
+    v1_container_t *con = calloc(1, sizeof(v1_container_t));
+    con->name = strdup("my-container");
+    con->image = strdup("ubuntu:16.04");
+    con->image_pull_policy = strdup("IfNotPresent");
+
+    list_t *commandlist = list_create();
+    char *cmd = strdup("sleep");
+    list_addElement(commandlist, cmd);
+    con->command = commandlist;
+
+    list_t *arglist = list_create();
+    char *arg1 = strdup("3600");
+    list_addElement(arglist, arg1);
+    con->args = arglist;
+
+    list_addElement(containerlist, con);
+    podinfo->spec->containers = containerlist;
+
+    v1_pod_t* apod = CoreV1API_createNamespacedPod(apiClient, namespace, podinfo, NULL, NULL, NULL);
+    printf("code=%ld\n", apiClient->response_code);
+
+    v1_pod_free(apod);
+}
+
+int
+loadK8sConfigInCluster(char *token, int token_buf_size)
+{
+    static char fname[] = "loadK8sConfigInCluster()";
+
+    FILE *fp;
+    fp = fopen(K8S_TOKEN_FILE_IN_CLUSTER, "r");
+
+    if (fp == NULL) {
+        if (errno == ENOENT) {
+            printf("\
+%s: The file %s does not exist.",
+            fname, K8S_TOKEN_FILE_IN_CLUSTER);
+            return (-1);
+        } else {
+            printf("\
+%s: Failed to open file %s (%m).",
+            fname, K8S_TOKEN_FILE_IN_CLUSTER);
+            return (-1);
+        }
+    }
+
+    while (fgets(token, token_buf_size, fp) != NULL) {
+        ;
+    }
+
+    printf("%s\n", token);
+
+    fclose(fp);
+
+    return 0;
+}
+
+int
+init_k8s_connector(const char *token_out_of_cluster)
+{
+    list_t *apiKeys;
+    apiKeys = list_create();
+
+    char *keyToken = strdup(K8S_AUTH_KEY);
+    char token_in_cluster[K8S_TOKEN_BUF_SIZE];
+    memset(token_in_cluster, 0, sizeof(token_in_cluster));
+
+    //loadK8sConfigInCluster(token_in_cluster, K8S_TOKEN_BUF_SIZE); // in cluster
+
+    char valueToken[K8S_TOKEN_BUF_SIZE];
+    memset(valueToken, 0, sizeof(valueToken));
+    //sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token); // in cluster
+    
+    sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token_out_of_cluster); // out of cluster
+
+    keyValuePair_t *keyPairToken = keyValuePair_create(keyToken, valueToken);
+    list_addElement(apiKeys, keyPairToken);
+
+    g_k8sAPIConnector = apiClient_create_with_base_path(K8S_APISERVER_BASEPATH, NULL, apiKeys);
+}
+
+int main(int argc, char *argv[])
+{
+
+    init_k8s_connector(argv[1]);
+
+    create_a_pod(g_k8sAPIConnector);
+
+    apiClient_free(g_k8sAPIConnector);
+}
+

--- a/examples/create_pod/main.c
+++ b/examples/create_pod/main.c
@@ -12,11 +12,11 @@
 
 apiClient_t *g_k8sAPIConnector;
 
-void create_a_pod(apiClient_t *apiClient)
+void create_a_pod(apiClient_t * apiClient)
 {
     char *namespace = "default";
 
-    v1_pod_t * podinfo = calloc(1, sizeof(v1_pod_t));
+    v1_pod_t *podinfo = calloc(1, sizeof(v1_pod_t));
     podinfo->api_version = strdup("v1");
     podinfo->kind = strdup("Pod");
     podinfo->spec = calloc(1, sizeof(v1_pod_spec_t));
@@ -43,14 +43,13 @@ void create_a_pod(apiClient_t *apiClient)
     list_addElement(containerlist, con);
     podinfo->spec->containers = containerlist;
 
-    v1_pod_t* apod = CoreV1API_createNamespacedPod(apiClient, namespace, podinfo, NULL, NULL, NULL);
+    v1_pod_t *apod = CoreV1API_createNamespacedPod(apiClient, namespace, podinfo, NULL, NULL, NULL);
     printf("code=%ld\n", apiClient->response_code);
 
     v1_pod_free(apod);
 }
 
-int
-loadK8sConfigInCluster(char *token, int token_buf_size)
+int loadK8sConfigInCluster(char *token, int token_buf_size)
 {
     static char fname[] = "loadK8sConfigInCluster()";
 
@@ -78,17 +77,16 @@ loadK8sConfigInCluster(char *token, int token_buf_size)
     return 0;
 }
 
-int
-init_k8s_connector(const char *token_out_of_cluster)
+int init_k8s_connector(const char *token_out_of_cluster)
 {
     list_t *apiKeys;
     apiKeys = list_create();
 
     char *keyToken = strdup(K8S_AUTH_KEY);
-    
+
     char valueToken[K8S_TOKEN_BUF_SIZE];
     memset(valueToken, 0, sizeof(valueToken));
-    
+
     sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token_out_of_cluster);
 
     keyValuePair_t *keyPairToken = keyValuePair_create(keyToken, valueToken);
@@ -99,11 +97,9 @@ init_k8s_connector(const char *token_out_of_cluster)
 
 int main(int argc, char *argv[])
 {
-
     init_k8s_connector(argv[1]);
 
     create_a_pod(g_k8sAPIConnector);
 
     apiClient_free(g_k8sAPIConnector);
 }
-

--- a/examples/list_pod/Makefile
+++ b/examples/list_pod/Makefile
@@ -1,0 +1,8 @@
+INCLUDE:=-I../../kubernetes/include -I../../kubernetes/model -I../../kubernetes/api
+LIBS:=-L../../kubernetes/build -lkubernetes -lcurl -lpthread -lssl -lz
+CFLAGS:=-g
+
+all:
+	gcc main.c $(CFLAGS) $(INCLUDE) $(LIBS) -o list_pod_bin
+clean:
+	rm ./list_pod_bin

--- a/examples/list_pod/main.c
+++ b/examples/list_pod/main.c
@@ -1,0 +1,111 @@
+#include <apiClient.h>
+#include <CoreV1API.h>
+#include <malloc.h>
+#include <stdio.h>
+#include <errno.h>
+
+#define K8S_APISERVER_BASEPATH "https://9.111.254.254:6443"
+#define K8S_TOKEN_FILE_IN_CLUSTER "/var/run/secrets/kubernetes.io/serviceaccount/token"
+#define K8S_TOKEN_BUF_SIZE 1024
+#define K8S_AUTH_KEY "Authorization"
+#define K8S_AUTH_VALUE_TEMPLATE "Bearer %s"
+
+apiClient_t *g_k8sAPIConnector;
+
+void list_pod(apiClient_t *apiClient)
+{
+    v1_pod_list_t *pod_list = NULL;
+    pod_list = CoreV1API_listNamespacedPod( apiClient ,
+                                            "default", /*namespace*/
+                                            NULL, /* pretty */
+                                            0, /* allowWatchBookmarks */
+                                            NULL, /* continue */
+                                            NULL, /* fieldSelector */
+                                            NULL, /* labelSelector */
+                                            0, /* limit */
+                                            NULL, /* resourceVersion */
+                                            0, /* timeoutSeconds */
+                                            0 /* watch */
+                    );
+    printf("return code=%ld\n", apiClient->response_code);
+    if(pod_list){
+        printf("Get pod list.\n");
+        listEntry_t *listEntry = NULL;
+        v1_pod_t *pod = NULL;
+        list_ForEach(listEntry, pod_list->items){
+            pod = listEntry->data;
+            printf("pod name=%s\n", pod->metadata->name);
+        }
+
+    }else{
+        printf("Cannot list any pod.\n");
+    }
+}
+
+int
+loadK8sConfigInCluster(char *token, int token_buf_size)
+{
+    static char fname[] = "loadK8sConfigInCluster()";
+
+    FILE *fp;
+    fp = fopen(K8S_TOKEN_FILE_IN_CLUSTER, "r");
+
+    if (fp == NULL) {
+        if (errno == ENOENT) {
+            printf("\
+%s: The file %s does not exist.",
+fname, K8S_TOKEN_FILE_IN_CLUSTER);
+            return (-1);
+        } else {
+            printf("\
+%s: Failed to open file %s (%m).",
+fname, K8S_TOKEN_FILE_IN_CLUSTER);
+            return (-1);
+        }
+    }
+
+    while (fgets(token, token_buf_size, fp) != NULL) {
+        ;
+    }
+
+    printf("%s\n", token);
+
+    fclose(fp);
+
+    return 0;
+}
+
+int
+init_k8s_connector(const char *token_out_of_cluster)
+{
+    list_t *apiKeys;
+    apiKeys = list_create();
+
+    char *keyToken = strdup(K8S_AUTH_KEY);
+    char token_in_cluster[K8S_TOKEN_BUF_SIZE];
+    memset(token_in_cluster, 0, sizeof(token_in_cluster));
+
+    //loadK8sConfigInCluster(token_in_cluster, K8S_TOKEN_BUF_SIZE); // in cluster
+
+    char valueToken[K8S_TOKEN_BUF_SIZE];
+    memset(valueToken, 0, sizeof(valueToken));
+    //sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token); // in cluster
+    
+    sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token_out_of_cluster); // out of cluster
+
+    keyValuePair_t *keyPairToken = keyValuePair_create(keyToken, valueToken);
+    list_addElement(apiKeys, keyPairToken);
+
+    g_k8sAPIConnector = apiClient_create_with_base_path(K8S_APISERVER_BASEPATH, NULL, apiKeys);
+}
+
+int main(int argc, char *argv[])
+{
+
+    init_k8s_connector(argv[1]);
+
+    list_pod(g_k8sAPIConnector);
+
+    apiClient_free(g_k8sAPIConnector);
+}
+

--- a/examples/list_pod/main.c
+++ b/examples/list_pod/main.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-#define K8S_APISERVER_BASEPATH "https://9.111.254.254:6443"
+#define K8S_APISERVER_BASEPATH "https://your.server.here"
 #define K8S_TOKEN_FILE_IN_CLUSTER "/var/run/secrets/kubernetes.io/serviceaccount/token"
 #define K8S_TOKEN_BUF_SIZE 1024
 #define K8S_AUTH_KEY "Authorization"
@@ -52,14 +52,10 @@ loadK8sConfigInCluster(char *token, int token_buf_size)
 
     if (fp == NULL) {
         if (errno == ENOENT) {
-            printf("\
-%s: The file %s does not exist.",
-fname, K8S_TOKEN_FILE_IN_CLUSTER);
+            printf("%s: The file %s does not exist.", fname, K8S_TOKEN_FILE_IN_CLUSTER);
             return (-1);
         } else {
-            printf("\
-%s: Failed to open file %s (%m).",
-fname, K8S_TOKEN_FILE_IN_CLUSTER);
+            printf("%s: Failed to open file %s.", fname, K8S_TOKEN_FILE_IN_CLUSTER);
             return (-1);
         }
     }
@@ -82,16 +78,11 @@ init_k8s_connector(const char *token_out_of_cluster)
     apiKeys = list_create();
 
     char *keyToken = strdup(K8S_AUTH_KEY);
-    char token_in_cluster[K8S_TOKEN_BUF_SIZE];
-    memset(token_in_cluster, 0, sizeof(token_in_cluster));
-
-    //loadK8sConfigInCluster(token_in_cluster, K8S_TOKEN_BUF_SIZE); // in cluster
 
     char valueToken[K8S_TOKEN_BUF_SIZE];
     memset(valueToken, 0, sizeof(valueToken));
-    //sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token); // in cluster
     
-    sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token_out_of_cluster); // out of cluster
+    sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token_out_of_cluster);
 
     keyValuePair_t *keyPairToken = keyValuePair_create(keyToken, valueToken);
     list_addElement(apiKeys, keyPairToken);

--- a/examples/list_pod/main.c
+++ b/examples/list_pod/main.c
@@ -12,38 +12,35 @@
 
 apiClient_t *g_k8sAPIConnector;
 
-void list_pod(apiClient_t *apiClient)
+void list_pod(apiClient_t * apiClient)
 {
     v1_pod_list_t *pod_list = NULL;
-    pod_list = CoreV1API_listNamespacedPod( apiClient ,
-                                            "default", /*namespace*/
-                                            NULL, /* pretty */
-                                            0, /* allowWatchBookmarks */
-                                            NULL, /* continue */
-                                            NULL, /* fieldSelector */
-                                            NULL, /* labelSelector */
-                                            0, /* limit */
-                                            NULL, /* resourceVersion */
-                                            0, /* timeoutSeconds */
-                                            0 /* watch */
-                    );
+    pod_list = CoreV1API_listNamespacedPod(apiClient, "default",    /*namespace */
+                                           NULL,    /* pretty */
+                                           0,   /* allowWatchBookmarks */
+                                           NULL,    /* continue */
+                                           NULL,    /* fieldSelector */
+                                           NULL,    /* labelSelector */
+                                           0,   /* limit */
+                                           NULL,    /* resourceVersion */
+                                           0,   /* timeoutSeconds */
+                                           0    /* watch */
+        );
     printf("return code=%ld\n", apiClient->response_code);
-    if(pod_list){
+    if (pod_list) {
         printf("Get pod list.\n");
         listEntry_t *listEntry = NULL;
         v1_pod_t *pod = NULL;
-        list_ForEach(listEntry, pod_list->items){
+        list_ForEach(listEntry, pod_list->items) {
             pod = listEntry->data;
             printf("pod name=%s\n", pod->metadata->name);
         }
-
-    }else{
+    } else {
         printf("Cannot list any pod.\n");
     }
 }
 
-int
-loadK8sConfigInCluster(char *token, int token_buf_size)
+int loadK8sConfigInCluster(char *token, int token_buf_size)
 {
     static char fname[] = "loadK8sConfigInCluster()";
 
@@ -71,8 +68,7 @@ loadK8sConfigInCluster(char *token, int token_buf_size)
     return 0;
 }
 
-int
-init_k8s_connector(const char *token_out_of_cluster)
+int init_k8s_connector(const char *token_out_of_cluster)
 {
     list_t *apiKeys;
     apiKeys = list_create();
@@ -81,7 +77,7 @@ init_k8s_connector(const char *token_out_of_cluster)
 
     char valueToken[K8S_TOKEN_BUF_SIZE];
     memset(valueToken, 0, sizeof(valueToken));
-    
+
     sprintf(valueToken, K8S_AUTH_VALUE_TEMPLATE, token_out_of_cluster);
 
     keyValuePair_t *keyPairToken = keyValuePair_create(keyToken, valueToken);
@@ -92,11 +88,9 @@ init_k8s_connector(const char *token_out_of_cluster)
 
 int main(int argc, char *argv[])
 {
-
     init_k8s_connector(argv[1]);
 
     list_pod(g_k8sAPIConnector);
 
     apiClient_free(g_k8sAPIConnector);
 }
-


### PR DESCRIPTION
Add two examples to demo how to use the c client library:
- Create a pod
- List pods


Because now kuberentes-client/c has no utility such as "config" functions in addition to the source code generated by OpenAPI c generator,  these two examples implement the config utility functions in their own source code.
```
int loadK8sConfigInCluster(char *token, int token_buf_size);
int init_k8s_connector(const char *token_out_of_cluster);
```

After this PR, I will implement and integrate the config utility to kuberentes-client/c. the same as other language client libraries.
 