### PR TITLE
Merge 2 useful PRs and other changes from OpenAPITools/openapi-generator repo

### DIFF
--- a/kubernetes/api/AdmissionregistrationV1API.c
+++ b/kubernetes/api/AdmissionregistrationV1API.c
@@ -15,7 +15,7 @@
 // create a MutatingWebhookConfiguration
 //
 v1_mutating_webhook_configuration_t*
-AdmissionregistrationV1API_createMutatingWebhookConfiguration(apiClient_t *apiClient, v1_mutating_webhook_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+AdmissionregistrationV1API_createMutatingWebhookConfiguration(apiClient_t *apiClient, v1_mutating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // create a ValidatingWebhookConfiguration
 //
 v1_validating_webhook_configuration_t*
-AdmissionregistrationV1API_createValidatingWebhookConfiguration(apiClient_t *apiClient, v1_validating_webhook_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+AdmissionregistrationV1API_createValidatingWebhookConfiguration(apiClient_t *apiClient, v1_validating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -317,7 +317,7 @@ end:
 // delete collection of MutatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1API_deleteCollectionMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AdmissionregistrationV1API_deleteCollectionMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -678,7 +678,7 @@ end:
 // delete collection of ValidatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1API_deleteCollectionValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AdmissionregistrationV1API_deleteCollectionValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1039,7 +1039,7 @@ end:
 // delete a MutatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1API_deleteMutatingWebhookConfiguration(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AdmissionregistrationV1API_deleteMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1238,7 +1238,7 @@ end:
 // delete a ValidatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1API_deleteValidatingWebhookConfiguration(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AdmissionregistrationV1API_deleteValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1499,7 +1499,7 @@ end:
 // list or watch objects of kind MutatingWebhookConfiguration
 //
 v1_mutating_webhook_configuration_list_t*
-AdmissionregistrationV1API_listMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AdmissionregistrationV1API_listMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1763,7 +1763,7 @@ end:
 // list or watch objects of kind ValidatingWebhookConfiguration
 //
 v1_validating_webhook_configuration_list_t*
-AdmissionregistrationV1API_listValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AdmissionregistrationV1API_listValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2027,7 +2027,7 @@ end:
 // partially update the specified MutatingWebhookConfiguration
 //
 v1_mutating_webhook_configuration_t*
-AdmissionregistrationV1API_patchMutatingWebhookConfiguration(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AdmissionregistrationV1API_patchMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2207,7 +2207,7 @@ end:
 // partially update the specified ValidatingWebhookConfiguration
 //
 v1_validating_webhook_configuration_t*
-AdmissionregistrationV1API_patchValidatingWebhookConfiguration(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AdmissionregistrationV1API_patchValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2387,7 +2387,7 @@ end:
 // read the specified MutatingWebhookConfiguration
 //
 v1_mutating_webhook_configuration_t*
-AdmissionregistrationV1API_readMutatingWebhookConfiguration(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+AdmissionregistrationV1API_readMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2524,7 +2524,7 @@ end:
 // read the specified ValidatingWebhookConfiguration
 //
 v1_validating_webhook_configuration_t*
-AdmissionregistrationV1API_readValidatingWebhookConfiguration(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+AdmissionregistrationV1API_readValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2661,7 +2661,7 @@ end:
 // replace the specified MutatingWebhookConfiguration
 //
 v1_mutating_webhook_configuration_t*
-AdmissionregistrationV1API_replaceMutatingWebhookConfiguration(apiClient_t *apiClient, char * name, v1_mutating_webhook_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+AdmissionregistrationV1API_replaceMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , v1_mutating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2820,7 +2820,7 @@ end:
 // replace the specified ValidatingWebhookConfiguration
 //
 v1_validating_webhook_configuration_t*
-AdmissionregistrationV1API_replaceValidatingWebhookConfiguration(apiClient_t *apiClient, char * name, v1_validating_webhook_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+AdmissionregistrationV1API_replaceValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , v1_validating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AdmissionregistrationV1API.h
+++ b/kubernetes/api/AdmissionregistrationV1API.h
@@ -16,37 +16,37 @@
 // create a MutatingWebhookConfiguration
 //
 v1_mutating_webhook_configuration_t*
-AdmissionregistrationV1API_createMutatingWebhookConfiguration(apiClient_t *apiClient ,v1_mutating_webhook_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AdmissionregistrationV1API_createMutatingWebhookConfiguration(apiClient_t *apiClient, v1_mutating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ValidatingWebhookConfiguration
 //
 v1_validating_webhook_configuration_t*
-AdmissionregistrationV1API_createValidatingWebhookConfiguration(apiClient_t *apiClient ,v1_validating_webhook_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AdmissionregistrationV1API_createValidatingWebhookConfiguration(apiClient_t *apiClient, v1_validating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of MutatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1API_deleteCollectionMutatingWebhookConfiguration(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AdmissionregistrationV1API_deleteCollectionMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ValidatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1API_deleteCollectionValidatingWebhookConfiguration(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AdmissionregistrationV1API_deleteCollectionValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a MutatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1API_deleteMutatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AdmissionregistrationV1API_deleteMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ValidatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1API_deleteValidatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AdmissionregistrationV1API_deleteValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -58,48 +58,48 @@ AdmissionregistrationV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind MutatingWebhookConfiguration
 //
 v1_mutating_webhook_configuration_list_t*
-AdmissionregistrationV1API_listMutatingWebhookConfiguration(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AdmissionregistrationV1API_listMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ValidatingWebhookConfiguration
 //
 v1_validating_webhook_configuration_list_t*
-AdmissionregistrationV1API_listValidatingWebhookConfiguration(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AdmissionregistrationV1API_listValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified MutatingWebhookConfiguration
 //
 v1_mutating_webhook_configuration_t*
-AdmissionregistrationV1API_patchMutatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AdmissionregistrationV1API_patchMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ValidatingWebhookConfiguration
 //
 v1_validating_webhook_configuration_t*
-AdmissionregistrationV1API_patchValidatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AdmissionregistrationV1API_patchValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified MutatingWebhookConfiguration
 //
 v1_mutating_webhook_configuration_t*
-AdmissionregistrationV1API_readMutatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+AdmissionregistrationV1API_readMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read the specified ValidatingWebhookConfiguration
 //
 v1_validating_webhook_configuration_t*
-AdmissionregistrationV1API_readValidatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+AdmissionregistrationV1API_readValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified MutatingWebhookConfiguration
 //
 v1_mutating_webhook_configuration_t*
-AdmissionregistrationV1API_replaceMutatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,v1_mutating_webhook_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AdmissionregistrationV1API_replaceMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , v1_mutating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ValidatingWebhookConfiguration
 //
 v1_validating_webhook_configuration_t*
-AdmissionregistrationV1API_replaceValidatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,v1_validating_webhook_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AdmissionregistrationV1API_replaceValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , v1_validating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/AdmissionregistrationV1beta1API.c
+++ b/kubernetes/api/AdmissionregistrationV1beta1API.c
@@ -15,7 +15,7 @@
 // create a MutatingWebhookConfiguration
 //
 v1beta1_mutating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_createMutatingWebhookConfiguration(apiClient_t *apiClient, v1beta1_mutating_webhook_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+AdmissionregistrationV1beta1API_createMutatingWebhookConfiguration(apiClient_t *apiClient, v1beta1_mutating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // create a ValidatingWebhookConfiguration
 //
 v1beta1_validating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_createValidatingWebhookConfiguration(apiClient_t *apiClient, v1beta1_validating_webhook_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+AdmissionregistrationV1beta1API_createValidatingWebhookConfiguration(apiClient_t *apiClient, v1beta1_validating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -317,7 +317,7 @@ end:
 // delete collection of MutatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1beta1API_deleteCollectionMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AdmissionregistrationV1beta1API_deleteCollectionMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -678,7 +678,7 @@ end:
 // delete collection of ValidatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1beta1API_deleteCollectionValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AdmissionregistrationV1beta1API_deleteCollectionValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1039,7 +1039,7 @@ end:
 // delete a MutatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1beta1API_deleteMutatingWebhookConfiguration(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AdmissionregistrationV1beta1API_deleteMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1238,7 +1238,7 @@ end:
 // delete a ValidatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1beta1API_deleteValidatingWebhookConfiguration(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AdmissionregistrationV1beta1API_deleteValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1499,7 +1499,7 @@ end:
 // list or watch objects of kind MutatingWebhookConfiguration
 //
 v1beta1_mutating_webhook_configuration_list_t*
-AdmissionregistrationV1beta1API_listMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AdmissionregistrationV1beta1API_listMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1763,7 +1763,7 @@ end:
 // list or watch objects of kind ValidatingWebhookConfiguration
 //
 v1beta1_validating_webhook_configuration_list_t*
-AdmissionregistrationV1beta1API_listValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AdmissionregistrationV1beta1API_listValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2027,7 +2027,7 @@ end:
 // partially update the specified MutatingWebhookConfiguration
 //
 v1beta1_mutating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_patchMutatingWebhookConfiguration(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AdmissionregistrationV1beta1API_patchMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2207,7 +2207,7 @@ end:
 // partially update the specified ValidatingWebhookConfiguration
 //
 v1beta1_validating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_patchValidatingWebhookConfiguration(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AdmissionregistrationV1beta1API_patchValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2387,7 +2387,7 @@ end:
 // read the specified MutatingWebhookConfiguration
 //
 v1beta1_mutating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_readMutatingWebhookConfiguration(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+AdmissionregistrationV1beta1API_readMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2524,7 +2524,7 @@ end:
 // read the specified ValidatingWebhookConfiguration
 //
 v1beta1_validating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_readValidatingWebhookConfiguration(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+AdmissionregistrationV1beta1API_readValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2661,7 +2661,7 @@ end:
 // replace the specified MutatingWebhookConfiguration
 //
 v1beta1_mutating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_replaceMutatingWebhookConfiguration(apiClient_t *apiClient, char * name, v1beta1_mutating_webhook_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+AdmissionregistrationV1beta1API_replaceMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , v1beta1_mutating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2820,7 +2820,7 @@ end:
 // replace the specified ValidatingWebhookConfiguration
 //
 v1beta1_validating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_replaceValidatingWebhookConfiguration(apiClient_t *apiClient, char * name, v1beta1_validating_webhook_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+AdmissionregistrationV1beta1API_replaceValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , v1beta1_validating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AdmissionregistrationV1beta1API.h
+++ b/kubernetes/api/AdmissionregistrationV1beta1API.h
@@ -16,37 +16,37 @@
 // create a MutatingWebhookConfiguration
 //
 v1beta1_mutating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_createMutatingWebhookConfiguration(apiClient_t *apiClient ,v1beta1_mutating_webhook_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AdmissionregistrationV1beta1API_createMutatingWebhookConfiguration(apiClient_t *apiClient, v1beta1_mutating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ValidatingWebhookConfiguration
 //
 v1beta1_validating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_createValidatingWebhookConfiguration(apiClient_t *apiClient ,v1beta1_validating_webhook_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AdmissionregistrationV1beta1API_createValidatingWebhookConfiguration(apiClient_t *apiClient, v1beta1_validating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of MutatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1beta1API_deleteCollectionMutatingWebhookConfiguration(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AdmissionregistrationV1beta1API_deleteCollectionMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ValidatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1beta1API_deleteCollectionValidatingWebhookConfiguration(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AdmissionregistrationV1beta1API_deleteCollectionValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a MutatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1beta1API_deleteMutatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AdmissionregistrationV1beta1API_deleteMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ValidatingWebhookConfiguration
 //
 v1_status_t*
-AdmissionregistrationV1beta1API_deleteValidatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AdmissionregistrationV1beta1API_deleteValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -58,48 +58,48 @@ AdmissionregistrationV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind MutatingWebhookConfiguration
 //
 v1beta1_mutating_webhook_configuration_list_t*
-AdmissionregistrationV1beta1API_listMutatingWebhookConfiguration(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AdmissionregistrationV1beta1API_listMutatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ValidatingWebhookConfiguration
 //
 v1beta1_validating_webhook_configuration_list_t*
-AdmissionregistrationV1beta1API_listValidatingWebhookConfiguration(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AdmissionregistrationV1beta1API_listValidatingWebhookConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified MutatingWebhookConfiguration
 //
 v1beta1_mutating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_patchMutatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AdmissionregistrationV1beta1API_patchMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ValidatingWebhookConfiguration
 //
 v1beta1_validating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_patchValidatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AdmissionregistrationV1beta1API_patchValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified MutatingWebhookConfiguration
 //
 v1beta1_mutating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_readMutatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+AdmissionregistrationV1beta1API_readMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read the specified ValidatingWebhookConfiguration
 //
 v1beta1_validating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_readValidatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+AdmissionregistrationV1beta1API_readValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified MutatingWebhookConfiguration
 //
 v1beta1_mutating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_replaceMutatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,v1beta1_mutating_webhook_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AdmissionregistrationV1beta1API_replaceMutatingWebhookConfiguration(apiClient_t *apiClient, char * name , v1beta1_mutating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ValidatingWebhookConfiguration
 //
 v1beta1_validating_webhook_configuration_t*
-AdmissionregistrationV1beta1API_replaceValidatingWebhookConfiguration(apiClient_t *apiClient ,char * name ,v1beta1_validating_webhook_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AdmissionregistrationV1beta1API_replaceValidatingWebhookConfiguration(apiClient_t *apiClient, char * name , v1beta1_validating_webhook_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/ApiextensionsV1API.c
+++ b/kubernetes/api/ApiextensionsV1API.c
@@ -15,7 +15,7 @@
 // create a CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_createCustomResourceDefinition(apiClient_t *apiClient, v1_custom_resource_definition_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiextensionsV1API_createCustomResourceDefinition(apiClient_t *apiClient, v1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete collection of CustomResourceDefinition
 //
 v1_status_t*
-ApiextensionsV1API_deleteCollectionCustomResourceDefinition(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+ApiextensionsV1API_deleteCollectionCustomResourceDefinition(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -527,7 +527,7 @@ end:
 // delete a CustomResourceDefinition
 //
 v1_status_t*
-ApiextensionsV1API_deleteCustomResourceDefinition(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+ApiextensionsV1API_deleteCustomResourceDefinition(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind CustomResourceDefinition
 //
 v1_custom_resource_definition_list_t*
-ApiextensionsV1API_listCustomResourceDefinition(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+ApiextensionsV1API_listCustomResourceDefinition(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_patchCustomResourceDefinition(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ApiextensionsV1API_patchCustomResourceDefinition(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // partially update status of the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_patchCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ApiextensionsV1API_patchCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1412,7 +1412,7 @@ end:
 // read the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_readCustomResourceDefinition(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+ApiextensionsV1API_readCustomResourceDefinition(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1549,7 +1549,7 @@ end:
 // read status of the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_readCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name, char * pretty)
+ApiextensionsV1API_readCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1646,7 +1646,7 @@ end:
 // replace the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_replaceCustomResourceDefinition(apiClient_t *apiClient, char * name, v1_custom_resource_definition_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiextensionsV1API_replaceCustomResourceDefinition(apiClient_t *apiClient, char * name , v1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1805,7 +1805,7 @@ end:
 // replace status of the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_replaceCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name, v1_custom_resource_definition_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiextensionsV1API_replaceCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , v1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/ApiextensionsV1API.h
+++ b/kubernetes/api/ApiextensionsV1API.h
@@ -14,19 +14,19 @@
 // create a CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_createCustomResourceDefinition(apiClient_t *apiClient ,v1_custom_resource_definition_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiextensionsV1API_createCustomResourceDefinition(apiClient_t *apiClient, v1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of CustomResourceDefinition
 //
 v1_status_t*
-ApiextensionsV1API_deleteCollectionCustomResourceDefinition(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+ApiextensionsV1API_deleteCollectionCustomResourceDefinition(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a CustomResourceDefinition
 //
 v1_status_t*
-ApiextensionsV1API_deleteCustomResourceDefinition(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+ApiextensionsV1API_deleteCustomResourceDefinition(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,42 +38,42 @@ ApiextensionsV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind CustomResourceDefinition
 //
 v1_custom_resource_definition_list_t*
-ApiextensionsV1API_listCustomResourceDefinition(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ApiextensionsV1API_listCustomResourceDefinition(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_patchCustomResourceDefinition(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ApiextensionsV1API_patchCustomResourceDefinition(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_patchCustomResourceDefinitionStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ApiextensionsV1API_patchCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_readCustomResourceDefinition(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+ApiextensionsV1API_readCustomResourceDefinition(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_readCustomResourceDefinitionStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+ApiextensionsV1API_readCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // replace the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_replaceCustomResourceDefinition(apiClient_t *apiClient ,char * name ,v1_custom_resource_definition_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiextensionsV1API_replaceCustomResourceDefinition(apiClient_t *apiClient, char * name , v1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified CustomResourceDefinition
 //
 v1_custom_resource_definition_t*
-ApiextensionsV1API_replaceCustomResourceDefinitionStatus(apiClient_t *apiClient ,char * name ,v1_custom_resource_definition_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiextensionsV1API_replaceCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , v1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/ApiextensionsV1beta1API.c
+++ b/kubernetes/api/ApiextensionsV1beta1API.c
@@ -15,7 +15,7 @@
 // create a CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_createCustomResourceDefinition(apiClient_t *apiClient, v1beta1_custom_resource_definition_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiextensionsV1beta1API_createCustomResourceDefinition(apiClient_t *apiClient, v1beta1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete collection of CustomResourceDefinition
 //
 v1_status_t*
-ApiextensionsV1beta1API_deleteCollectionCustomResourceDefinition(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+ApiextensionsV1beta1API_deleteCollectionCustomResourceDefinition(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -527,7 +527,7 @@ end:
 // delete a CustomResourceDefinition
 //
 v1_status_t*
-ApiextensionsV1beta1API_deleteCustomResourceDefinition(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+ApiextensionsV1beta1API_deleteCustomResourceDefinition(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_list_t*
-ApiextensionsV1beta1API_listCustomResourceDefinition(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+ApiextensionsV1beta1API_listCustomResourceDefinition(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_patchCustomResourceDefinition(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ApiextensionsV1beta1API_patchCustomResourceDefinition(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // partially update status of the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_patchCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ApiextensionsV1beta1API_patchCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1412,7 +1412,7 @@ end:
 // read the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_readCustomResourceDefinition(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+ApiextensionsV1beta1API_readCustomResourceDefinition(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1549,7 +1549,7 @@ end:
 // read status of the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_readCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name, char * pretty)
+ApiextensionsV1beta1API_readCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1646,7 +1646,7 @@ end:
 // replace the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_replaceCustomResourceDefinition(apiClient_t *apiClient, char * name, v1beta1_custom_resource_definition_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiextensionsV1beta1API_replaceCustomResourceDefinition(apiClient_t *apiClient, char * name , v1beta1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1805,7 +1805,7 @@ end:
 // replace status of the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_replaceCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name, v1beta1_custom_resource_definition_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiextensionsV1beta1API_replaceCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , v1beta1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/ApiextensionsV1beta1API.h
+++ b/kubernetes/api/ApiextensionsV1beta1API.h
@@ -14,19 +14,19 @@
 // create a CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_createCustomResourceDefinition(apiClient_t *apiClient ,v1beta1_custom_resource_definition_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiextensionsV1beta1API_createCustomResourceDefinition(apiClient_t *apiClient, v1beta1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of CustomResourceDefinition
 //
 v1_status_t*
-ApiextensionsV1beta1API_deleteCollectionCustomResourceDefinition(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+ApiextensionsV1beta1API_deleteCollectionCustomResourceDefinition(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a CustomResourceDefinition
 //
 v1_status_t*
-ApiextensionsV1beta1API_deleteCustomResourceDefinition(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+ApiextensionsV1beta1API_deleteCustomResourceDefinition(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,42 +38,42 @@ ApiextensionsV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_list_t*
-ApiextensionsV1beta1API_listCustomResourceDefinition(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ApiextensionsV1beta1API_listCustomResourceDefinition(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_patchCustomResourceDefinition(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ApiextensionsV1beta1API_patchCustomResourceDefinition(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_patchCustomResourceDefinitionStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ApiextensionsV1beta1API_patchCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_readCustomResourceDefinition(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+ApiextensionsV1beta1API_readCustomResourceDefinition(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_readCustomResourceDefinitionStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+ApiextensionsV1beta1API_readCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // replace the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_replaceCustomResourceDefinition(apiClient_t *apiClient ,char * name ,v1beta1_custom_resource_definition_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiextensionsV1beta1API_replaceCustomResourceDefinition(apiClient_t *apiClient, char * name , v1beta1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified CustomResourceDefinition
 //
 v1beta1_custom_resource_definition_t*
-ApiextensionsV1beta1API_replaceCustomResourceDefinitionStatus(apiClient_t *apiClient ,char * name ,v1beta1_custom_resource_definition_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiextensionsV1beta1API_replaceCustomResourceDefinitionStatus(apiClient_t *apiClient, char * name , v1beta1_custom_resource_definition_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/ApiregistrationV1API.c
+++ b/kubernetes/api/ApiregistrationV1API.c
@@ -15,7 +15,7 @@
 // create an APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_createAPIService(apiClient_t *apiClient, v1_api_service_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiregistrationV1API_createAPIService(apiClient_t *apiClient, v1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete an APIService
 //
 v1_status_t*
-ApiregistrationV1API_deleteAPIService(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+ApiregistrationV1API_deleteAPIService(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -365,7 +365,7 @@ end:
 // delete collection of APIService
 //
 v1_status_t*
-ApiregistrationV1API_deleteCollectionAPIService(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+ApiregistrationV1API_deleteCollectionAPIService(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind APIService
 //
 v1_api_service_list_t*
-ApiregistrationV1API_listAPIService(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+ApiregistrationV1API_listAPIService(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_patchAPIService(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ApiregistrationV1API_patchAPIService(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // partially update status of the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_patchAPIServiceStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ApiregistrationV1API_patchAPIServiceStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1412,7 +1412,7 @@ end:
 // read the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_readAPIService(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+ApiregistrationV1API_readAPIService(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1549,7 +1549,7 @@ end:
 // read status of the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_readAPIServiceStatus(apiClient_t *apiClient, char * name, char * pretty)
+ApiregistrationV1API_readAPIServiceStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1646,7 +1646,7 @@ end:
 // replace the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_replaceAPIService(apiClient_t *apiClient, char * name, v1_api_service_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiregistrationV1API_replaceAPIService(apiClient_t *apiClient, char * name , v1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1805,7 +1805,7 @@ end:
 // replace status of the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_replaceAPIServiceStatus(apiClient_t *apiClient, char * name, v1_api_service_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiregistrationV1API_replaceAPIServiceStatus(apiClient_t *apiClient, char * name , v1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/ApiregistrationV1API.h
+++ b/kubernetes/api/ApiregistrationV1API.h
@@ -14,19 +14,19 @@
 // create an APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_createAPIService(apiClient_t *apiClient ,v1_api_service_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiregistrationV1API_createAPIService(apiClient_t *apiClient, v1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete an APIService
 //
 v1_status_t*
-ApiregistrationV1API_deleteAPIService(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+ApiregistrationV1API_deleteAPIService(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete collection of APIService
 //
 v1_status_t*
-ApiregistrationV1API_deleteCollectionAPIService(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+ApiregistrationV1API_deleteCollectionAPIService(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,42 +38,42 @@ ApiregistrationV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind APIService
 //
 v1_api_service_list_t*
-ApiregistrationV1API_listAPIService(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ApiregistrationV1API_listAPIService(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_patchAPIService(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ApiregistrationV1API_patchAPIService(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_patchAPIServiceStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ApiregistrationV1API_patchAPIServiceStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_readAPIService(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+ApiregistrationV1API_readAPIService(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_readAPIServiceStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+ApiregistrationV1API_readAPIServiceStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // replace the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_replaceAPIService(apiClient_t *apiClient ,char * name ,v1_api_service_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiregistrationV1API_replaceAPIService(apiClient_t *apiClient, char * name , v1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified APIService
 //
 v1_api_service_t*
-ApiregistrationV1API_replaceAPIServiceStatus(apiClient_t *apiClient ,char * name ,v1_api_service_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiregistrationV1API_replaceAPIServiceStatus(apiClient_t *apiClient, char * name , v1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/ApiregistrationV1beta1API.c
+++ b/kubernetes/api/ApiregistrationV1beta1API.c
@@ -15,7 +15,7 @@
 // create an APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_createAPIService(apiClient_t *apiClient, v1beta1_api_service_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiregistrationV1beta1API_createAPIService(apiClient_t *apiClient, v1beta1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete an APIService
 //
 v1_status_t*
-ApiregistrationV1beta1API_deleteAPIService(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+ApiregistrationV1beta1API_deleteAPIService(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -365,7 +365,7 @@ end:
 // delete collection of APIService
 //
 v1_status_t*
-ApiregistrationV1beta1API_deleteCollectionAPIService(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+ApiregistrationV1beta1API_deleteCollectionAPIService(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind APIService
 //
 v1beta1_api_service_list_t*
-ApiregistrationV1beta1API_listAPIService(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+ApiregistrationV1beta1API_listAPIService(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_patchAPIService(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ApiregistrationV1beta1API_patchAPIService(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // partially update status of the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_patchAPIServiceStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ApiregistrationV1beta1API_patchAPIServiceStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1412,7 +1412,7 @@ end:
 // read the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_readAPIService(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+ApiregistrationV1beta1API_readAPIService(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1549,7 +1549,7 @@ end:
 // read status of the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_readAPIServiceStatus(apiClient_t *apiClient, char * name, char * pretty)
+ApiregistrationV1beta1API_readAPIServiceStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1646,7 +1646,7 @@ end:
 // replace the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_replaceAPIService(apiClient_t *apiClient, char * name, v1beta1_api_service_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiregistrationV1beta1API_replaceAPIService(apiClient_t *apiClient, char * name , v1beta1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1805,7 +1805,7 @@ end:
 // replace status of the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_replaceAPIServiceStatus(apiClient_t *apiClient, char * name, v1beta1_api_service_t * body, char * pretty, char * dryRun, char * fieldManager)
+ApiregistrationV1beta1API_replaceAPIServiceStatus(apiClient_t *apiClient, char * name , v1beta1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/ApiregistrationV1beta1API.h
+++ b/kubernetes/api/ApiregistrationV1beta1API.h
@@ -14,19 +14,19 @@
 // create an APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_createAPIService(apiClient_t *apiClient ,v1beta1_api_service_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiregistrationV1beta1API_createAPIService(apiClient_t *apiClient, v1beta1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete an APIService
 //
 v1_status_t*
-ApiregistrationV1beta1API_deleteAPIService(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+ApiregistrationV1beta1API_deleteAPIService(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete collection of APIService
 //
 v1_status_t*
-ApiregistrationV1beta1API_deleteCollectionAPIService(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+ApiregistrationV1beta1API_deleteCollectionAPIService(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,42 +38,42 @@ ApiregistrationV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind APIService
 //
 v1beta1_api_service_list_t*
-ApiregistrationV1beta1API_listAPIService(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ApiregistrationV1beta1API_listAPIService(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_patchAPIService(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ApiregistrationV1beta1API_patchAPIService(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_patchAPIServiceStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ApiregistrationV1beta1API_patchAPIServiceStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_readAPIService(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+ApiregistrationV1beta1API_readAPIService(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_readAPIServiceStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+ApiregistrationV1beta1API_readAPIServiceStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // replace the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_replaceAPIService(apiClient_t *apiClient ,char * name ,v1beta1_api_service_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiregistrationV1beta1API_replaceAPIService(apiClient_t *apiClient, char * name , v1beta1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified APIService
 //
 v1beta1_api_service_t*
-ApiregistrationV1beta1API_replaceAPIServiceStatus(apiClient_t *apiClient ,char * name ,v1beta1_api_service_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ApiregistrationV1beta1API_replaceAPIServiceStatus(apiClient_t *apiClient, char * name , v1beta1_api_service_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/AppsV1API.c
+++ b/kubernetes/api/AppsV1API.c
@@ -15,7 +15,7 @@
 // create a ControllerRevision
 //
 v1_controller_revision_t*
-AppsV1API_createNamespacedControllerRevision(apiClient_t *apiClient, char * namespace, v1_controller_revision_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_createNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , v1_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // create a DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_createNamespacedDaemonSet(apiClient_t *apiClient, char * namespace, v1_daemon_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_createNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , v1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -339,7 +339,7 @@ end:
 // create a Deployment
 //
 v1_deployment_t*
-AppsV1API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace, v1_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace , v1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -501,7 +501,7 @@ end:
 // create a ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_createNamespacedReplicaSet(apiClient_t *apiClient, char * namespace, v1_replica_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_createNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , v1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -663,7 +663,7 @@ end:
 // create a StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_createNamespacedStatefulSet(apiClient_t *apiClient, char * namespace, v1_stateful_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_createNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , v1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -825,7 +825,7 @@ end:
 // delete collection of ControllerRevision
 //
 v1_status_t*
-AppsV1API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1197,7 +1197,7 @@ end:
 // delete collection of DaemonSet
 //
 v1_status_t*
-AppsV1API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1569,7 +1569,7 @@ end:
 // delete collection of Deployment
 //
 v1_status_t*
-AppsV1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1941,7 +1941,7 @@ end:
 // delete collection of ReplicaSet
 //
 v1_status_t*
-AppsV1API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2313,7 +2313,7 @@ end:
 // delete collection of StatefulSet
 //
 v1_status_t*
-AppsV1API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2685,7 +2685,7 @@ end:
 // delete a ControllerRevision
 //
 v1_status_t*
-AppsV1API_deleteNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1API_deleteNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2895,7 +2895,7 @@ end:
 // delete a DaemonSet
 //
 v1_status_t*
-AppsV1API_deleteNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1API_deleteNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3105,7 +3105,7 @@ end:
 // delete a Deployment
 //
 v1_status_t*
-AppsV1API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3315,7 +3315,7 @@ end:
 // delete a ReplicaSet
 //
 v1_status_t*
-AppsV1API_deleteNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1API_deleteNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3525,7 +3525,7 @@ end:
 // delete a StatefulSet
 //
 v1_status_t*
-AppsV1API_deleteNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1API_deleteNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3797,7 +3797,7 @@ end:
 // list or watch objects of kind ControllerRevision
 //
 v1_controller_revision_list_t*
-AppsV1API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4061,7 +4061,7 @@ end:
 // list or watch objects of kind DaemonSet
 //
 v1_daemon_set_list_t*
-AppsV1API_listDaemonSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1API_listDaemonSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4325,7 +4325,7 @@ end:
 // list or watch objects of kind Deployment
 //
 v1_deployment_list_t*
-AppsV1API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4589,7 +4589,7 @@ end:
 // list or watch objects of kind ControllerRevision
 //
 v1_controller_revision_list_t*
-AppsV1API_listNamespacedControllerRevision(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1API_listNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4864,7 +4864,7 @@ end:
 // list or watch objects of kind DaemonSet
 //
 v1_daemon_set_list_t*
-AppsV1API_listNamespacedDaemonSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1API_listNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5139,7 +5139,7 @@ end:
 // list or watch objects of kind Deployment
 //
 v1_deployment_list_t*
-AppsV1API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5414,7 +5414,7 @@ end:
 // list or watch objects of kind ReplicaSet
 //
 v1_replica_set_list_t*
-AppsV1API_listNamespacedReplicaSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1API_listNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5689,7 +5689,7 @@ end:
 // list or watch objects of kind StatefulSet
 //
 v1_stateful_set_list_t*
-AppsV1API_listNamespacedStatefulSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1API_listNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5964,7 +5964,7 @@ end:
 // list or watch objects of kind ReplicaSet
 //
 v1_replica_set_list_t*
-AppsV1API_listReplicaSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1API_listReplicaSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6228,7 +6228,7 @@ end:
 // list or watch objects of kind StatefulSet
 //
 v1_stateful_set_list_t*
-AppsV1API_listStatefulSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1API_listStatefulSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6492,7 +6492,7 @@ end:
 // partially update the specified ControllerRevision
 //
 v1_controller_revision_t*
-AppsV1API_patchNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6683,7 +6683,7 @@ end:
 // partially update the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_patchNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6874,7 +6874,7 @@ end:
 // partially update status of the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7065,7 +7065,7 @@ end:
 // partially update the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_patchNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7256,7 +7256,7 @@ end:
 // partially update scale of the specified Deployment
 //
 v1_scale_t*
-AppsV1API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7447,7 +7447,7 @@ end:
 // partially update status of the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7638,7 +7638,7 @@ end:
 // partially update the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_patchNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7829,7 +7829,7 @@ end:
 // partially update scale of the specified ReplicaSet
 //
 v1_scale_t*
-AppsV1API_patchNamespacedReplicaSetScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8020,7 +8020,7 @@ end:
 // partially update status of the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8211,7 +8211,7 @@ end:
 // partially update the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_patchNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8402,7 +8402,7 @@ end:
 // partially update scale of the specified StatefulSet
 //
 v1_scale_t*
-AppsV1API_patchNamespacedStatefulSetScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8593,7 +8593,7 @@ end:
 // partially update status of the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8784,7 +8784,7 @@ end:
 // read the specified ControllerRevision
 //
 v1_controller_revision_t*
-AppsV1API_readNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1API_readNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8932,7 +8932,7 @@ end:
 // read the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_readNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1API_readNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9080,7 +9080,7 @@ end:
 // read status of the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_readNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1API_readNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9188,7 +9188,7 @@ end:
 // read the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_readNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1API_readNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9336,7 +9336,7 @@ end:
 // read scale of the specified Deployment
 //
 v1_scale_t*
-AppsV1API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9444,7 +9444,7 @@ end:
 // read status of the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9552,7 +9552,7 @@ end:
 // read the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_readNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1API_readNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9700,7 +9700,7 @@ end:
 // read scale of the specified ReplicaSet
 //
 v1_scale_t*
-AppsV1API_readNamespacedReplicaSetScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1API_readNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9808,7 +9808,7 @@ end:
 // read status of the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_readNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1API_readNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9916,7 +9916,7 @@ end:
 // read the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10064,7 +10064,7 @@ end:
 // read scale of the specified StatefulSet
 //
 v1_scale_t*
-AppsV1API_readNamespacedStatefulSetScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1API_readNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10172,7 +10172,7 @@ end:
 // read status of the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_readNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1API_readNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10280,7 +10280,7 @@ end:
 // replace the specified ControllerRevision
 //
 v1_controller_revision_t*
-AppsV1API_replaceNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, v1_controller_revision_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , v1_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10450,7 +10450,7 @@ end:
 // replace the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_replaceNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, v1_daemon_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , v1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10620,7 +10620,7 @@ end:
 // replace status of the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name, char * namespace, v1_daemon_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10790,7 +10790,7 @@ end:
 // replace the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, v1_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , v1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10960,7 +10960,7 @@ end:
 // replace scale of the specified Deployment
 //
 v1_scale_t*
-AppsV1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, v1_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , v1_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11130,7 +11130,7 @@ end:
 // replace status of the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, v1_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , v1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11300,7 +11300,7 @@ end:
 // replace the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_replaceNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, v1_replica_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , v1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11470,7 +11470,7 @@ end:
 // replace scale of the specified ReplicaSet
 //
 v1_scale_t*
-AppsV1API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient, char * name, char * namespace, v1_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , v1_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11640,7 +11640,7 @@ end:
 // replace status of the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name, char * namespace, v1_replica_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11810,7 +11810,7 @@ end:
 // replace the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_replaceNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, v1_stateful_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , v1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11980,7 +11980,7 @@ end:
 // replace scale of the specified StatefulSet
 //
 v1_scale_t*
-AppsV1API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient, char * name, char * namespace, v1_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , v1_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12150,7 +12150,7 @@ end:
 // replace status of the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name, char * namespace, v1_stateful_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AppsV1API.h
+++ b/kubernetes/api/AppsV1API.h
@@ -23,91 +23,91 @@
 // create a ControllerRevision
 //
 v1_controller_revision_t*
-AppsV1API_createNamespacedControllerRevision(apiClient_t *apiClient ,char * namespace ,v1_controller_revision_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_createNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , v1_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_createNamespacedDaemonSet(apiClient_t *apiClient ,char * namespace ,v1_daemon_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_createNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , v1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Deployment
 //
 v1_deployment_t*
-AppsV1API_createNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,v1_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace , v1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_createNamespacedReplicaSet(apiClient_t *apiClient ,char * namespace ,v1_replica_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_createNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , v1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_createNamespacedStatefulSet(apiClient_t *apiClient ,char * namespace ,v1_stateful_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_createNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , v1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of ControllerRevision
 //
 v1_status_t*
-AppsV1API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of DaemonSet
 //
 v1_status_t*
-AppsV1API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Deployment
 //
 v1_status_t*
-AppsV1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ReplicaSet
 //
 v1_status_t*
-AppsV1API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of StatefulSet
 //
 v1_status_t*
-AppsV1API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a ControllerRevision
 //
 v1_status_t*
-AppsV1API_deleteNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1API_deleteNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a DaemonSet
 //
 v1_status_t*
-AppsV1API_deleteNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1API_deleteNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a Deployment
 //
 v1_status_t*
-AppsV1API_deleteNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ReplicaSet
 //
 v1_status_t*
-AppsV1API_deleteNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1API_deleteNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a StatefulSet
 //
 v1_status_t*
-AppsV1API_deleteNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1API_deleteNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -119,276 +119,276 @@ AppsV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind ControllerRevision
 //
 v1_controller_revision_list_t*
-AppsV1API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind DaemonSet
 //
 v1_daemon_set_list_t*
-AppsV1API_listDaemonSetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1API_listDaemonSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Deployment
 //
 v1_deployment_list_t*
-AppsV1API_listDeploymentForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ControllerRevision
 //
 v1_controller_revision_list_t*
-AppsV1API_listNamespacedControllerRevision(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1API_listNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind DaemonSet
 //
 v1_daemon_set_list_t*
-AppsV1API_listNamespacedDaemonSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1API_listNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Deployment
 //
 v1_deployment_list_t*
-AppsV1API_listNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ReplicaSet
 //
 v1_replica_set_list_t*
-AppsV1API_listNamespacedReplicaSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1API_listNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind StatefulSet
 //
 v1_stateful_set_list_t*
-AppsV1API_listNamespacedStatefulSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1API_listNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ReplicaSet
 //
 v1_replica_set_list_t*
-AppsV1API_listReplicaSetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1API_listReplicaSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind StatefulSet
 //
 v1_stateful_set_list_t*
-AppsV1API_listStatefulSetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1API_listStatefulSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified ControllerRevision
 //
 v1_controller_revision_t*
-AppsV1API_patchNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_patchNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_patchNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified Deployment
 //
 v1_scale_t*
-AppsV1API_patchNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_patchNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified ReplicaSet
 //
 v1_scale_t*
-AppsV1API_patchNamespacedReplicaSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_patchNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified StatefulSet
 //
 v1_scale_t*
-AppsV1API_patchNamespacedStatefulSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified ControllerRevision
 //
 v1_controller_revision_t*
-AppsV1API_readNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1API_readNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_readNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1API_readNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_readNamespacedDaemonSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1API_readNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_readNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1API_readNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified Deployment
 //
 v1_scale_t*
-AppsV1API_readNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_readNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_readNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1API_readNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified ReplicaSet
 //
 v1_scale_t*
-AppsV1API_readNamespacedReplicaSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1API_readNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_readNamespacedReplicaSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1API_readNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_readNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified StatefulSet
 //
 v1_scale_t*
-AppsV1API_readNamespacedStatefulSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1API_readNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_readNamespacedStatefulSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1API_readNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified ControllerRevision
 //
 v1_controller_revision_t*
-AppsV1API_replaceNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,v1_controller_revision_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , v1_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_replaceNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,v1_daemon_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , v1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified DaemonSet
 //
 v1_daemon_set_t*
-AppsV1API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_daemon_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_replaceNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,v1_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , v1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified Deployment
 //
 v1_scale_t*
-AppsV1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,v1_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , v1_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified Deployment
 //
 v1_deployment_t*
-AppsV1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , v1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_replaceNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,v1_replica_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , v1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified ReplicaSet
 //
 v1_scale_t*
-AppsV1API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,v1_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , v1_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified ReplicaSet
 //
 v1_replica_set_t*
-AppsV1API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_replica_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_replaceNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,v1_stateful_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , v1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified StatefulSet
 //
 v1_scale_t*
-AppsV1API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,v1_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , v1_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_stateful_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/AppsV1beta1API.c
+++ b/kubernetes/api/AppsV1beta1API.c
@@ -15,7 +15,7 @@
 // create a ControllerRevision
 //
 v1beta1_controller_revision_t*
-AppsV1beta1API_createNamespacedControllerRevision(apiClient_t *apiClient, char * namespace, v1beta1_controller_revision_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta1API_createNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , v1beta1_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // create a Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace, apps_v1beta1_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta1API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace , apps_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -339,7 +339,7 @@ end:
 // create rollback of a Deployment
 //
 v1_status_t*
-AppsV1beta1API_createNamespacedDeploymentRollback(apiClient_t *apiClient, char * name, char * namespace, apps_v1beta1_deployment_rollback_t * body, char * dryRun, char * fieldManager, char * pretty)
+AppsV1beta1API_createNamespacedDeploymentRollback(apiClient_t *apiClient, char * name , char * namespace , apps_v1beta1_deployment_rollback_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -512,7 +512,7 @@ end:
 // create a StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_createNamespacedStatefulSet(apiClient_t *apiClient, char * namespace, v1beta1_stateful_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta1API_createNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , v1beta1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -674,7 +674,7 @@ end:
 // delete collection of ControllerRevision
 //
 v1_status_t*
-AppsV1beta1API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1beta1API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1046,7 +1046,7 @@ end:
 // delete collection of Deployment
 //
 v1_status_t*
-AppsV1beta1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1beta1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1418,7 +1418,7 @@ end:
 // delete collection of StatefulSet
 //
 v1_status_t*
-AppsV1beta1API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1beta1API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1790,7 +1790,7 @@ end:
 // delete a ControllerRevision
 //
 v1_status_t*
-AppsV1beta1API_deleteNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1beta1API_deleteNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2000,7 +2000,7 @@ end:
 // delete a Deployment
 //
 v1_status_t*
-AppsV1beta1API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1beta1API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2210,7 +2210,7 @@ end:
 // delete a StatefulSet
 //
 v1_status_t*
-AppsV1beta1API_deleteNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1beta1API_deleteNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2482,7 +2482,7 @@ end:
 // list or watch objects of kind ControllerRevision
 //
 v1beta1_controller_revision_list_t*
-AppsV1beta1API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta1API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2746,7 +2746,7 @@ end:
 // list or watch objects of kind Deployment
 //
 apps_v1beta1_deployment_list_t*
-AppsV1beta1API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta1API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3010,7 +3010,7 @@ end:
 // list or watch objects of kind ControllerRevision
 //
 v1beta1_controller_revision_list_t*
-AppsV1beta1API_listNamespacedControllerRevision(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta1API_listNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3285,7 +3285,7 @@ end:
 // list or watch objects of kind Deployment
 //
 apps_v1beta1_deployment_list_t*
-AppsV1beta1API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta1API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3560,7 +3560,7 @@ end:
 // list or watch objects of kind StatefulSet
 //
 v1beta1_stateful_set_list_t*
-AppsV1beta1API_listNamespacedStatefulSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta1API_listNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3835,7 +3835,7 @@ end:
 // list or watch objects of kind StatefulSet
 //
 v1beta1_stateful_set_list_t*
-AppsV1beta1API_listStatefulSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta1API_listStatefulSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4099,7 +4099,7 @@ end:
 // partially update the specified ControllerRevision
 //
 v1beta1_controller_revision_t*
-AppsV1beta1API_patchNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta1API_patchNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4290,7 +4290,7 @@ end:
 // partially update the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_patchNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta1API_patchNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4481,7 +4481,7 @@ end:
 // partially update scale of the specified Deployment
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta1API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4672,7 +4672,7 @@ end:
 // partially update status of the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4863,7 +4863,7 @@ end:
 // partially update the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_patchNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta1API_patchNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5054,7 +5054,7 @@ end:
 // partially update scale of the specified StatefulSet
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_patchNamespacedStatefulSetScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta1API_patchNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5245,7 +5245,7 @@ end:
 // partially update status of the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta1API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5436,7 +5436,7 @@ end:
 // read the specified ControllerRevision
 //
 v1beta1_controller_revision_t*
-AppsV1beta1API_readNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1beta1API_readNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5584,7 +5584,7 @@ end:
 // read the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_readNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1beta1API_readNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5732,7 +5732,7 @@ end:
 // read scale of the specified Deployment
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta1API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5840,7 +5840,7 @@ end:
 // read status of the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta1API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5948,7 +5948,7 @@ end:
 // read the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1beta1API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6096,7 +6096,7 @@ end:
 // read scale of the specified StatefulSet
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_readNamespacedStatefulSetScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta1API_readNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6204,7 +6204,7 @@ end:
 // read status of the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_readNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta1API_readNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6312,7 +6312,7 @@ end:
 // replace the specified ControllerRevision
 //
 v1beta1_controller_revision_t*
-AppsV1beta1API_replaceNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, v1beta1_controller_revision_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta1API_replaceNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , v1beta1_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6482,7 +6482,7 @@ end:
 // replace the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, apps_v1beta1_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta1API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , apps_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6652,7 +6652,7 @@ end:
 // replace scale of the specified Deployment
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, apps_v1beta1_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , apps_v1beta1_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6822,7 +6822,7 @@ end:
 // replace status of the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, apps_v1beta1_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , apps_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6992,7 +6992,7 @@ end:
 // replace the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_replaceNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, v1beta1_stateful_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta1API_replaceNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , v1beta1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7162,7 +7162,7 @@ end:
 // replace scale of the specified StatefulSet
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient, char * name, char * namespace, apps_v1beta1_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta1API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , apps_v1beta1_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7332,7 +7332,7 @@ end:
 // replace status of the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name, char * namespace, v1beta1_stateful_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta1API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AppsV1beta1API.h
+++ b/kubernetes/api/AppsV1beta1API.h
@@ -20,61 +20,61 @@
 // create a ControllerRevision
 //
 v1beta1_controller_revision_t*
-AppsV1beta1API_createNamespacedControllerRevision(apiClient_t *apiClient ,char * namespace ,v1beta1_controller_revision_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta1API_createNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , v1beta1_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_createNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,apps_v1beta1_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta1API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace , apps_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create rollback of a Deployment
 //
 v1_status_t*
-AppsV1beta1API_createNamespacedDeploymentRollback(apiClient_t *apiClient ,char * name ,char * namespace ,apps_v1beta1_deployment_rollback_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AppsV1beta1API_createNamespacedDeploymentRollback(apiClient_t *apiClient, char * name , char * namespace , apps_v1beta1_deployment_rollback_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create a StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_createNamespacedStatefulSet(apiClient_t *apiClient ,char * namespace ,v1beta1_stateful_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta1API_createNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , v1beta1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of ControllerRevision
 //
 v1_status_t*
-AppsV1beta1API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1beta1API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Deployment
 //
 v1_status_t*
-AppsV1beta1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1beta1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of StatefulSet
 //
 v1_status_t*
-AppsV1beta1API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1beta1API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a ControllerRevision
 //
 v1_status_t*
-AppsV1beta1API_deleteNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1beta1API_deleteNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a Deployment
 //
 v1_status_t*
-AppsV1beta1API_deleteNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1beta1API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a StatefulSet
 //
 v1_status_t*
-AppsV1beta1API_deleteNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1beta1API_deleteNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -86,162 +86,162 @@ AppsV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind ControllerRevision
 //
 v1beta1_controller_revision_list_t*
-AppsV1beta1API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta1API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Deployment
 //
 apps_v1beta1_deployment_list_t*
-AppsV1beta1API_listDeploymentForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta1API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ControllerRevision
 //
 v1beta1_controller_revision_list_t*
-AppsV1beta1API_listNamespacedControllerRevision(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta1API_listNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Deployment
 //
 apps_v1beta1_deployment_list_t*
-AppsV1beta1API_listNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta1API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind StatefulSet
 //
 v1beta1_stateful_set_list_t*
-AppsV1beta1API_listNamespacedStatefulSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta1API_listNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind StatefulSet
 //
 v1beta1_stateful_set_list_t*
-AppsV1beta1API_listStatefulSetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta1API_listStatefulSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified ControllerRevision
 //
 v1beta1_controller_revision_t*
-AppsV1beta1API_patchNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta1API_patchNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_patchNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta1API_patchNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified Deployment
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_patchNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta1API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_patchNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta1API_patchNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified StatefulSet
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_patchNamespacedStatefulSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta1API_patchNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta1API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified ControllerRevision
 //
 v1beta1_controller_revision_t*
-AppsV1beta1API_readNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1beta1API_readNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_readNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1beta1API_readNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified Deployment
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_readNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta1API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_readNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta1API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_readNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1beta1API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified StatefulSet
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_readNamespacedStatefulSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta1API_readNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_readNamespacedStatefulSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta1API_readNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified ControllerRevision
 //
 v1beta1_controller_revision_t*
-AppsV1beta1API_replaceNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_controller_revision_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta1API_replaceNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , v1beta1_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_replaceNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,apps_v1beta1_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta1API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , apps_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified Deployment
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,apps_v1beta1_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , apps_v1beta1_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified Deployment
 //
 apps_v1beta1_deployment_t*
-AppsV1beta1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,apps_v1beta1_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , apps_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_replaceNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_stateful_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta1API_replaceNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , v1beta1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified StatefulSet
 //
 apps_v1beta1_scale_t*
-AppsV1beta1API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,apps_v1beta1_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta1API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , apps_v1beta1_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified StatefulSet
 //
 v1beta1_stateful_set_t*
-AppsV1beta1API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_stateful_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta1API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta1_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/AppsV1beta2API.c
+++ b/kubernetes/api/AppsV1beta2API.c
@@ -15,7 +15,7 @@
 // create a ControllerRevision
 //
 v1beta2_controller_revision_t*
-AppsV1beta2API_createNamespacedControllerRevision(apiClient_t *apiClient, char * namespace, v1beta2_controller_revision_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_createNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , v1beta2_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // create a DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_createNamespacedDaemonSet(apiClient_t *apiClient, char * namespace, v1beta2_daemon_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_createNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , v1beta2_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -339,7 +339,7 @@ end:
 // create a Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace, v1beta2_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace , v1beta2_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -501,7 +501,7 @@ end:
 // create a ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_createNamespacedReplicaSet(apiClient_t *apiClient, char * namespace, v1beta2_replica_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_createNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , v1beta2_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -663,7 +663,7 @@ end:
 // create a StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_createNamespacedStatefulSet(apiClient_t *apiClient, char * namespace, v1beta2_stateful_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_createNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , v1beta2_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -825,7 +825,7 @@ end:
 // delete collection of ControllerRevision
 //
 v1_status_t*
-AppsV1beta2API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1beta2API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1197,7 +1197,7 @@ end:
 // delete collection of DaemonSet
 //
 v1_status_t*
-AppsV1beta2API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1beta2API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1569,7 +1569,7 @@ end:
 // delete collection of Deployment
 //
 v1_status_t*
-AppsV1beta2API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1beta2API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1941,7 +1941,7 @@ end:
 // delete collection of ReplicaSet
 //
 v1_status_t*
-AppsV1beta2API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1beta2API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2313,7 +2313,7 @@ end:
 // delete collection of StatefulSet
 //
 v1_status_t*
-AppsV1beta2API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AppsV1beta2API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2685,7 +2685,7 @@ end:
 // delete a ControllerRevision
 //
 v1_status_t*
-AppsV1beta2API_deleteNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1beta2API_deleteNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2895,7 +2895,7 @@ end:
 // delete a DaemonSet
 //
 v1_status_t*
-AppsV1beta2API_deleteNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1beta2API_deleteNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3105,7 +3105,7 @@ end:
 // delete a Deployment
 //
 v1_status_t*
-AppsV1beta2API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1beta2API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3315,7 +3315,7 @@ end:
 // delete a ReplicaSet
 //
 v1_status_t*
-AppsV1beta2API_deleteNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1beta2API_deleteNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3525,7 +3525,7 @@ end:
 // delete a StatefulSet
 //
 v1_status_t*
-AppsV1beta2API_deleteNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AppsV1beta2API_deleteNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3797,7 +3797,7 @@ end:
 // list or watch objects of kind ControllerRevision
 //
 v1beta2_controller_revision_list_t*
-AppsV1beta2API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta2API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4061,7 +4061,7 @@ end:
 // list or watch objects of kind DaemonSet
 //
 v1beta2_daemon_set_list_t*
-AppsV1beta2API_listDaemonSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta2API_listDaemonSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4325,7 +4325,7 @@ end:
 // list or watch objects of kind Deployment
 //
 v1beta2_deployment_list_t*
-AppsV1beta2API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta2API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4589,7 +4589,7 @@ end:
 // list or watch objects of kind ControllerRevision
 //
 v1beta2_controller_revision_list_t*
-AppsV1beta2API_listNamespacedControllerRevision(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta2API_listNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4864,7 +4864,7 @@ end:
 // list or watch objects of kind DaemonSet
 //
 v1beta2_daemon_set_list_t*
-AppsV1beta2API_listNamespacedDaemonSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta2API_listNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5139,7 +5139,7 @@ end:
 // list or watch objects of kind Deployment
 //
 v1beta2_deployment_list_t*
-AppsV1beta2API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta2API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5414,7 +5414,7 @@ end:
 // list or watch objects of kind ReplicaSet
 //
 v1beta2_replica_set_list_t*
-AppsV1beta2API_listNamespacedReplicaSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta2API_listNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5689,7 +5689,7 @@ end:
 // list or watch objects of kind StatefulSet
 //
 v1beta2_stateful_set_list_t*
-AppsV1beta2API_listNamespacedStatefulSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta2API_listNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5964,7 +5964,7 @@ end:
 // list or watch objects of kind ReplicaSet
 //
 v1beta2_replica_set_list_t*
-AppsV1beta2API_listReplicaSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta2API_listReplicaSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6228,7 +6228,7 @@ end:
 // list or watch objects of kind StatefulSet
 //
 v1beta2_stateful_set_list_t*
-AppsV1beta2API_listStatefulSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AppsV1beta2API_listStatefulSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6492,7 +6492,7 @@ end:
 // partially update the specified ControllerRevision
 //
 v1beta2_controller_revision_t*
-AppsV1beta2API_patchNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6683,7 +6683,7 @@ end:
 // partially update the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_patchNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6874,7 +6874,7 @@ end:
 // partially update status of the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7065,7 +7065,7 @@ end:
 // partially update the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_patchNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7256,7 +7256,7 @@ end:
 // partially update scale of the specified Deployment
 //
 v1beta2_scale_t*
-AppsV1beta2API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7447,7 +7447,7 @@ end:
 // partially update status of the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7638,7 +7638,7 @@ end:
 // partially update the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_patchNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7829,7 +7829,7 @@ end:
 // partially update scale of the specified ReplicaSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_patchNamespacedReplicaSetScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8020,7 +8020,7 @@ end:
 // partially update status of the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8211,7 +8211,7 @@ end:
 // partially update the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_patchNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8402,7 +8402,7 @@ end:
 // partially update scale of the specified StatefulSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_patchNamespacedStatefulSetScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8593,7 +8593,7 @@ end:
 // partially update status of the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AppsV1beta2API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8784,7 +8784,7 @@ end:
 // read the specified ControllerRevision
 //
 v1beta2_controller_revision_t*
-AppsV1beta2API_readNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1beta2API_readNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8932,7 +8932,7 @@ end:
 // read the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_readNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1beta2API_readNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9080,7 +9080,7 @@ end:
 // read status of the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_readNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta2API_readNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9188,7 +9188,7 @@ end:
 // read the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_readNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1beta2API_readNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9336,7 +9336,7 @@ end:
 // read scale of the specified Deployment
 //
 v1beta2_scale_t*
-AppsV1beta2API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta2API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9444,7 +9444,7 @@ end:
 // read status of the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta2API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9552,7 +9552,7 @@ end:
 // read the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_readNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1beta2API_readNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9700,7 +9700,7 @@ end:
 // read scale of the specified ReplicaSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_readNamespacedReplicaSetScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta2API_readNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9808,7 +9808,7 @@ end:
 // read status of the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_readNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta2API_readNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9916,7 +9916,7 @@ end:
 // read the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AppsV1beta2API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10064,7 +10064,7 @@ end:
 // read scale of the specified StatefulSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_readNamespacedStatefulSetScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta2API_readNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10172,7 +10172,7 @@ end:
 // read status of the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_readNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AppsV1beta2API_readNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10280,7 +10280,7 @@ end:
 // replace the specified ControllerRevision
 //
 v1beta2_controller_revision_t*
-AppsV1beta2API_replaceNamespacedControllerRevision(apiClient_t *apiClient, char * name, char * namespace, v1beta2_controller_revision_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , v1beta2_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10450,7 +10450,7 @@ end:
 // replace the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_replaceNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, v1beta2_daemon_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , v1beta2_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10620,7 +10620,7 @@ end:
 // replace status of the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name, char * namespace, v1beta2_daemon_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta2_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10790,7 +10790,7 @@ end:
 // replace the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, v1beta2_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , v1beta2_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10960,7 +10960,7 @@ end:
 // replace scale of the specified Deployment
 //
 v1beta2_scale_t*
-AppsV1beta2API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, v1beta2_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , v1beta2_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11130,7 +11130,7 @@ end:
 // replace status of the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, v1beta2_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta2_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11300,7 +11300,7 @@ end:
 // replace the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_replaceNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, v1beta2_replica_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , v1beta2_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11470,7 +11470,7 @@ end:
 // replace scale of the specified ReplicaSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient, char * name, char * namespace, v1beta2_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , v1beta2_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11640,7 +11640,7 @@ end:
 // replace status of the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name, char * namespace, v1beta2_replica_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta2_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11810,7 +11810,7 @@ end:
 // replace the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_replaceNamespacedStatefulSet(apiClient_t *apiClient, char * name, char * namespace, v1beta2_stateful_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , v1beta2_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11980,7 +11980,7 @@ end:
 // replace scale of the specified StatefulSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient, char * name, char * namespace, v1beta2_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , v1beta2_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12150,7 +12150,7 @@ end:
 // replace status of the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name, char * namespace, v1beta2_stateful_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+AppsV1beta2API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta2_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AppsV1beta2API.h
+++ b/kubernetes/api/AppsV1beta2API.h
@@ -23,91 +23,91 @@
 // create a ControllerRevision
 //
 v1beta2_controller_revision_t*
-AppsV1beta2API_createNamespacedControllerRevision(apiClient_t *apiClient ,char * namespace ,v1beta2_controller_revision_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_createNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , v1beta2_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_createNamespacedDaemonSet(apiClient_t *apiClient ,char * namespace ,v1beta2_daemon_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_createNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , v1beta2_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_createNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,v1beta2_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace , v1beta2_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_createNamespacedReplicaSet(apiClient_t *apiClient ,char * namespace ,v1beta2_replica_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_createNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , v1beta2_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_createNamespacedStatefulSet(apiClient_t *apiClient ,char * namespace ,v1beta2_stateful_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_createNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , v1beta2_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of ControllerRevision
 //
 v1_status_t*
-AppsV1beta2API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1beta2API_deleteCollectionNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of DaemonSet
 //
 v1_status_t*
-AppsV1beta2API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1beta2API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Deployment
 //
 v1_status_t*
-AppsV1beta2API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1beta2API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ReplicaSet
 //
 v1_status_t*
-AppsV1beta2API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1beta2API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of StatefulSet
 //
 v1_status_t*
-AppsV1beta2API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AppsV1beta2API_deleteCollectionNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a ControllerRevision
 //
 v1_status_t*
-AppsV1beta2API_deleteNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1beta2API_deleteNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a DaemonSet
 //
 v1_status_t*
-AppsV1beta2API_deleteNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1beta2API_deleteNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a Deployment
 //
 v1_status_t*
-AppsV1beta2API_deleteNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1beta2API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ReplicaSet
 //
 v1_status_t*
-AppsV1beta2API_deleteNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1beta2API_deleteNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a StatefulSet
 //
 v1_status_t*
-AppsV1beta2API_deleteNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AppsV1beta2API_deleteNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -119,276 +119,276 @@ AppsV1beta2API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind ControllerRevision
 //
 v1beta2_controller_revision_list_t*
-AppsV1beta2API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta2API_listControllerRevisionForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind DaemonSet
 //
 v1beta2_daemon_set_list_t*
-AppsV1beta2API_listDaemonSetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta2API_listDaemonSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Deployment
 //
 v1beta2_deployment_list_t*
-AppsV1beta2API_listDeploymentForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta2API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ControllerRevision
 //
 v1beta2_controller_revision_list_t*
-AppsV1beta2API_listNamespacedControllerRevision(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta2API_listNamespacedControllerRevision(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind DaemonSet
 //
 v1beta2_daemon_set_list_t*
-AppsV1beta2API_listNamespacedDaemonSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta2API_listNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Deployment
 //
 v1beta2_deployment_list_t*
-AppsV1beta2API_listNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta2API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ReplicaSet
 //
 v1beta2_replica_set_list_t*
-AppsV1beta2API_listNamespacedReplicaSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta2API_listNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind StatefulSet
 //
 v1beta2_stateful_set_list_t*
-AppsV1beta2API_listNamespacedStatefulSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta2API_listNamespacedStatefulSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ReplicaSet
 //
 v1beta2_replica_set_list_t*
-AppsV1beta2API_listReplicaSetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta2API_listReplicaSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind StatefulSet
 //
 v1beta2_stateful_set_list_t*
-AppsV1beta2API_listStatefulSetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AppsV1beta2API_listStatefulSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified ControllerRevision
 //
 v1beta2_controller_revision_t*
-AppsV1beta2API_patchNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_patchNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_patchNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified Deployment
 //
 v1beta2_scale_t*
-AppsV1beta2API_patchNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_patchNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_patchNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified ReplicaSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_patchNamespacedReplicaSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_patchNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified StatefulSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_patchNamespacedStatefulSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AppsV1beta2API_patchNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified ControllerRevision
 //
 v1beta2_controller_revision_t*
-AppsV1beta2API_readNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1beta2API_readNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_readNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1beta2API_readNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_readNamespacedDaemonSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta2API_readNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_readNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1beta2API_readNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified Deployment
 //
 v1beta2_scale_t*
-AppsV1beta2API_readNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta2API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_readNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta2API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_readNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1beta2API_readNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified ReplicaSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_readNamespacedReplicaSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta2API_readNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_readNamespacedReplicaSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta2API_readNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_readNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AppsV1beta2API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified StatefulSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_readNamespacedStatefulSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta2API_readNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_readNamespacedStatefulSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AppsV1beta2API_readNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified ControllerRevision
 //
 v1beta2_controller_revision_t*
-AppsV1beta2API_replaceNamespacedControllerRevision(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_controller_revision_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedControllerRevision(apiClient_t *apiClient, char * name , char * namespace , v1beta2_controller_revision_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_replaceNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_daemon_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , v1beta2_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified DaemonSet
 //
 v1beta2_daemon_set_t*
-AppsV1beta2API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_daemon_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta2_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_replaceNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , v1beta2_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified Deployment
 //
 v1beta2_scale_t*
-AppsV1beta2API_replaceNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , v1beta2_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified Deployment
 //
 v1beta2_deployment_t*
-AppsV1beta2API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta2_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_replaceNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_replica_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , v1beta2_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified ReplicaSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , v1beta2_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified ReplicaSet
 //
 v1beta2_replica_set_t*
-AppsV1beta2API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_replica_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta2_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_replaceNamespacedStatefulSet(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_stateful_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * namespace , v1beta2_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified StatefulSet
 //
 v1beta2_scale_t*
-AppsV1beta2API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedStatefulSetScale(apiClient_t *apiClient, char * name , char * namespace , v1beta2_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified StatefulSet
 //
 v1beta2_stateful_set_t*
-AppsV1beta2API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta2_stateful_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AppsV1beta2API_replaceNamespacedStatefulSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta2_stateful_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/AuditregistrationV1alpha1API.c
+++ b/kubernetes/api/AuditregistrationV1alpha1API.c
@@ -15,7 +15,7 @@
 // create an AuditSink
 //
 v1alpha1_audit_sink_t*
-AuditregistrationV1alpha1API_createAuditSink(apiClient_t *apiClient, v1alpha1_audit_sink_t * body, char * pretty, char * dryRun, char * fieldManager)
+AuditregistrationV1alpha1API_createAuditSink(apiClient_t *apiClient, v1alpha1_audit_sink_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete an AuditSink
 //
 v1_status_t*
-AuditregistrationV1alpha1API_deleteAuditSink(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AuditregistrationV1alpha1API_deleteAuditSink(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -365,7 +365,7 @@ end:
 // delete collection of AuditSink
 //
 v1_status_t*
-AuditregistrationV1alpha1API_deleteCollectionAuditSink(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AuditregistrationV1alpha1API_deleteCollectionAuditSink(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind AuditSink
 //
 v1alpha1_audit_sink_list_t*
-AuditregistrationV1alpha1API_listAuditSink(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AuditregistrationV1alpha1API_listAuditSink(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified AuditSink
 //
 v1alpha1_audit_sink_t*
-AuditregistrationV1alpha1API_patchAuditSink(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AuditregistrationV1alpha1API_patchAuditSink(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // read the specified AuditSink
 //
 v1alpha1_audit_sink_t*
-AuditregistrationV1alpha1API_readAuditSink(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+AuditregistrationV1alpha1API_readAuditSink(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1369,7 +1369,7 @@ end:
 // replace the specified AuditSink
 //
 v1alpha1_audit_sink_t*
-AuditregistrationV1alpha1API_replaceAuditSink(apiClient_t *apiClient, char * name, v1alpha1_audit_sink_t * body, char * pretty, char * dryRun, char * fieldManager)
+AuditregistrationV1alpha1API_replaceAuditSink(apiClient_t *apiClient, char * name , v1alpha1_audit_sink_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AuditregistrationV1alpha1API.h
+++ b/kubernetes/api/AuditregistrationV1alpha1API.h
@@ -14,19 +14,19 @@
 // create an AuditSink
 //
 v1alpha1_audit_sink_t*
-AuditregistrationV1alpha1API_createAuditSink(apiClient_t *apiClient ,v1alpha1_audit_sink_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AuditregistrationV1alpha1API_createAuditSink(apiClient_t *apiClient, v1alpha1_audit_sink_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete an AuditSink
 //
 v1_status_t*
-AuditregistrationV1alpha1API_deleteAuditSink(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AuditregistrationV1alpha1API_deleteAuditSink(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete collection of AuditSink
 //
 v1_status_t*
-AuditregistrationV1alpha1API_deleteCollectionAuditSink(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AuditregistrationV1alpha1API_deleteCollectionAuditSink(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,24 +38,24 @@ AuditregistrationV1alpha1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind AuditSink
 //
 v1alpha1_audit_sink_list_t*
-AuditregistrationV1alpha1API_listAuditSink(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AuditregistrationV1alpha1API_listAuditSink(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified AuditSink
 //
 v1alpha1_audit_sink_t*
-AuditregistrationV1alpha1API_patchAuditSink(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AuditregistrationV1alpha1API_patchAuditSink(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified AuditSink
 //
 v1alpha1_audit_sink_t*
-AuditregistrationV1alpha1API_readAuditSink(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+AuditregistrationV1alpha1API_readAuditSink(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified AuditSink
 //
 v1alpha1_audit_sink_t*
-AuditregistrationV1alpha1API_replaceAuditSink(apiClient_t *apiClient ,char * name ,v1alpha1_audit_sink_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AuditregistrationV1alpha1API_replaceAuditSink(apiClient_t *apiClient, char * name , v1alpha1_audit_sink_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/AuthenticationV1API.c
+++ b/kubernetes/api/AuthenticationV1API.c
@@ -15,7 +15,7 @@
 // create a TokenReview
 //
 v1_token_review_t*
-AuthenticationV1API_createTokenReview(apiClient_t *apiClient, v1_token_review_t * body, char * dryRun, char * fieldManager, char * pretty)
+AuthenticationV1API_createTokenReview(apiClient_t *apiClient, v1_token_review_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AuthenticationV1API.h
+++ b/kubernetes/api/AuthenticationV1API.h
@@ -11,7 +11,7 @@
 // create a TokenReview
 //
 v1_token_review_t*
-AuthenticationV1API_createTokenReview(apiClient_t *apiClient ,v1_token_review_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AuthenticationV1API_createTokenReview(apiClient_t *apiClient, v1_token_review_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // get available resources

--- a/kubernetes/api/AuthenticationV1beta1API.c
+++ b/kubernetes/api/AuthenticationV1beta1API.c
@@ -15,7 +15,7 @@
 // create a TokenReview
 //
 v1beta1_token_review_t*
-AuthenticationV1beta1API_createTokenReview(apiClient_t *apiClient, v1beta1_token_review_t * body, char * dryRun, char * fieldManager, char * pretty)
+AuthenticationV1beta1API_createTokenReview(apiClient_t *apiClient, v1beta1_token_review_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AuthenticationV1beta1API.h
+++ b/kubernetes/api/AuthenticationV1beta1API.h
@@ -11,7 +11,7 @@
 // create a TokenReview
 //
 v1beta1_token_review_t*
-AuthenticationV1beta1API_createTokenReview(apiClient_t *apiClient ,v1beta1_token_review_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AuthenticationV1beta1API_createTokenReview(apiClient_t *apiClient, v1beta1_token_review_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // get available resources

--- a/kubernetes/api/AuthorizationV1API.c
+++ b/kubernetes/api/AuthorizationV1API.c
@@ -15,7 +15,7 @@
 // create a LocalSubjectAccessReview
 //
 v1_local_subject_access_review_t*
-AuthorizationV1API_createNamespacedLocalSubjectAccessReview(apiClient_t *apiClient, char * namespace, v1_local_subject_access_review_t * body, char * dryRun, char * fieldManager, char * pretty)
+AuthorizationV1API_createNamespacedLocalSubjectAccessReview(apiClient_t *apiClient, char * namespace , v1_local_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // create a SelfSubjectAccessReview
 //
 v1_self_subject_access_review_t*
-AuthorizationV1API_createSelfSubjectAccessReview(apiClient_t *apiClient, v1_self_subject_access_review_t * body, char * dryRun, char * fieldManager, char * pretty)
+AuthorizationV1API_createSelfSubjectAccessReview(apiClient_t *apiClient, v1_self_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -328,7 +328,7 @@ end:
 // create a SelfSubjectRulesReview
 //
 v1_self_subject_rules_review_t*
-AuthorizationV1API_createSelfSubjectRulesReview(apiClient_t *apiClient, v1_self_subject_rules_review_t * body, char * dryRun, char * fieldManager, char * pretty)
+AuthorizationV1API_createSelfSubjectRulesReview(apiClient_t *apiClient, v1_self_subject_rules_review_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -479,7 +479,7 @@ end:
 // create a SubjectAccessReview
 //
 v1_subject_access_review_t*
-AuthorizationV1API_createSubjectAccessReview(apiClient_t *apiClient, v1_subject_access_review_t * body, char * dryRun, char * fieldManager, char * pretty)
+AuthorizationV1API_createSubjectAccessReview(apiClient_t *apiClient, v1_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AuthorizationV1API.h
+++ b/kubernetes/api/AuthorizationV1API.h
@@ -14,25 +14,25 @@
 // create a LocalSubjectAccessReview
 //
 v1_local_subject_access_review_t*
-AuthorizationV1API_createNamespacedLocalSubjectAccessReview(apiClient_t *apiClient ,char * namespace ,v1_local_subject_access_review_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AuthorizationV1API_createNamespacedLocalSubjectAccessReview(apiClient_t *apiClient, char * namespace , v1_local_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create a SelfSubjectAccessReview
 //
 v1_self_subject_access_review_t*
-AuthorizationV1API_createSelfSubjectAccessReview(apiClient_t *apiClient ,v1_self_subject_access_review_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AuthorizationV1API_createSelfSubjectAccessReview(apiClient_t *apiClient, v1_self_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create a SelfSubjectRulesReview
 //
 v1_self_subject_rules_review_t*
-AuthorizationV1API_createSelfSubjectRulesReview(apiClient_t *apiClient ,v1_self_subject_rules_review_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AuthorizationV1API_createSelfSubjectRulesReview(apiClient_t *apiClient, v1_self_subject_rules_review_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create a SubjectAccessReview
 //
 v1_subject_access_review_t*
-AuthorizationV1API_createSubjectAccessReview(apiClient_t *apiClient ,v1_subject_access_review_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AuthorizationV1API_createSubjectAccessReview(apiClient_t *apiClient, v1_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // get available resources

--- a/kubernetes/api/AuthorizationV1beta1API.c
+++ b/kubernetes/api/AuthorizationV1beta1API.c
@@ -15,7 +15,7 @@
 // create a LocalSubjectAccessReview
 //
 v1beta1_local_subject_access_review_t*
-AuthorizationV1beta1API_createNamespacedLocalSubjectAccessReview(apiClient_t *apiClient, char * namespace, v1beta1_local_subject_access_review_t * body, char * dryRun, char * fieldManager, char * pretty)
+AuthorizationV1beta1API_createNamespacedLocalSubjectAccessReview(apiClient_t *apiClient, char * namespace , v1beta1_local_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // create a SelfSubjectAccessReview
 //
 v1beta1_self_subject_access_review_t*
-AuthorizationV1beta1API_createSelfSubjectAccessReview(apiClient_t *apiClient, v1beta1_self_subject_access_review_t * body, char * dryRun, char * fieldManager, char * pretty)
+AuthorizationV1beta1API_createSelfSubjectAccessReview(apiClient_t *apiClient, v1beta1_self_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -328,7 +328,7 @@ end:
 // create a SelfSubjectRulesReview
 //
 v1beta1_self_subject_rules_review_t*
-AuthorizationV1beta1API_createSelfSubjectRulesReview(apiClient_t *apiClient, v1beta1_self_subject_rules_review_t * body, char * dryRun, char * fieldManager, char * pretty)
+AuthorizationV1beta1API_createSelfSubjectRulesReview(apiClient_t *apiClient, v1beta1_self_subject_rules_review_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -479,7 +479,7 @@ end:
 // create a SubjectAccessReview
 //
 v1beta1_subject_access_review_t*
-AuthorizationV1beta1API_createSubjectAccessReview(apiClient_t *apiClient, v1beta1_subject_access_review_t * body, char * dryRun, char * fieldManager, char * pretty)
+AuthorizationV1beta1API_createSubjectAccessReview(apiClient_t *apiClient, v1beta1_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AuthorizationV1beta1API.h
+++ b/kubernetes/api/AuthorizationV1beta1API.h
@@ -14,25 +14,25 @@
 // create a LocalSubjectAccessReview
 //
 v1beta1_local_subject_access_review_t*
-AuthorizationV1beta1API_createNamespacedLocalSubjectAccessReview(apiClient_t *apiClient ,char * namespace ,v1beta1_local_subject_access_review_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AuthorizationV1beta1API_createNamespacedLocalSubjectAccessReview(apiClient_t *apiClient, char * namespace , v1beta1_local_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create a SelfSubjectAccessReview
 //
 v1beta1_self_subject_access_review_t*
-AuthorizationV1beta1API_createSelfSubjectAccessReview(apiClient_t *apiClient ,v1beta1_self_subject_access_review_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AuthorizationV1beta1API_createSelfSubjectAccessReview(apiClient_t *apiClient, v1beta1_self_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create a SelfSubjectRulesReview
 //
 v1beta1_self_subject_rules_review_t*
-AuthorizationV1beta1API_createSelfSubjectRulesReview(apiClient_t *apiClient ,v1beta1_self_subject_rules_review_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AuthorizationV1beta1API_createSelfSubjectRulesReview(apiClient_t *apiClient, v1beta1_self_subject_rules_review_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create a SubjectAccessReview
 //
 v1beta1_subject_access_review_t*
-AuthorizationV1beta1API_createSubjectAccessReview(apiClient_t *apiClient ,v1beta1_subject_access_review_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+AuthorizationV1beta1API_createSubjectAccessReview(apiClient_t *apiClient, v1beta1_subject_access_review_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // get available resources

--- a/kubernetes/api/AutoscalingV1API.c
+++ b/kubernetes/api/AutoscalingV1API.c
@@ -15,7 +15,7 @@
 // create a HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace, v1_horizontal_pod_autoscaler_t * body, char * pretty, char * dryRun, char * fieldManager)
+AutoscalingV1API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , v1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV1API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AutoscalingV1API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete a HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV1API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AutoscalingV1API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_list_t*
-AutoscalingV1API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AutoscalingV1API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_list_t*
-AutoscalingV1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AutoscalingV1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AutoscalingV1API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // partially update status of the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AutoscalingV1API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1742,7 +1742,7 @@ end:
 // read the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AutoscalingV1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1890,7 +1890,7 @@ end:
 // read status of the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AutoscalingV1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1998,7 +1998,7 @@ end:
 // replace the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, v1_horizontal_pod_autoscaler_t * body, char * pretty, char * dryRun, char * fieldManager)
+AutoscalingV1API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , v1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2168,7 +2168,7 @@ end:
 // replace status of the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name, char * namespace, v1_horizontal_pod_autoscaler_t * body, char * pretty, char * dryRun, char * fieldManager)
+AutoscalingV1API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , v1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AutoscalingV1API.h
+++ b/kubernetes/api/AutoscalingV1API.h
@@ -14,19 +14,19 @@
 // create a HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * namespace ,v1_horizontal_pod_autoscaler_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AutoscalingV1API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , v1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV1API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AutoscalingV1API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV1API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AutoscalingV1API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,48 +38,48 @@ AutoscalingV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_list_t*
-AutoscalingV1API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AutoscalingV1API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_list_t*
-AutoscalingV1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AutoscalingV1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AutoscalingV1API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AutoscalingV1API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AutoscalingV1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AutoscalingV1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,v1_horizontal_pod_autoscaler_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AutoscalingV1API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , v1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_horizontal_pod_autoscaler_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AutoscalingV1API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , v1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/AutoscalingV2beta1API.c
+++ b/kubernetes/api/AutoscalingV2beta1API.c
@@ -15,7 +15,7 @@
 // create a HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace, v2beta1_horizontal_pod_autoscaler_t * body, char * pretty, char * dryRun, char * fieldManager)
+AutoscalingV2beta1API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , v2beta1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV2beta1API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AutoscalingV2beta1API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete a HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV2beta1API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AutoscalingV2beta1API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_list_t*
-AutoscalingV2beta1API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AutoscalingV2beta1API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_list_t*
-AutoscalingV2beta1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AutoscalingV2beta1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AutoscalingV2beta1API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // partially update status of the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AutoscalingV2beta1API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1742,7 +1742,7 @@ end:
 // read the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AutoscalingV2beta1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1890,7 +1890,7 @@ end:
 // read status of the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AutoscalingV2beta1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1998,7 +1998,7 @@ end:
 // replace the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, v2beta1_horizontal_pod_autoscaler_t * body, char * pretty, char * dryRun, char * fieldManager)
+AutoscalingV2beta1API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , v2beta1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2168,7 +2168,7 @@ end:
 // replace status of the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name, char * namespace, v2beta1_horizontal_pod_autoscaler_t * body, char * pretty, char * dryRun, char * fieldManager)
+AutoscalingV2beta1API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , v2beta1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AutoscalingV2beta1API.h
+++ b/kubernetes/api/AutoscalingV2beta1API.h
@@ -14,19 +14,19 @@
 // create a HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * namespace ,v2beta1_horizontal_pod_autoscaler_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AutoscalingV2beta1API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , v2beta1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV2beta1API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AutoscalingV2beta1API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV2beta1API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AutoscalingV2beta1API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,48 +38,48 @@ AutoscalingV2beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_list_t*
-AutoscalingV2beta1API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AutoscalingV2beta1API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_list_t*
-AutoscalingV2beta1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AutoscalingV2beta1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AutoscalingV2beta1API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AutoscalingV2beta1API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AutoscalingV2beta1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AutoscalingV2beta1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,v2beta1_horizontal_pod_autoscaler_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AutoscalingV2beta1API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , v2beta1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified HorizontalPodAutoscaler
 //
 v2beta1_horizontal_pod_autoscaler_t*
-AutoscalingV2beta1API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v2beta1_horizontal_pod_autoscaler_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AutoscalingV2beta1API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , v2beta1_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/AutoscalingV2beta2API.c
+++ b/kubernetes/api/AutoscalingV2beta2API.c
@@ -15,7 +15,7 @@
 // create a HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace, v2beta2_horizontal_pod_autoscaler_t * body, char * pretty, char * dryRun, char * fieldManager)
+AutoscalingV2beta2API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , v2beta2_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV2beta2API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+AutoscalingV2beta2API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete a HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV2beta2API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+AutoscalingV2beta2API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_list_t*
-AutoscalingV2beta2API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+AutoscalingV2beta2API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_list_t*
-AutoscalingV2beta2API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+AutoscalingV2beta2API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AutoscalingV2beta2API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // partially update status of the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+AutoscalingV2beta2API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1742,7 +1742,7 @@ end:
 // read the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+AutoscalingV2beta2API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1890,7 +1890,7 @@ end:
 // read status of the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+AutoscalingV2beta2API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1998,7 +1998,7 @@ end:
 // replace the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name, char * namespace, v2beta2_horizontal_pod_autoscaler_t * body, char * pretty, char * dryRun, char * fieldManager)
+AutoscalingV2beta2API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , v2beta2_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2168,7 +2168,7 @@ end:
 // replace status of the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name, char * namespace, v2beta2_horizontal_pod_autoscaler_t * body, char * pretty, char * dryRun, char * fieldManager)
+AutoscalingV2beta2API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , v2beta2_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AutoscalingV2beta2API.h
+++ b/kubernetes/api/AutoscalingV2beta2API.h
@@ -14,19 +14,19 @@
 // create a HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * namespace ,v2beta2_horizontal_pod_autoscaler_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AutoscalingV2beta2API_createNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , v2beta2_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV2beta2API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+AutoscalingV2beta2API_deleteCollectionNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a HorizontalPodAutoscaler
 //
 v1_status_t*
-AutoscalingV2beta2API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+AutoscalingV2beta2API_deleteNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,48 +38,48 @@ AutoscalingV2beta2API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_list_t*
-AutoscalingV2beta2API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AutoscalingV2beta2API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_list_t*
-AutoscalingV2beta2API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+AutoscalingV2beta2API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AutoscalingV2beta2API_patchNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+AutoscalingV2beta2API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+AutoscalingV2beta2API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+AutoscalingV2beta2API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient ,char * name ,char * namespace ,v2beta2_horizontal_pod_autoscaler_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AutoscalingV2beta2API_replaceNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * namespace , v2beta2_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified HorizontalPodAutoscaler
 //
 v2beta2_horizontal_pod_autoscaler_t*
-AutoscalingV2beta2API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v2beta2_horizontal_pod_autoscaler_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+AutoscalingV2beta2API_replaceNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * namespace , v2beta2_horizontal_pod_autoscaler_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/BatchV1API.c
+++ b/kubernetes/api/BatchV1API.c
@@ -15,7 +15,7 @@
 // create a Job
 //
 v1_job_t*
-BatchV1API_createNamespacedJob(apiClient_t *apiClient, char * namespace, v1_job_t * body, char * pretty, char * dryRun, char * fieldManager)
+BatchV1API_createNamespacedJob(apiClient_t *apiClient, char * namespace , v1_job_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of Job
 //
 v1_status_t*
-BatchV1API_deleteCollectionNamespacedJob(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+BatchV1API_deleteCollectionNamespacedJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete a Job
 //
 v1_status_t*
-BatchV1API_deleteNamespacedJob(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+BatchV1API_deleteNamespacedJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind Job
 //
 v1_job_list_t*
-BatchV1API_listJobForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+BatchV1API_listJobForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind Job
 //
 v1_job_list_t*
-BatchV1API_listNamespacedJob(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+BatchV1API_listNamespacedJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified Job
 //
 v1_job_t*
-BatchV1API_patchNamespacedJob(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+BatchV1API_patchNamespacedJob(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // partially update status of the specified Job
 //
 v1_job_t*
-BatchV1API_patchNamespacedJobStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+BatchV1API_patchNamespacedJobStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1742,7 +1742,7 @@ end:
 // read the specified Job
 //
 v1_job_t*
-BatchV1API_readNamespacedJob(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+BatchV1API_readNamespacedJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1890,7 +1890,7 @@ end:
 // read status of the specified Job
 //
 v1_job_t*
-BatchV1API_readNamespacedJobStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+BatchV1API_readNamespacedJobStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1998,7 +1998,7 @@ end:
 // replace the specified Job
 //
 v1_job_t*
-BatchV1API_replaceNamespacedJob(apiClient_t *apiClient, char * name, char * namespace, v1_job_t * body, char * pretty, char * dryRun, char * fieldManager)
+BatchV1API_replaceNamespacedJob(apiClient_t *apiClient, char * name , char * namespace , v1_job_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2168,7 +2168,7 @@ end:
 // replace status of the specified Job
 //
 v1_job_t*
-BatchV1API_replaceNamespacedJobStatus(apiClient_t *apiClient, char * name, char * namespace, v1_job_t * body, char * pretty, char * dryRun, char * fieldManager)
+BatchV1API_replaceNamespacedJobStatus(apiClient_t *apiClient, char * name , char * namespace , v1_job_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/BatchV1API.h
+++ b/kubernetes/api/BatchV1API.h
@@ -14,19 +14,19 @@
 // create a Job
 //
 v1_job_t*
-BatchV1API_createNamespacedJob(apiClient_t *apiClient ,char * namespace ,v1_job_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+BatchV1API_createNamespacedJob(apiClient_t *apiClient, char * namespace , v1_job_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of Job
 //
 v1_status_t*
-BatchV1API_deleteCollectionNamespacedJob(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+BatchV1API_deleteCollectionNamespacedJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a Job
 //
 v1_status_t*
-BatchV1API_deleteNamespacedJob(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+BatchV1API_deleteNamespacedJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,48 +38,48 @@ BatchV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind Job
 //
 v1_job_list_t*
-BatchV1API_listJobForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+BatchV1API_listJobForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Job
 //
 v1_job_list_t*
-BatchV1API_listNamespacedJob(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+BatchV1API_listNamespacedJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified Job
 //
 v1_job_t*
-BatchV1API_patchNamespacedJob(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+BatchV1API_patchNamespacedJob(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Job
 //
 v1_job_t*
-BatchV1API_patchNamespacedJobStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+BatchV1API_patchNamespacedJobStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified Job
 //
 v1_job_t*
-BatchV1API_readNamespacedJob(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+BatchV1API_readNamespacedJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified Job
 //
 v1_job_t*
-BatchV1API_readNamespacedJobStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+BatchV1API_readNamespacedJobStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified Job
 //
 v1_job_t*
-BatchV1API_replaceNamespacedJob(apiClient_t *apiClient ,char * name ,char * namespace ,v1_job_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+BatchV1API_replaceNamespacedJob(apiClient_t *apiClient, char * name , char * namespace , v1_job_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified Job
 //
 v1_job_t*
-BatchV1API_replaceNamespacedJobStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_job_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+BatchV1API_replaceNamespacedJobStatus(apiClient_t *apiClient, char * name , char * namespace , v1_job_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/BatchV1beta1API.c
+++ b/kubernetes/api/BatchV1beta1API.c
@@ -15,7 +15,7 @@
 // create a CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_createNamespacedCronJob(apiClient_t *apiClient, char * namespace, v1beta1_cron_job_t * body, char * pretty, char * dryRun, char * fieldManager)
+BatchV1beta1API_createNamespacedCronJob(apiClient_t *apiClient, char * namespace , v1beta1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of CronJob
 //
 v1_status_t*
-BatchV1beta1API_deleteCollectionNamespacedCronJob(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+BatchV1beta1API_deleteCollectionNamespacedCronJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete a CronJob
 //
 v1_status_t*
-BatchV1beta1API_deleteNamespacedCronJob(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+BatchV1beta1API_deleteNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind CronJob
 //
 v1beta1_cron_job_list_t*
-BatchV1beta1API_listCronJobForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+BatchV1beta1API_listCronJobForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind CronJob
 //
 v1beta1_cron_job_list_t*
-BatchV1beta1API_listNamespacedCronJob(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+BatchV1beta1API_listNamespacedCronJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_patchNamespacedCronJob(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+BatchV1beta1API_patchNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // partially update status of the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_patchNamespacedCronJobStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+BatchV1beta1API_patchNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1742,7 +1742,7 @@ end:
 // read the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_readNamespacedCronJob(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+BatchV1beta1API_readNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1890,7 +1890,7 @@ end:
 // read status of the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_readNamespacedCronJobStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+BatchV1beta1API_readNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1998,7 +1998,7 @@ end:
 // replace the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_replaceNamespacedCronJob(apiClient_t *apiClient, char * name, char * namespace, v1beta1_cron_job_t * body, char * pretty, char * dryRun, char * fieldManager)
+BatchV1beta1API_replaceNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , v1beta1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2168,7 +2168,7 @@ end:
 // replace status of the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_replaceNamespacedCronJobStatus(apiClient_t *apiClient, char * name, char * namespace, v1beta1_cron_job_t * body, char * pretty, char * dryRun, char * fieldManager)
+BatchV1beta1API_replaceNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/BatchV1beta1API.h
+++ b/kubernetes/api/BatchV1beta1API.h
@@ -14,19 +14,19 @@
 // create a CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_createNamespacedCronJob(apiClient_t *apiClient ,char * namespace ,v1beta1_cron_job_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+BatchV1beta1API_createNamespacedCronJob(apiClient_t *apiClient, char * namespace , v1beta1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of CronJob
 //
 v1_status_t*
-BatchV1beta1API_deleteCollectionNamespacedCronJob(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+BatchV1beta1API_deleteCollectionNamespacedCronJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a CronJob
 //
 v1_status_t*
-BatchV1beta1API_deleteNamespacedCronJob(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+BatchV1beta1API_deleteNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,48 +38,48 @@ BatchV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind CronJob
 //
 v1beta1_cron_job_list_t*
-BatchV1beta1API_listCronJobForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+BatchV1beta1API_listCronJobForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind CronJob
 //
 v1beta1_cron_job_list_t*
-BatchV1beta1API_listNamespacedCronJob(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+BatchV1beta1API_listNamespacedCronJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_patchNamespacedCronJob(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+BatchV1beta1API_patchNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_patchNamespacedCronJobStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+BatchV1beta1API_patchNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_readNamespacedCronJob(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+BatchV1beta1API_readNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_readNamespacedCronJobStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+BatchV1beta1API_readNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_replaceNamespacedCronJob(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_cron_job_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+BatchV1beta1API_replaceNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , v1beta1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified CronJob
 //
 v1beta1_cron_job_t*
-BatchV1beta1API_replaceNamespacedCronJobStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_cron_job_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+BatchV1beta1API_replaceNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/BatchV2alpha1API.c
+++ b/kubernetes/api/BatchV2alpha1API.c
@@ -15,7 +15,7 @@
 // create a CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_createNamespacedCronJob(apiClient_t *apiClient, char * namespace, v2alpha1_cron_job_t * body, char * pretty, char * dryRun, char * fieldManager)
+BatchV2alpha1API_createNamespacedCronJob(apiClient_t *apiClient, char * namespace , v2alpha1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of CronJob
 //
 v1_status_t*
-BatchV2alpha1API_deleteCollectionNamespacedCronJob(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+BatchV2alpha1API_deleteCollectionNamespacedCronJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete a CronJob
 //
 v1_status_t*
-BatchV2alpha1API_deleteNamespacedCronJob(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+BatchV2alpha1API_deleteNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind CronJob
 //
 v2alpha1_cron_job_list_t*
-BatchV2alpha1API_listCronJobForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+BatchV2alpha1API_listCronJobForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind CronJob
 //
 v2alpha1_cron_job_list_t*
-BatchV2alpha1API_listNamespacedCronJob(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+BatchV2alpha1API_listNamespacedCronJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_patchNamespacedCronJob(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+BatchV2alpha1API_patchNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // partially update status of the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_patchNamespacedCronJobStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+BatchV2alpha1API_patchNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1742,7 +1742,7 @@ end:
 // read the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_readNamespacedCronJob(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+BatchV2alpha1API_readNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1890,7 +1890,7 @@ end:
 // read status of the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_readNamespacedCronJobStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+BatchV2alpha1API_readNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1998,7 +1998,7 @@ end:
 // replace the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_replaceNamespacedCronJob(apiClient_t *apiClient, char * name, char * namespace, v2alpha1_cron_job_t * body, char * pretty, char * dryRun, char * fieldManager)
+BatchV2alpha1API_replaceNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , v2alpha1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2168,7 +2168,7 @@ end:
 // replace status of the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_replaceNamespacedCronJobStatus(apiClient_t *apiClient, char * name, char * namespace, v2alpha1_cron_job_t * body, char * pretty, char * dryRun, char * fieldManager)
+BatchV2alpha1API_replaceNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , v2alpha1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/BatchV2alpha1API.h
+++ b/kubernetes/api/BatchV2alpha1API.h
@@ -14,19 +14,19 @@
 // create a CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_createNamespacedCronJob(apiClient_t *apiClient ,char * namespace ,v2alpha1_cron_job_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+BatchV2alpha1API_createNamespacedCronJob(apiClient_t *apiClient, char * namespace , v2alpha1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of CronJob
 //
 v1_status_t*
-BatchV2alpha1API_deleteCollectionNamespacedCronJob(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+BatchV2alpha1API_deleteCollectionNamespacedCronJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a CronJob
 //
 v1_status_t*
-BatchV2alpha1API_deleteNamespacedCronJob(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+BatchV2alpha1API_deleteNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,48 +38,48 @@ BatchV2alpha1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind CronJob
 //
 v2alpha1_cron_job_list_t*
-BatchV2alpha1API_listCronJobForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+BatchV2alpha1API_listCronJobForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind CronJob
 //
 v2alpha1_cron_job_list_t*
-BatchV2alpha1API_listNamespacedCronJob(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+BatchV2alpha1API_listNamespacedCronJob(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_patchNamespacedCronJob(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+BatchV2alpha1API_patchNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_patchNamespacedCronJobStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+BatchV2alpha1API_patchNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_readNamespacedCronJob(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+BatchV2alpha1API_readNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_readNamespacedCronJobStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+BatchV2alpha1API_readNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_replaceNamespacedCronJob(apiClient_t *apiClient ,char * name ,char * namespace ,v2alpha1_cron_job_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+BatchV2alpha1API_replaceNamespacedCronJob(apiClient_t *apiClient, char * name , char * namespace , v2alpha1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified CronJob
 //
 v2alpha1_cron_job_t*
-BatchV2alpha1API_replaceNamespacedCronJobStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v2alpha1_cron_job_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+BatchV2alpha1API_replaceNamespacedCronJobStatus(apiClient_t *apiClient, char * name , char * namespace , v2alpha1_cron_job_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/CertificatesV1beta1API.c
+++ b/kubernetes/api/CertificatesV1beta1API.c
@@ -15,7 +15,7 @@
 // create a CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_createCertificateSigningRequest(apiClient_t *apiClient, v1beta1_certificate_signing_request_t * body, char * pretty, char * dryRun, char * fieldManager)
+CertificatesV1beta1API_createCertificateSigningRequest(apiClient_t *apiClient, v1beta1_certificate_signing_request_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete a CertificateSigningRequest
 //
 v1_status_t*
-CertificatesV1beta1API_deleteCertificateSigningRequest(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CertificatesV1beta1API_deleteCertificateSigningRequest(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -365,7 +365,7 @@ end:
 // delete collection of CertificateSigningRequest
 //
 v1_status_t*
-CertificatesV1beta1API_deleteCollectionCertificateSigningRequest(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CertificatesV1beta1API_deleteCollectionCertificateSigningRequest(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_list_t*
-CertificatesV1beta1API_listCertificateSigningRequest(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CertificatesV1beta1API_listCertificateSigningRequest(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_patchCertificateSigningRequest(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CertificatesV1beta1API_patchCertificateSigningRequest(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // partially update status of the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_patchCertificateSigningRequestStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CertificatesV1beta1API_patchCertificateSigningRequestStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1412,7 +1412,7 @@ end:
 // read the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_readCertificateSigningRequest(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+CertificatesV1beta1API_readCertificateSigningRequest(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1549,7 +1549,7 @@ end:
 // read status of the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_readCertificateSigningRequestStatus(apiClient_t *apiClient, char * name, char * pretty)
+CertificatesV1beta1API_readCertificateSigningRequestStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1646,7 +1646,7 @@ end:
 // replace the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_replaceCertificateSigningRequest(apiClient_t *apiClient, char * name, v1beta1_certificate_signing_request_t * body, char * pretty, char * dryRun, char * fieldManager)
+CertificatesV1beta1API_replaceCertificateSigningRequest(apiClient_t *apiClient, char * name , v1beta1_certificate_signing_request_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1805,7 +1805,7 @@ end:
 // replace approval of the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_replaceCertificateSigningRequestApproval(apiClient_t *apiClient, char * name, v1beta1_certificate_signing_request_t * body, char * dryRun, char * fieldManager, char * pretty)
+CertificatesV1beta1API_replaceCertificateSigningRequestApproval(apiClient_t *apiClient, char * name , v1beta1_certificate_signing_request_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1964,7 +1964,7 @@ end:
 // replace status of the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_replaceCertificateSigningRequestStatus(apiClient_t *apiClient, char * name, v1beta1_certificate_signing_request_t * body, char * pretty, char * dryRun, char * fieldManager)
+CertificatesV1beta1API_replaceCertificateSigningRequestStatus(apiClient_t *apiClient, char * name , v1beta1_certificate_signing_request_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/CertificatesV1beta1API.h
+++ b/kubernetes/api/CertificatesV1beta1API.h
@@ -14,19 +14,19 @@
 // create a CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_createCertificateSigningRequest(apiClient_t *apiClient ,v1beta1_certificate_signing_request_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CertificatesV1beta1API_createCertificateSigningRequest(apiClient_t *apiClient, v1beta1_certificate_signing_request_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete a CertificateSigningRequest
 //
 v1_status_t*
-CertificatesV1beta1API_deleteCertificateSigningRequest(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CertificatesV1beta1API_deleteCertificateSigningRequest(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete collection of CertificateSigningRequest
 //
 v1_status_t*
-CertificatesV1beta1API_deleteCollectionCertificateSigningRequest(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CertificatesV1beta1API_deleteCollectionCertificateSigningRequest(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,48 +38,48 @@ CertificatesV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_list_t*
-CertificatesV1beta1API_listCertificateSigningRequest(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CertificatesV1beta1API_listCertificateSigningRequest(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_patchCertificateSigningRequest(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CertificatesV1beta1API_patchCertificateSigningRequest(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_patchCertificateSigningRequestStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CertificatesV1beta1API_patchCertificateSigningRequestStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_readCertificateSigningRequest(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+CertificatesV1beta1API_readCertificateSigningRequest(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_readCertificateSigningRequestStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+CertificatesV1beta1API_readCertificateSigningRequestStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // replace the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_replaceCertificateSigningRequest(apiClient_t *apiClient ,char * name ,v1beta1_certificate_signing_request_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CertificatesV1beta1API_replaceCertificateSigningRequest(apiClient_t *apiClient, char * name , v1beta1_certificate_signing_request_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace approval of the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_replaceCertificateSigningRequestApproval(apiClient_t *apiClient ,char * name ,v1beta1_certificate_signing_request_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+CertificatesV1beta1API_replaceCertificateSigningRequestApproval(apiClient_t *apiClient, char * name , v1beta1_certificate_signing_request_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // replace status of the specified CertificateSigningRequest
 //
 v1beta1_certificate_signing_request_t*
-CertificatesV1beta1API_replaceCertificateSigningRequestStatus(apiClient_t *apiClient ,char * name ,v1beta1_certificate_signing_request_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CertificatesV1beta1API_replaceCertificateSigningRequestStatus(apiClient_t *apiClient, char * name , v1beta1_certificate_signing_request_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/CoordinationV1API.c
+++ b/kubernetes/api/CoordinationV1API.c
@@ -15,7 +15,7 @@
 // create a Lease
 //
 v1_lease_t*
-CoordinationV1API_createNamespacedLease(apiClient_t *apiClient, char * namespace, v1_lease_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoordinationV1API_createNamespacedLease(apiClient_t *apiClient, char * namespace , v1_lease_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of Lease
 //
 v1_status_t*
-CoordinationV1API_deleteCollectionNamespacedLease(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoordinationV1API_deleteCollectionNamespacedLease(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete a Lease
 //
 v1_status_t*
-CoordinationV1API_deleteNamespacedLease(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoordinationV1API_deleteNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind Lease
 //
 v1_lease_list_t*
-CoordinationV1API_listLeaseForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoordinationV1API_listLeaseForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind Lease
 //
 v1_lease_list_t*
-CoordinationV1API_listNamespacedLease(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoordinationV1API_listNamespacedLease(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified Lease
 //
 v1_lease_t*
-CoordinationV1API_patchNamespacedLease(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoordinationV1API_patchNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // read the specified Lease
 //
 v1_lease_t*
-CoordinationV1API_readNamespacedLease(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoordinationV1API_readNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1699,7 +1699,7 @@ end:
 // replace the specified Lease
 //
 v1_lease_t*
-CoordinationV1API_replaceNamespacedLease(apiClient_t *apiClient, char * name, char * namespace, v1_lease_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoordinationV1API_replaceNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , v1_lease_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/CoordinationV1API.h
+++ b/kubernetes/api/CoordinationV1API.h
@@ -14,19 +14,19 @@
 // create a Lease
 //
 v1_lease_t*
-CoordinationV1API_createNamespacedLease(apiClient_t *apiClient ,char * namespace ,v1_lease_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoordinationV1API_createNamespacedLease(apiClient_t *apiClient, char * namespace , v1_lease_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of Lease
 //
 v1_status_t*
-CoordinationV1API_deleteCollectionNamespacedLease(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoordinationV1API_deleteCollectionNamespacedLease(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a Lease
 //
 v1_status_t*
-CoordinationV1API_deleteNamespacedLease(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoordinationV1API_deleteNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,30 +38,30 @@ CoordinationV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind Lease
 //
 v1_lease_list_t*
-CoordinationV1API_listLeaseForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoordinationV1API_listLeaseForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Lease
 //
 v1_lease_list_t*
-CoordinationV1API_listNamespacedLease(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoordinationV1API_listNamespacedLease(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified Lease
 //
 v1_lease_t*
-CoordinationV1API_patchNamespacedLease(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoordinationV1API_patchNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified Lease
 //
 v1_lease_t*
-CoordinationV1API_readNamespacedLease(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoordinationV1API_readNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // replace the specified Lease
 //
 v1_lease_t*
-CoordinationV1API_replaceNamespacedLease(apiClient_t *apiClient ,char * name ,char * namespace ,v1_lease_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoordinationV1API_replaceNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , v1_lease_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/CoordinationV1beta1API.c
+++ b/kubernetes/api/CoordinationV1beta1API.c
@@ -15,7 +15,7 @@
 // create a Lease
 //
 v1beta1_lease_t*
-CoordinationV1beta1API_createNamespacedLease(apiClient_t *apiClient, char * namespace, v1beta1_lease_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoordinationV1beta1API_createNamespacedLease(apiClient_t *apiClient, char * namespace , v1beta1_lease_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of Lease
 //
 v1_status_t*
-CoordinationV1beta1API_deleteCollectionNamespacedLease(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoordinationV1beta1API_deleteCollectionNamespacedLease(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete a Lease
 //
 v1_status_t*
-CoordinationV1beta1API_deleteNamespacedLease(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoordinationV1beta1API_deleteNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind Lease
 //
 v1beta1_lease_list_t*
-CoordinationV1beta1API_listLeaseForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoordinationV1beta1API_listLeaseForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind Lease
 //
 v1beta1_lease_list_t*
-CoordinationV1beta1API_listNamespacedLease(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoordinationV1beta1API_listNamespacedLease(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified Lease
 //
 v1beta1_lease_t*
-CoordinationV1beta1API_patchNamespacedLease(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoordinationV1beta1API_patchNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // read the specified Lease
 //
 v1beta1_lease_t*
-CoordinationV1beta1API_readNamespacedLease(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoordinationV1beta1API_readNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1699,7 +1699,7 @@ end:
 // replace the specified Lease
 //
 v1beta1_lease_t*
-CoordinationV1beta1API_replaceNamespacedLease(apiClient_t *apiClient, char * name, char * namespace, v1beta1_lease_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoordinationV1beta1API_replaceNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , v1beta1_lease_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/CoordinationV1beta1API.h
+++ b/kubernetes/api/CoordinationV1beta1API.h
@@ -14,19 +14,19 @@
 // create a Lease
 //
 v1beta1_lease_t*
-CoordinationV1beta1API_createNamespacedLease(apiClient_t *apiClient ,char * namespace ,v1beta1_lease_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoordinationV1beta1API_createNamespacedLease(apiClient_t *apiClient, char * namespace , v1beta1_lease_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of Lease
 //
 v1_status_t*
-CoordinationV1beta1API_deleteCollectionNamespacedLease(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoordinationV1beta1API_deleteCollectionNamespacedLease(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a Lease
 //
 v1_status_t*
-CoordinationV1beta1API_deleteNamespacedLease(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoordinationV1beta1API_deleteNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,30 +38,30 @@ CoordinationV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind Lease
 //
 v1beta1_lease_list_t*
-CoordinationV1beta1API_listLeaseForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoordinationV1beta1API_listLeaseForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Lease
 //
 v1beta1_lease_list_t*
-CoordinationV1beta1API_listNamespacedLease(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoordinationV1beta1API_listNamespacedLease(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified Lease
 //
 v1beta1_lease_t*
-CoordinationV1beta1API_patchNamespacedLease(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoordinationV1beta1API_patchNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified Lease
 //
 v1beta1_lease_t*
-CoordinationV1beta1API_readNamespacedLease(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoordinationV1beta1API_readNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // replace the specified Lease
 //
 v1beta1_lease_t*
-CoordinationV1beta1API_replaceNamespacedLease(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_lease_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoordinationV1beta1API_replaceNamespacedLease(apiClient_t *apiClient, char * name , char * namespace , v1beta1_lease_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/CoreV1API.c
+++ b/kubernetes/api/CoreV1API.c
@@ -15,7 +15,7 @@
 // connect DELETE requests to proxy of Pod
 //
 char*
-CoreV1API_connectDeleteNamespacedPodProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectDeleteNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -115,7 +115,7 @@ end:
 // connect DELETE requests to proxy of Pod
 //
 char*
-CoreV1API_connectDeleteNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectDeleteNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -226,7 +226,7 @@ end:
 // connect DELETE requests to proxy of Service
 //
 char*
-CoreV1API_connectDeleteNamespacedServiceProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectDeleteNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -326,7 +326,7 @@ end:
 // connect DELETE requests to proxy of Service
 //
 char*
-CoreV1API_connectDeleteNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectDeleteNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -437,7 +437,7 @@ end:
 // connect DELETE requests to proxy of Node
 //
 char*
-CoreV1API_connectDeleteNodeProxy(apiClient_t *apiClient, char * name, char * path)
+CoreV1API_connectDeleteNodeProxy(apiClient_t *apiClient, char * name , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -526,7 +526,7 @@ end:
 // connect DELETE requests to proxy of Node
 //
 char*
-CoreV1API_connectDeleteNodeProxyWithPath(apiClient_t *apiClient, char * name, char * path, char * path2)
+CoreV1API_connectDeleteNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -626,7 +626,7 @@ end:
 // connect GET requests to attach of Pod
 //
 char*
-CoreV1API_connectGetNamespacedPodAttach(apiClient_t *apiClient, char * name, char * namespace, char * container, int stderr, int stdin, int stdout, int tty)
+CoreV1API_connectGetNamespacedPodAttach(apiClient_t *apiClient, char * name , char * namespace , char * container , int stderr , int stdin , int stdout , int tty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -806,7 +806,7 @@ end:
 // connect GET requests to exec of Pod
 //
 char*
-CoreV1API_connectGetNamespacedPodExec(apiClient_t *apiClient, char * name, char * namespace, char * command, char * container, int stderr, int stdin, int stdout, int tty)
+CoreV1API_connectGetNamespacedPodExec(apiClient_t *apiClient, char * name , char * namespace , char * command , char * container , int stderr , int stdin , int stdout , int tty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1010,7 +1010,7 @@ end:
 // connect GET requests to portforward of Pod
 //
 char*
-CoreV1API_connectGetNamespacedPodPortforward(apiClient_t *apiClient, char * name, char * namespace, int ports)
+CoreV1API_connectGetNamespacedPodPortforward(apiClient_t *apiClient, char * name , char * namespace , int ports )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1106,7 +1106,7 @@ end:
 // connect GET requests to proxy of Pod
 //
 char*
-CoreV1API_connectGetNamespacedPodProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectGetNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1206,7 +1206,7 @@ end:
 // connect GET requests to proxy of Pod
 //
 char*
-CoreV1API_connectGetNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectGetNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1317,7 +1317,7 @@ end:
 // connect GET requests to proxy of Service
 //
 char*
-CoreV1API_connectGetNamespacedServiceProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectGetNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1417,7 +1417,7 @@ end:
 // connect GET requests to proxy of Service
 //
 char*
-CoreV1API_connectGetNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectGetNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1528,7 +1528,7 @@ end:
 // connect GET requests to proxy of Node
 //
 char*
-CoreV1API_connectGetNodeProxy(apiClient_t *apiClient, char * name, char * path)
+CoreV1API_connectGetNodeProxy(apiClient_t *apiClient, char * name , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1617,7 +1617,7 @@ end:
 // connect GET requests to proxy of Node
 //
 char*
-CoreV1API_connectGetNodeProxyWithPath(apiClient_t *apiClient, char * name, char * path, char * path2)
+CoreV1API_connectGetNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1717,7 +1717,7 @@ end:
 // connect HEAD requests to proxy of Pod
 //
 char*
-CoreV1API_connectHeadNamespacedPodProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectHeadNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1817,7 +1817,7 @@ end:
 // connect HEAD requests to proxy of Pod
 //
 char*
-CoreV1API_connectHeadNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectHeadNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1928,7 +1928,7 @@ end:
 // connect HEAD requests to proxy of Service
 //
 char*
-CoreV1API_connectHeadNamespacedServiceProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectHeadNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2028,7 +2028,7 @@ end:
 // connect HEAD requests to proxy of Service
 //
 char*
-CoreV1API_connectHeadNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectHeadNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2139,7 +2139,7 @@ end:
 // connect HEAD requests to proxy of Node
 //
 char*
-CoreV1API_connectHeadNodeProxy(apiClient_t *apiClient, char * name, char * path)
+CoreV1API_connectHeadNodeProxy(apiClient_t *apiClient, char * name , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2228,7 +2228,7 @@ end:
 // connect HEAD requests to proxy of Node
 //
 char*
-CoreV1API_connectHeadNodeProxyWithPath(apiClient_t *apiClient, char * name, char * path, char * path2)
+CoreV1API_connectHeadNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2328,7 +2328,7 @@ end:
 // connect OPTIONS requests to proxy of Pod
 //
 char*
-CoreV1API_connectOptionsNamespacedPodProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectOptionsNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2428,7 +2428,7 @@ end:
 // connect OPTIONS requests to proxy of Pod
 //
 char*
-CoreV1API_connectOptionsNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectOptionsNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2539,7 +2539,7 @@ end:
 // connect OPTIONS requests to proxy of Service
 //
 char*
-CoreV1API_connectOptionsNamespacedServiceProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectOptionsNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2639,7 +2639,7 @@ end:
 // connect OPTIONS requests to proxy of Service
 //
 char*
-CoreV1API_connectOptionsNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectOptionsNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2750,7 +2750,7 @@ end:
 // connect OPTIONS requests to proxy of Node
 //
 char*
-CoreV1API_connectOptionsNodeProxy(apiClient_t *apiClient, char * name, char * path)
+CoreV1API_connectOptionsNodeProxy(apiClient_t *apiClient, char * name , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2839,7 +2839,7 @@ end:
 // connect OPTIONS requests to proxy of Node
 //
 char*
-CoreV1API_connectOptionsNodeProxyWithPath(apiClient_t *apiClient, char * name, char * path, char * path2)
+CoreV1API_connectOptionsNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2939,7 +2939,7 @@ end:
 // connect PATCH requests to proxy of Pod
 //
 char*
-CoreV1API_connectPatchNamespacedPodProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectPatchNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3039,7 +3039,7 @@ end:
 // connect PATCH requests to proxy of Pod
 //
 char*
-CoreV1API_connectPatchNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectPatchNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3150,7 +3150,7 @@ end:
 // connect PATCH requests to proxy of Service
 //
 char*
-CoreV1API_connectPatchNamespacedServiceProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectPatchNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3250,7 +3250,7 @@ end:
 // connect PATCH requests to proxy of Service
 //
 char*
-CoreV1API_connectPatchNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectPatchNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3361,7 +3361,7 @@ end:
 // connect PATCH requests to proxy of Node
 //
 char*
-CoreV1API_connectPatchNodeProxy(apiClient_t *apiClient, char * name, char * path)
+CoreV1API_connectPatchNodeProxy(apiClient_t *apiClient, char * name , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3450,7 +3450,7 @@ end:
 // connect PATCH requests to proxy of Node
 //
 char*
-CoreV1API_connectPatchNodeProxyWithPath(apiClient_t *apiClient, char * name, char * path, char * path2)
+CoreV1API_connectPatchNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3550,7 +3550,7 @@ end:
 // connect POST requests to attach of Pod
 //
 char*
-CoreV1API_connectPostNamespacedPodAttach(apiClient_t *apiClient, char * name, char * namespace, char * container, int stderr, int stdin, int stdout, int tty)
+CoreV1API_connectPostNamespacedPodAttach(apiClient_t *apiClient, char * name , char * namespace , char * container , int stderr , int stdin , int stdout , int tty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3730,7 +3730,7 @@ end:
 // connect POST requests to exec of Pod
 //
 char*
-CoreV1API_connectPostNamespacedPodExec(apiClient_t *apiClient, char * name, char * namespace, char * command, char * container, int stderr, int stdin, int stdout, int tty)
+CoreV1API_connectPostNamespacedPodExec(apiClient_t *apiClient, char * name , char * namespace , char * command , char * container , int stderr , int stdin , int stdout , int tty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3934,7 +3934,7 @@ end:
 // connect POST requests to portforward of Pod
 //
 char*
-CoreV1API_connectPostNamespacedPodPortforward(apiClient_t *apiClient, char * name, char * namespace, int ports)
+CoreV1API_connectPostNamespacedPodPortforward(apiClient_t *apiClient, char * name , char * namespace , int ports )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4030,7 +4030,7 @@ end:
 // connect POST requests to proxy of Pod
 //
 char*
-CoreV1API_connectPostNamespacedPodProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectPostNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4130,7 +4130,7 @@ end:
 // connect POST requests to proxy of Pod
 //
 char*
-CoreV1API_connectPostNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectPostNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4241,7 +4241,7 @@ end:
 // connect POST requests to proxy of Service
 //
 char*
-CoreV1API_connectPostNamespacedServiceProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectPostNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4341,7 +4341,7 @@ end:
 // connect POST requests to proxy of Service
 //
 char*
-CoreV1API_connectPostNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectPostNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4452,7 +4452,7 @@ end:
 // connect POST requests to proxy of Node
 //
 char*
-CoreV1API_connectPostNodeProxy(apiClient_t *apiClient, char * name, char * path)
+CoreV1API_connectPostNodeProxy(apiClient_t *apiClient, char * name , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4541,7 +4541,7 @@ end:
 // connect POST requests to proxy of Node
 //
 char*
-CoreV1API_connectPostNodeProxyWithPath(apiClient_t *apiClient, char * name, char * path, char * path2)
+CoreV1API_connectPostNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4641,7 +4641,7 @@ end:
 // connect PUT requests to proxy of Pod
 //
 char*
-CoreV1API_connectPutNamespacedPodProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectPutNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4741,7 +4741,7 @@ end:
 // connect PUT requests to proxy of Pod
 //
 char*
-CoreV1API_connectPutNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectPutNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4852,7 +4852,7 @@ end:
 // connect PUT requests to proxy of Service
 //
 char*
-CoreV1API_connectPutNamespacedServiceProxy(apiClient_t *apiClient, char * name, char * namespace, char * path)
+CoreV1API_connectPutNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4952,7 +4952,7 @@ end:
 // connect PUT requests to proxy of Service
 //
 char*
-CoreV1API_connectPutNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name, char * namespace, char * path, char * path2)
+CoreV1API_connectPutNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5063,7 +5063,7 @@ end:
 // connect PUT requests to proxy of Node
 //
 char*
-CoreV1API_connectPutNodeProxy(apiClient_t *apiClient, char * name, char * path)
+CoreV1API_connectPutNodeProxy(apiClient_t *apiClient, char * name , char * path )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5152,7 +5152,7 @@ end:
 // connect PUT requests to proxy of Node
 //
 char*
-CoreV1API_connectPutNodeProxyWithPath(apiClient_t *apiClient, char * name, char * path, char * path2)
+CoreV1API_connectPutNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5252,7 +5252,7 @@ end:
 // create a Namespace
 //
 v1_namespace_t*
-CoreV1API_createNamespace(apiClient_t *apiClient, v1_namespace_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespace(apiClient_t *apiClient, v1_namespace_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5403,7 +5403,7 @@ end:
 // create a Binding
 //
 v1_binding_t*
-CoreV1API_createNamespacedBinding(apiClient_t *apiClient, char * namespace, v1_binding_t * body, char * dryRun, char * fieldManager, char * pretty)
+CoreV1API_createNamespacedBinding(apiClient_t *apiClient, char * namespace , v1_binding_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5565,7 +5565,7 @@ end:
 // create a ConfigMap
 //
 v1_config_map_t*
-CoreV1API_createNamespacedConfigMap(apiClient_t *apiClient, char * namespace, v1_config_map_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedConfigMap(apiClient_t *apiClient, char * namespace , v1_config_map_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5727,7 +5727,7 @@ end:
 // create Endpoints
 //
 v1_endpoints_t*
-CoreV1API_createNamespacedEndpoints(apiClient_t *apiClient, char * namespace, v1_endpoints_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedEndpoints(apiClient_t *apiClient, char * namespace , v1_endpoints_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5889,7 +5889,7 @@ end:
 // create an Event
 //
 v1_event_t*
-CoreV1API_createNamespacedEvent(apiClient_t *apiClient, char * namespace, v1_event_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedEvent(apiClient_t *apiClient, char * namespace , v1_event_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6051,7 +6051,7 @@ end:
 // create a LimitRange
 //
 v1_limit_range_t*
-CoreV1API_createNamespacedLimitRange(apiClient_t *apiClient, char * namespace, v1_limit_range_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedLimitRange(apiClient_t *apiClient, char * namespace , v1_limit_range_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6213,7 +6213,7 @@ end:
 // create a PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_createNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * namespace, v1_persistent_volume_claim_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * namespace , v1_persistent_volume_claim_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6375,7 +6375,7 @@ end:
 // create a Pod
 //
 v1_pod_t*
-CoreV1API_createNamespacedPod(apiClient_t *apiClient, char * namespace, v1_pod_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedPod(apiClient_t *apiClient, char * namespace , v1_pod_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6537,7 +6537,7 @@ end:
 // create binding of a Pod
 //
 v1_binding_t*
-CoreV1API_createNamespacedPodBinding(apiClient_t *apiClient, char * name, char * namespace, v1_binding_t * body, char * dryRun, char * fieldManager, char * pretty)
+CoreV1API_createNamespacedPodBinding(apiClient_t *apiClient, char * name , char * namespace , v1_binding_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6710,7 +6710,7 @@ end:
 // create eviction of a Pod
 //
 v1beta1_eviction_t*
-CoreV1API_createNamespacedPodEviction(apiClient_t *apiClient, char * name, char * namespace, v1beta1_eviction_t * body, char * dryRun, char * fieldManager, char * pretty)
+CoreV1API_createNamespacedPodEviction(apiClient_t *apiClient, char * name , char * namespace , v1beta1_eviction_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6883,7 +6883,7 @@ end:
 // create a PodTemplate
 //
 v1_pod_template_t*
-CoreV1API_createNamespacedPodTemplate(apiClient_t *apiClient, char * namespace, v1_pod_template_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedPodTemplate(apiClient_t *apiClient, char * namespace , v1_pod_template_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7045,7 +7045,7 @@ end:
 // create a ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_createNamespacedReplicationController(apiClient_t *apiClient, char * namespace, v1_replication_controller_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedReplicationController(apiClient_t *apiClient, char * namespace , v1_replication_controller_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7207,7 +7207,7 @@ end:
 // create a ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_createNamespacedResourceQuota(apiClient_t *apiClient, char * namespace, v1_resource_quota_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedResourceQuota(apiClient_t *apiClient, char * namespace , v1_resource_quota_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7369,7 +7369,7 @@ end:
 // create a Secret
 //
 v1_secret_t*
-CoreV1API_createNamespacedSecret(apiClient_t *apiClient, char * namespace, v1_secret_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedSecret(apiClient_t *apiClient, char * namespace , v1_secret_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7531,7 +7531,7 @@ end:
 // create a Service
 //
 v1_service_t*
-CoreV1API_createNamespacedService(apiClient_t *apiClient, char * namespace, v1_service_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedService(apiClient_t *apiClient, char * namespace , v1_service_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7693,7 +7693,7 @@ end:
 // create a ServiceAccount
 //
 v1_service_account_t*
-CoreV1API_createNamespacedServiceAccount(apiClient_t *apiClient, char * namespace, v1_service_account_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNamespacedServiceAccount(apiClient_t *apiClient, char * namespace , v1_service_account_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7855,7 +7855,7 @@ end:
 // create token of a ServiceAccount
 //
 v1_token_request_t*
-CoreV1API_createNamespacedServiceAccountToken(apiClient_t *apiClient, char * name, char * namespace, v1_token_request_t * body, char * dryRun, char * fieldManager, char * pretty)
+CoreV1API_createNamespacedServiceAccountToken(apiClient_t *apiClient, char * name , char * namespace , v1_token_request_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8028,7 +8028,7 @@ end:
 // create a Node
 //
 v1_node_t*
-CoreV1API_createNode(apiClient_t *apiClient, v1_node_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createNode(apiClient_t *apiClient, v1_node_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8179,7 +8179,7 @@ end:
 // create a PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_createPersistentVolume(apiClient_t *apiClient, v1_persistent_volume_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_createPersistentVolume(apiClient_t *apiClient, v1_persistent_volume_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8330,7 +8330,7 @@ end:
 // delete collection of ConfigMap
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedConfigMap(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedConfigMap(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8702,7 +8702,7 @@ end:
 // delete collection of Endpoints
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedEndpoints(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedEndpoints(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9074,7 +9074,7 @@ end:
 // delete collection of Event
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedEvent(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedEvent(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9446,7 +9446,7 @@ end:
 // delete collection of LimitRange
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedLimitRange(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedLimitRange(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9818,7 +9818,7 @@ end:
 // delete collection of PersistentVolumeClaim
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10190,7 +10190,7 @@ end:
 // delete collection of Pod
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedPod(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedPod(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10562,7 +10562,7 @@ end:
 // delete collection of PodTemplate
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedPodTemplate(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedPodTemplate(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10934,7 +10934,7 @@ end:
 // delete collection of ReplicationController
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedReplicationController(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedReplicationController(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11306,7 +11306,7 @@ end:
 // delete collection of ResourceQuota
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedResourceQuota(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedResourceQuota(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11678,7 +11678,7 @@ end:
 // delete collection of Secret
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedSecret(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedSecret(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12050,7 +12050,7 @@ end:
 // delete collection of ServiceAccount
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedServiceAccount(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNamespacedServiceAccount(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12422,7 +12422,7 @@ end:
 // delete collection of Node
 //
 v1_status_t*
-CoreV1API_deleteCollectionNode(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionNode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12783,7 +12783,7 @@ end:
 // delete collection of PersistentVolume
 //
 v1_status_t*
-CoreV1API_deleteCollectionPersistentVolume(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+CoreV1API_deleteCollectionPersistentVolume(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -13144,7 +13144,7 @@ end:
 // delete a Namespace
 //
 v1_status_t*
-CoreV1API_deleteNamespace(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespace(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -13343,7 +13343,7 @@ end:
 // delete a ConfigMap
 //
 v1_status_t*
-CoreV1API_deleteNamespacedConfigMap(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedConfigMap(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -13553,7 +13553,7 @@ end:
 // delete Endpoints
 //
 v1_status_t*
-CoreV1API_deleteNamespacedEndpoints(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedEndpoints(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -13763,7 +13763,7 @@ end:
 // delete an Event
 //
 v1_status_t*
-CoreV1API_deleteNamespacedEvent(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -13973,7 +13973,7 @@ end:
 // delete a LimitRange
 //
 v1_status_t*
-CoreV1API_deleteNamespacedLimitRange(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedLimitRange(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -14183,7 +14183,7 @@ end:
 // delete a PersistentVolumeClaim
 //
 v1_status_t*
-CoreV1API_deleteNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -14393,7 +14393,7 @@ end:
 // delete a Pod
 //
 v1_status_t*
-CoreV1API_deleteNamespacedPod(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedPod(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -14603,7 +14603,7 @@ end:
 // delete a PodTemplate
 //
 v1_status_t*
-CoreV1API_deleteNamespacedPodTemplate(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedPodTemplate(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -14813,7 +14813,7 @@ end:
 // delete a ReplicationController
 //
 v1_status_t*
-CoreV1API_deleteNamespacedReplicationController(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedReplicationController(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -15023,7 +15023,7 @@ end:
 // delete a ResourceQuota
 //
 v1_status_t*
-CoreV1API_deleteNamespacedResourceQuota(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedResourceQuota(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -15233,7 +15233,7 @@ end:
 // delete a Secret
 //
 v1_status_t*
-CoreV1API_deleteNamespacedSecret(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedSecret(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -15443,7 +15443,7 @@ end:
 // delete a Service
 //
 v1_status_t*
-CoreV1API_deleteNamespacedService(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedService(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -15653,7 +15653,7 @@ end:
 // delete a ServiceAccount
 //
 v1_status_t*
-CoreV1API_deleteNamespacedServiceAccount(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNamespacedServiceAccount(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -15863,7 +15863,7 @@ end:
 // delete a Node
 //
 v1_status_t*
-CoreV1API_deleteNode(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deleteNode(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -16062,7 +16062,7 @@ end:
 // delete a PersistentVolume
 //
 v1_status_t*
-CoreV1API_deletePersistentVolume(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CoreV1API_deletePersistentVolume(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -16323,7 +16323,7 @@ end:
 // list objects of kind ComponentStatus
 //
 v1_component_status_list_t*
-CoreV1API_listComponentStatus(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listComponentStatus(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -16587,7 +16587,7 @@ end:
 // list or watch objects of kind ConfigMap
 //
 v1_config_map_list_t*
-CoreV1API_listConfigMapForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listConfigMapForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -16851,7 +16851,7 @@ end:
 // list or watch objects of kind Endpoints
 //
 v1_endpoints_list_t*
-CoreV1API_listEndpointsForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listEndpointsForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -17115,7 +17115,7 @@ end:
 // list or watch objects of kind Event
 //
 v1_event_list_t*
-CoreV1API_listEventForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listEventForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -17379,7 +17379,7 @@ end:
 // list or watch objects of kind LimitRange
 //
 v1_limit_range_list_t*
-CoreV1API_listLimitRangeForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listLimitRangeForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -17643,7 +17643,7 @@ end:
 // list or watch objects of kind Namespace
 //
 v1_namespace_list_t*
-CoreV1API_listNamespace(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespace(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -17907,7 +17907,7 @@ end:
 // list or watch objects of kind ConfigMap
 //
 v1_config_map_list_t*
-CoreV1API_listNamespacedConfigMap(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedConfigMap(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -18182,7 +18182,7 @@ end:
 // list or watch objects of kind Endpoints
 //
 v1_endpoints_list_t*
-CoreV1API_listNamespacedEndpoints(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedEndpoints(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -18457,7 +18457,7 @@ end:
 // list or watch objects of kind Event
 //
 v1_event_list_t*
-CoreV1API_listNamespacedEvent(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedEvent(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -18732,7 +18732,7 @@ end:
 // list or watch objects of kind LimitRange
 //
 v1_limit_range_list_t*
-CoreV1API_listNamespacedLimitRange(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedLimitRange(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -19007,7 +19007,7 @@ end:
 // list or watch objects of kind PersistentVolumeClaim
 //
 v1_persistent_volume_claim_list_t*
-CoreV1API_listNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -19282,7 +19282,7 @@ end:
 // list or watch objects of kind Pod
 //
 v1_pod_list_t*
-CoreV1API_listNamespacedPod(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedPod(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -19557,7 +19557,7 @@ end:
 // list or watch objects of kind PodTemplate
 //
 v1_pod_template_list_t*
-CoreV1API_listNamespacedPodTemplate(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedPodTemplate(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -19832,7 +19832,7 @@ end:
 // list or watch objects of kind ReplicationController
 //
 v1_replication_controller_list_t*
-CoreV1API_listNamespacedReplicationController(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedReplicationController(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -20107,7 +20107,7 @@ end:
 // list or watch objects of kind ResourceQuota
 //
 v1_resource_quota_list_t*
-CoreV1API_listNamespacedResourceQuota(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedResourceQuota(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -20382,7 +20382,7 @@ end:
 // list or watch objects of kind Secret
 //
 v1_secret_list_t*
-CoreV1API_listNamespacedSecret(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedSecret(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -20657,7 +20657,7 @@ end:
 // list or watch objects of kind Service
 //
 v1_service_list_t*
-CoreV1API_listNamespacedService(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedService(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -20932,7 +20932,7 @@ end:
 // list or watch objects of kind ServiceAccount
 //
 v1_service_account_list_t*
-CoreV1API_listNamespacedServiceAccount(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNamespacedServiceAccount(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -21207,7 +21207,7 @@ end:
 // list or watch objects of kind Node
 //
 v1_node_list_t*
-CoreV1API_listNode(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listNode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -21471,7 +21471,7 @@ end:
 // list or watch objects of kind PersistentVolume
 //
 v1_persistent_volume_list_t*
-CoreV1API_listPersistentVolume(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listPersistentVolume(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -21735,7 +21735,7 @@ end:
 // list or watch objects of kind PersistentVolumeClaim
 //
 v1_persistent_volume_claim_list_t*
-CoreV1API_listPersistentVolumeClaimForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listPersistentVolumeClaimForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -21999,7 +21999,7 @@ end:
 // list or watch objects of kind Pod
 //
 v1_pod_list_t*
-CoreV1API_listPodForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listPodForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -22263,7 +22263,7 @@ end:
 // list or watch objects of kind PodTemplate
 //
 v1_pod_template_list_t*
-CoreV1API_listPodTemplateForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listPodTemplateForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -22527,7 +22527,7 @@ end:
 // list or watch objects of kind ReplicationController
 //
 v1_replication_controller_list_t*
-CoreV1API_listReplicationControllerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listReplicationControllerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -22791,7 +22791,7 @@ end:
 // list or watch objects of kind ResourceQuota
 //
 v1_resource_quota_list_t*
-CoreV1API_listResourceQuotaForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listResourceQuotaForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -23055,7 +23055,7 @@ end:
 // list or watch objects of kind Secret
 //
 v1_secret_list_t*
-CoreV1API_listSecretForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listSecretForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -23319,7 +23319,7 @@ end:
 // list or watch objects of kind ServiceAccount
 //
 v1_service_account_list_t*
-CoreV1API_listServiceAccountForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listServiceAccountForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -23583,7 +23583,7 @@ end:
 // list or watch objects of kind Service
 //
 v1_service_list_t*
-CoreV1API_listServiceForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+CoreV1API_listServiceForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -23847,7 +23847,7 @@ end:
 // partially update the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_patchNamespace(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespace(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -24027,7 +24027,7 @@ end:
 // partially update status of the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_patchNamespaceStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespaceStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -24207,7 +24207,7 @@ end:
 // partially update the specified ConfigMap
 //
 v1_config_map_t*
-CoreV1API_patchNamespacedConfigMap(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedConfigMap(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -24398,7 +24398,7 @@ end:
 // partially update the specified Endpoints
 //
 v1_endpoints_t*
-CoreV1API_patchNamespacedEndpoints(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedEndpoints(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -24589,7 +24589,7 @@ end:
 // partially update the specified Event
 //
 v1_event_t*
-CoreV1API_patchNamespacedEvent(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -24780,7 +24780,7 @@ end:
 // partially update the specified LimitRange
 //
 v1_limit_range_t*
-CoreV1API_patchNamespacedLimitRange(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedLimitRange(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -24971,7 +24971,7 @@ end:
 // partially update the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_patchNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -25162,7 +25162,7 @@ end:
 // partially update status of the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_patchNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -25353,7 +25353,7 @@ end:
 // partially update the specified Pod
 //
 v1_pod_t*
-CoreV1API_patchNamespacedPod(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedPod(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -25544,7 +25544,7 @@ end:
 // partially update status of the specified Pod
 //
 v1_pod_t*
-CoreV1API_patchNamespacedPodStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedPodStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -25735,7 +25735,7 @@ end:
 // partially update the specified PodTemplate
 //
 v1_pod_template_t*
-CoreV1API_patchNamespacedPodTemplate(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedPodTemplate(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -25926,7 +25926,7 @@ end:
 // partially update the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_patchNamespacedReplicationController(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedReplicationController(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -26117,7 +26117,7 @@ end:
 // partially update scale of the specified ReplicationController
 //
 v1_scale_t*
-CoreV1API_patchNamespacedReplicationControllerScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedReplicationControllerScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -26308,7 +26308,7 @@ end:
 // partially update status of the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_patchNamespacedReplicationControllerStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedReplicationControllerStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -26499,7 +26499,7 @@ end:
 // partially update the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_patchNamespacedResourceQuota(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedResourceQuota(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -26690,7 +26690,7 @@ end:
 // partially update status of the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_patchNamespacedResourceQuotaStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedResourceQuotaStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -26881,7 +26881,7 @@ end:
 // partially update the specified Secret
 //
 v1_secret_t*
-CoreV1API_patchNamespacedSecret(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedSecret(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -27072,7 +27072,7 @@ end:
 // partially update the specified Service
 //
 v1_service_t*
-CoreV1API_patchNamespacedService(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedService(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -27263,7 +27263,7 @@ end:
 // partially update the specified ServiceAccount
 //
 v1_service_account_t*
-CoreV1API_patchNamespacedServiceAccount(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedServiceAccount(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -27454,7 +27454,7 @@ end:
 // partially update status of the specified Service
 //
 v1_service_t*
-CoreV1API_patchNamespacedServiceStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNamespacedServiceStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -27645,7 +27645,7 @@ end:
 // partially update the specified Node
 //
 v1_node_t*
-CoreV1API_patchNode(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNode(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -27825,7 +27825,7 @@ end:
 // partially update status of the specified Node
 //
 v1_node_t*
-CoreV1API_patchNodeStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchNodeStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -28005,7 +28005,7 @@ end:
 // partially update the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_patchPersistentVolume(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchPersistentVolume(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -28185,7 +28185,7 @@ end:
 // partially update status of the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_patchPersistentVolumeStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+CoreV1API_patchPersistentVolumeStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -28365,7 +28365,7 @@ end:
 // read the specified ComponentStatus
 //
 v1_component_status_t*
-CoreV1API_readComponentStatus(apiClient_t *apiClient, char * name, char * pretty)
+CoreV1API_readComponentStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -28462,7 +28462,7 @@ end:
 // read the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_readNamespace(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+CoreV1API_readNamespace(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -28599,7 +28599,7 @@ end:
 // read status of the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_readNamespaceStatus(apiClient_t *apiClient, char * name, char * pretty)
+CoreV1API_readNamespaceStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -28696,7 +28696,7 @@ end:
 // read the specified ConfigMap
 //
 v1_config_map_t*
-CoreV1API_readNamespacedConfigMap(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedConfigMap(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -28844,7 +28844,7 @@ end:
 // read the specified Endpoints
 //
 v1_endpoints_t*
-CoreV1API_readNamespacedEndpoints(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedEndpoints(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -28992,7 +28992,7 @@ end:
 // read the specified Event
 //
 v1_event_t*
-CoreV1API_readNamespacedEvent(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -29140,7 +29140,7 @@ end:
 // read the specified LimitRange
 //
 v1_limit_range_t*
-CoreV1API_readNamespacedLimitRange(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedLimitRange(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -29288,7 +29288,7 @@ end:
 // read the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_readNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -29436,7 +29436,7 @@ end:
 // read status of the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_readNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+CoreV1API_readNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -29544,7 +29544,7 @@ end:
 // read the specified Pod
 //
 v1_pod_t*
-CoreV1API_readNamespacedPod(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedPod(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -29692,7 +29692,7 @@ end:
 // read log of the specified Pod
 //
 char*
-CoreV1API_readNamespacedPodLog(apiClient_t *apiClient, char * name, char * namespace, char * container, int follow, int insecureSkipTLSVerifyBackend, int limitBytes, char * pretty, int previous, int sinceSeconds, int tailLines, int timestamps)
+CoreV1API_readNamespacedPodLog(apiClient_t *apiClient, char * name , char * namespace , char * container , int follow , int insecureSkipTLSVerifyBackend , int limitBytes , char * pretty , int previous , int sinceSeconds , int tailLines , int timestamps )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -29959,7 +29959,7 @@ end:
 // read status of the specified Pod
 //
 v1_pod_t*
-CoreV1API_readNamespacedPodStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+CoreV1API_readNamespacedPodStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30067,7 +30067,7 @@ end:
 // read the specified PodTemplate
 //
 v1_pod_template_t*
-CoreV1API_readNamespacedPodTemplate(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedPodTemplate(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30215,7 +30215,7 @@ end:
 // read the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_readNamespacedReplicationController(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedReplicationController(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30363,7 +30363,7 @@ end:
 // read scale of the specified ReplicationController
 //
 v1_scale_t*
-CoreV1API_readNamespacedReplicationControllerScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+CoreV1API_readNamespacedReplicationControllerScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30471,7 +30471,7 @@ end:
 // read status of the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_readNamespacedReplicationControllerStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+CoreV1API_readNamespacedReplicationControllerStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30579,7 +30579,7 @@ end:
 // read the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_readNamespacedResourceQuota(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedResourceQuota(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30727,7 +30727,7 @@ end:
 // read status of the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_readNamespacedResourceQuotaStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+CoreV1API_readNamespacedResourceQuotaStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30835,7 +30835,7 @@ end:
 // read the specified Secret
 //
 v1_secret_t*
-CoreV1API_readNamespacedSecret(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedSecret(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30983,7 +30983,7 @@ end:
 // read the specified Service
 //
 v1_service_t*
-CoreV1API_readNamespacedService(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedService(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -31131,7 +31131,7 @@ end:
 // read the specified ServiceAccount
 //
 v1_service_account_t*
-CoreV1API_readNamespacedServiceAccount(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+CoreV1API_readNamespacedServiceAccount(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -31279,7 +31279,7 @@ end:
 // read status of the specified Service
 //
 v1_service_t*
-CoreV1API_readNamespacedServiceStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+CoreV1API_readNamespacedServiceStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -31387,7 +31387,7 @@ end:
 // read the specified Node
 //
 v1_node_t*
-CoreV1API_readNode(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+CoreV1API_readNode(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -31524,7 +31524,7 @@ end:
 // read status of the specified Node
 //
 v1_node_t*
-CoreV1API_readNodeStatus(apiClient_t *apiClient, char * name, char * pretty)
+CoreV1API_readNodeStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -31621,7 +31621,7 @@ end:
 // read the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_readPersistentVolume(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+CoreV1API_readPersistentVolume(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -31758,7 +31758,7 @@ end:
 // read status of the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_readPersistentVolumeStatus(apiClient_t *apiClient, char * name, char * pretty)
+CoreV1API_readPersistentVolumeStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -31855,7 +31855,7 @@ end:
 // replace the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_replaceNamespace(apiClient_t *apiClient, char * name, v1_namespace_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespace(apiClient_t *apiClient, char * name , v1_namespace_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -32014,7 +32014,7 @@ end:
 // replace finalize of the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_replaceNamespaceFinalize(apiClient_t *apiClient, char * name, v1_namespace_t * body, char * dryRun, char * fieldManager, char * pretty)
+CoreV1API_replaceNamespaceFinalize(apiClient_t *apiClient, char * name , v1_namespace_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -32173,7 +32173,7 @@ end:
 // replace status of the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_replaceNamespaceStatus(apiClient_t *apiClient, char * name, v1_namespace_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespaceStatus(apiClient_t *apiClient, char * name , v1_namespace_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -32332,7 +32332,7 @@ end:
 // replace the specified ConfigMap
 //
 v1_config_map_t*
-CoreV1API_replaceNamespacedConfigMap(apiClient_t *apiClient, char * name, char * namespace, v1_config_map_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedConfigMap(apiClient_t *apiClient, char * name , char * namespace , v1_config_map_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -32502,7 +32502,7 @@ end:
 // replace the specified Endpoints
 //
 v1_endpoints_t*
-CoreV1API_replaceNamespacedEndpoints(apiClient_t *apiClient, char * name, char * namespace, v1_endpoints_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedEndpoints(apiClient_t *apiClient, char * name , char * namespace , v1_endpoints_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -32672,7 +32672,7 @@ end:
 // replace the specified Event
 //
 v1_event_t*
-CoreV1API_replaceNamespacedEvent(apiClient_t *apiClient, char * name, char * namespace, v1_event_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , v1_event_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -32842,7 +32842,7 @@ end:
 // replace the specified LimitRange
 //
 v1_limit_range_t*
-CoreV1API_replaceNamespacedLimitRange(apiClient_t *apiClient, char * name, char * namespace, v1_limit_range_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedLimitRange(apiClient_t *apiClient, char * name , char * namespace , v1_limit_range_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -33012,7 +33012,7 @@ end:
 // replace the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_replaceNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name, char * namespace, v1_persistent_volume_claim_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name , char * namespace , v1_persistent_volume_claim_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -33182,7 +33182,7 @@ end:
 // replace status of the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_replaceNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient, char * name, char * namespace, v1_persistent_volume_claim_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient, char * name , char * namespace , v1_persistent_volume_claim_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -33352,7 +33352,7 @@ end:
 // replace the specified Pod
 //
 v1_pod_t*
-CoreV1API_replaceNamespacedPod(apiClient_t *apiClient, char * name, char * namespace, v1_pod_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedPod(apiClient_t *apiClient, char * name , char * namespace , v1_pod_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -33522,7 +33522,7 @@ end:
 // replace status of the specified Pod
 //
 v1_pod_t*
-CoreV1API_replaceNamespacedPodStatus(apiClient_t *apiClient, char * name, char * namespace, v1_pod_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedPodStatus(apiClient_t *apiClient, char * name , char * namespace , v1_pod_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -33692,7 +33692,7 @@ end:
 // replace the specified PodTemplate
 //
 v1_pod_template_t*
-CoreV1API_replaceNamespacedPodTemplate(apiClient_t *apiClient, char * name, char * namespace, v1_pod_template_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedPodTemplate(apiClient_t *apiClient, char * name , char * namespace , v1_pod_template_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -33862,7 +33862,7 @@ end:
 // replace the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_replaceNamespacedReplicationController(apiClient_t *apiClient, char * name, char * namespace, v1_replication_controller_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedReplicationController(apiClient_t *apiClient, char * name , char * namespace , v1_replication_controller_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -34032,7 +34032,7 @@ end:
 // replace scale of the specified ReplicationController
 //
 v1_scale_t*
-CoreV1API_replaceNamespacedReplicationControllerScale(apiClient_t *apiClient, char * name, char * namespace, v1_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedReplicationControllerScale(apiClient_t *apiClient, char * name , char * namespace , v1_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -34202,7 +34202,7 @@ end:
 // replace status of the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_replaceNamespacedReplicationControllerStatus(apiClient_t *apiClient, char * name, char * namespace, v1_replication_controller_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedReplicationControllerStatus(apiClient_t *apiClient, char * name , char * namespace , v1_replication_controller_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -34372,7 +34372,7 @@ end:
 // replace the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_replaceNamespacedResourceQuota(apiClient_t *apiClient, char * name, char * namespace, v1_resource_quota_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedResourceQuota(apiClient_t *apiClient, char * name , char * namespace , v1_resource_quota_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -34542,7 +34542,7 @@ end:
 // replace status of the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_replaceNamespacedResourceQuotaStatus(apiClient_t *apiClient, char * name, char * namespace, v1_resource_quota_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedResourceQuotaStatus(apiClient_t *apiClient, char * name , char * namespace , v1_resource_quota_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -34712,7 +34712,7 @@ end:
 // replace the specified Secret
 //
 v1_secret_t*
-CoreV1API_replaceNamespacedSecret(apiClient_t *apiClient, char * name, char * namespace, v1_secret_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedSecret(apiClient_t *apiClient, char * name , char * namespace , v1_secret_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -34882,7 +34882,7 @@ end:
 // replace the specified Service
 //
 v1_service_t*
-CoreV1API_replaceNamespacedService(apiClient_t *apiClient, char * name, char * namespace, v1_service_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedService(apiClient_t *apiClient, char * name , char * namespace , v1_service_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -35052,7 +35052,7 @@ end:
 // replace the specified ServiceAccount
 //
 v1_service_account_t*
-CoreV1API_replaceNamespacedServiceAccount(apiClient_t *apiClient, char * name, char * namespace, v1_service_account_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedServiceAccount(apiClient_t *apiClient, char * name , char * namespace , v1_service_account_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -35222,7 +35222,7 @@ end:
 // replace status of the specified Service
 //
 v1_service_t*
-CoreV1API_replaceNamespacedServiceStatus(apiClient_t *apiClient, char * name, char * namespace, v1_service_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNamespacedServiceStatus(apiClient_t *apiClient, char * name , char * namespace , v1_service_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -35392,7 +35392,7 @@ end:
 // replace the specified Node
 //
 v1_node_t*
-CoreV1API_replaceNode(apiClient_t *apiClient, char * name, v1_node_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNode(apiClient_t *apiClient, char * name , v1_node_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -35551,7 +35551,7 @@ end:
 // replace status of the specified Node
 //
 v1_node_t*
-CoreV1API_replaceNodeStatus(apiClient_t *apiClient, char * name, v1_node_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replaceNodeStatus(apiClient_t *apiClient, char * name , v1_node_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -35710,7 +35710,7 @@ end:
 // replace the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_replacePersistentVolume(apiClient_t *apiClient, char * name, v1_persistent_volume_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replacePersistentVolume(apiClient_t *apiClient, char * name , v1_persistent_volume_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -35869,7 +35869,7 @@ end:
 // replace status of the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_replacePersistentVolumeStatus(apiClient_t *apiClient, char * name, v1_persistent_volume_t * body, char * pretty, char * dryRun, char * fieldManager)
+CoreV1API_replacePersistentVolumeStatus(apiClient_t *apiClient, char * name , v1_persistent_volume_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/CoreV1API.h
+++ b/kubernetes/api/CoreV1API.h
@@ -48,571 +48,571 @@
 // connect DELETE requests to proxy of Pod
 //
 char*
-CoreV1API_connectDeleteNamespacedPodProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectDeleteNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect DELETE requests to proxy of Pod
 //
 char*
-CoreV1API_connectDeleteNamespacedPodProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectDeleteNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect DELETE requests to proxy of Service
 //
 char*
-CoreV1API_connectDeleteNamespacedServiceProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectDeleteNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect DELETE requests to proxy of Service
 //
 char*
-CoreV1API_connectDeleteNamespacedServiceProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectDeleteNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect DELETE requests to proxy of Node
 //
 char*
-CoreV1API_connectDeleteNodeProxy(apiClient_t *apiClient ,char * name ,char * path);
+CoreV1API_connectDeleteNodeProxy(apiClient_t *apiClient, char * name , char * path );
 
 
 // connect DELETE requests to proxy of Node
 //
 char*
-CoreV1API_connectDeleteNodeProxyWithPath(apiClient_t *apiClient ,char * name ,char * path ,char * path2);
+CoreV1API_connectDeleteNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 );
 
 
 // connect GET requests to attach of Pod
 //
 char*
-CoreV1API_connectGetNamespacedPodAttach(apiClient_t *apiClient ,char * name ,char * namespace ,char * container ,int stderr ,int stdin ,int stdout ,int tty);
+CoreV1API_connectGetNamespacedPodAttach(apiClient_t *apiClient, char * name , char * namespace , char * container , int stderr , int stdin , int stdout , int tty );
 
 
 // connect GET requests to exec of Pod
 //
 char*
-CoreV1API_connectGetNamespacedPodExec(apiClient_t *apiClient ,char * name ,char * namespace ,char * command ,char * container ,int stderr ,int stdin ,int stdout ,int tty);
+CoreV1API_connectGetNamespacedPodExec(apiClient_t *apiClient, char * name , char * namespace , char * command , char * container , int stderr , int stdin , int stdout , int tty );
 
 
 // connect GET requests to portforward of Pod
 //
 char*
-CoreV1API_connectGetNamespacedPodPortforward(apiClient_t *apiClient ,char * name ,char * namespace ,int ports);
+CoreV1API_connectGetNamespacedPodPortforward(apiClient_t *apiClient, char * name , char * namespace , int ports );
 
 
 // connect GET requests to proxy of Pod
 //
 char*
-CoreV1API_connectGetNamespacedPodProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectGetNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect GET requests to proxy of Pod
 //
 char*
-CoreV1API_connectGetNamespacedPodProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectGetNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect GET requests to proxy of Service
 //
 char*
-CoreV1API_connectGetNamespacedServiceProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectGetNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect GET requests to proxy of Service
 //
 char*
-CoreV1API_connectGetNamespacedServiceProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectGetNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect GET requests to proxy of Node
 //
 char*
-CoreV1API_connectGetNodeProxy(apiClient_t *apiClient ,char * name ,char * path);
+CoreV1API_connectGetNodeProxy(apiClient_t *apiClient, char * name , char * path );
 
 
 // connect GET requests to proxy of Node
 //
 char*
-CoreV1API_connectGetNodeProxyWithPath(apiClient_t *apiClient ,char * name ,char * path ,char * path2);
+CoreV1API_connectGetNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 );
 
 
 // connect HEAD requests to proxy of Pod
 //
 char*
-CoreV1API_connectHeadNamespacedPodProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectHeadNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect HEAD requests to proxy of Pod
 //
 char*
-CoreV1API_connectHeadNamespacedPodProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectHeadNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect HEAD requests to proxy of Service
 //
 char*
-CoreV1API_connectHeadNamespacedServiceProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectHeadNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect HEAD requests to proxy of Service
 //
 char*
-CoreV1API_connectHeadNamespacedServiceProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectHeadNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect HEAD requests to proxy of Node
 //
 char*
-CoreV1API_connectHeadNodeProxy(apiClient_t *apiClient ,char * name ,char * path);
+CoreV1API_connectHeadNodeProxy(apiClient_t *apiClient, char * name , char * path );
 
 
 // connect HEAD requests to proxy of Node
 //
 char*
-CoreV1API_connectHeadNodeProxyWithPath(apiClient_t *apiClient ,char * name ,char * path ,char * path2);
+CoreV1API_connectHeadNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 );
 
 
 // connect OPTIONS requests to proxy of Pod
 //
 char*
-CoreV1API_connectOptionsNamespacedPodProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectOptionsNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect OPTIONS requests to proxy of Pod
 //
 char*
-CoreV1API_connectOptionsNamespacedPodProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectOptionsNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect OPTIONS requests to proxy of Service
 //
 char*
-CoreV1API_connectOptionsNamespacedServiceProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectOptionsNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect OPTIONS requests to proxy of Service
 //
 char*
-CoreV1API_connectOptionsNamespacedServiceProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectOptionsNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect OPTIONS requests to proxy of Node
 //
 char*
-CoreV1API_connectOptionsNodeProxy(apiClient_t *apiClient ,char * name ,char * path);
+CoreV1API_connectOptionsNodeProxy(apiClient_t *apiClient, char * name , char * path );
 
 
 // connect OPTIONS requests to proxy of Node
 //
 char*
-CoreV1API_connectOptionsNodeProxyWithPath(apiClient_t *apiClient ,char * name ,char * path ,char * path2);
+CoreV1API_connectOptionsNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 );
 
 
 // connect PATCH requests to proxy of Pod
 //
 char*
-CoreV1API_connectPatchNamespacedPodProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectPatchNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect PATCH requests to proxy of Pod
 //
 char*
-CoreV1API_connectPatchNamespacedPodProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectPatchNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect PATCH requests to proxy of Service
 //
 char*
-CoreV1API_connectPatchNamespacedServiceProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectPatchNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect PATCH requests to proxy of Service
 //
 char*
-CoreV1API_connectPatchNamespacedServiceProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectPatchNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect PATCH requests to proxy of Node
 //
 char*
-CoreV1API_connectPatchNodeProxy(apiClient_t *apiClient ,char * name ,char * path);
+CoreV1API_connectPatchNodeProxy(apiClient_t *apiClient, char * name , char * path );
 
 
 // connect PATCH requests to proxy of Node
 //
 char*
-CoreV1API_connectPatchNodeProxyWithPath(apiClient_t *apiClient ,char * name ,char * path ,char * path2);
+CoreV1API_connectPatchNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 );
 
 
 // connect POST requests to attach of Pod
 //
 char*
-CoreV1API_connectPostNamespacedPodAttach(apiClient_t *apiClient ,char * name ,char * namespace ,char * container ,int stderr ,int stdin ,int stdout ,int tty);
+CoreV1API_connectPostNamespacedPodAttach(apiClient_t *apiClient, char * name , char * namespace , char * container , int stderr , int stdin , int stdout , int tty );
 
 
 // connect POST requests to exec of Pod
 //
 char*
-CoreV1API_connectPostNamespacedPodExec(apiClient_t *apiClient ,char * name ,char * namespace ,char * command ,char * container ,int stderr ,int stdin ,int stdout ,int tty);
+CoreV1API_connectPostNamespacedPodExec(apiClient_t *apiClient, char * name , char * namespace , char * command , char * container , int stderr , int stdin , int stdout , int tty );
 
 
 // connect POST requests to portforward of Pod
 //
 char*
-CoreV1API_connectPostNamespacedPodPortforward(apiClient_t *apiClient ,char * name ,char * namespace ,int ports);
+CoreV1API_connectPostNamespacedPodPortforward(apiClient_t *apiClient, char * name , char * namespace , int ports );
 
 
 // connect POST requests to proxy of Pod
 //
 char*
-CoreV1API_connectPostNamespacedPodProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectPostNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect POST requests to proxy of Pod
 //
 char*
-CoreV1API_connectPostNamespacedPodProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectPostNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect POST requests to proxy of Service
 //
 char*
-CoreV1API_connectPostNamespacedServiceProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectPostNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect POST requests to proxy of Service
 //
 char*
-CoreV1API_connectPostNamespacedServiceProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectPostNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect POST requests to proxy of Node
 //
 char*
-CoreV1API_connectPostNodeProxy(apiClient_t *apiClient ,char * name ,char * path);
+CoreV1API_connectPostNodeProxy(apiClient_t *apiClient, char * name , char * path );
 
 
 // connect POST requests to proxy of Node
 //
 char*
-CoreV1API_connectPostNodeProxyWithPath(apiClient_t *apiClient ,char * name ,char * path ,char * path2);
+CoreV1API_connectPostNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 );
 
 
 // connect PUT requests to proxy of Pod
 //
 char*
-CoreV1API_connectPutNamespacedPodProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectPutNamespacedPodProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect PUT requests to proxy of Pod
 //
 char*
-CoreV1API_connectPutNamespacedPodProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectPutNamespacedPodProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect PUT requests to proxy of Service
 //
 char*
-CoreV1API_connectPutNamespacedServiceProxy(apiClient_t *apiClient ,char * name ,char * namespace ,char * path);
+CoreV1API_connectPutNamespacedServiceProxy(apiClient_t *apiClient, char * name , char * namespace , char * path );
 
 
 // connect PUT requests to proxy of Service
 //
 char*
-CoreV1API_connectPutNamespacedServiceProxyWithPath(apiClient_t *apiClient ,char * name ,char * namespace ,char * path ,char * path2);
+CoreV1API_connectPutNamespacedServiceProxyWithPath(apiClient_t *apiClient, char * name , char * namespace , char * path , char * path2 );
 
 
 // connect PUT requests to proxy of Node
 //
 char*
-CoreV1API_connectPutNodeProxy(apiClient_t *apiClient ,char * name ,char * path);
+CoreV1API_connectPutNodeProxy(apiClient_t *apiClient, char * name , char * path );
 
 
 // connect PUT requests to proxy of Node
 //
 char*
-CoreV1API_connectPutNodeProxyWithPath(apiClient_t *apiClient ,char * name ,char * path ,char * path2);
+CoreV1API_connectPutNodeProxyWithPath(apiClient_t *apiClient, char * name , char * path , char * path2 );
 
 
 // create a Namespace
 //
 v1_namespace_t*
-CoreV1API_createNamespace(apiClient_t *apiClient ,v1_namespace_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespace(apiClient_t *apiClient, v1_namespace_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Binding
 //
 v1_binding_t*
-CoreV1API_createNamespacedBinding(apiClient_t *apiClient ,char * namespace ,v1_binding_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+CoreV1API_createNamespacedBinding(apiClient_t *apiClient, char * namespace , v1_binding_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create a ConfigMap
 //
 v1_config_map_t*
-CoreV1API_createNamespacedConfigMap(apiClient_t *apiClient ,char * namespace ,v1_config_map_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedConfigMap(apiClient_t *apiClient, char * namespace , v1_config_map_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create Endpoints
 //
 v1_endpoints_t*
-CoreV1API_createNamespacedEndpoints(apiClient_t *apiClient ,char * namespace ,v1_endpoints_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedEndpoints(apiClient_t *apiClient, char * namespace , v1_endpoints_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create an Event
 //
 v1_event_t*
-CoreV1API_createNamespacedEvent(apiClient_t *apiClient ,char * namespace ,v1_event_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedEvent(apiClient_t *apiClient, char * namespace , v1_event_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a LimitRange
 //
 v1_limit_range_t*
-CoreV1API_createNamespacedLimitRange(apiClient_t *apiClient ,char * namespace ,v1_limit_range_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedLimitRange(apiClient_t *apiClient, char * namespace , v1_limit_range_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_createNamespacedPersistentVolumeClaim(apiClient_t *apiClient ,char * namespace ,v1_persistent_volume_claim_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * namespace , v1_persistent_volume_claim_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Pod
 //
 v1_pod_t*
-CoreV1API_createNamespacedPod(apiClient_t *apiClient ,char * namespace ,v1_pod_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedPod(apiClient_t *apiClient, char * namespace , v1_pod_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create binding of a Pod
 //
 v1_binding_t*
-CoreV1API_createNamespacedPodBinding(apiClient_t *apiClient ,char * name ,char * namespace ,v1_binding_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+CoreV1API_createNamespacedPodBinding(apiClient_t *apiClient, char * name , char * namespace , v1_binding_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create eviction of a Pod
 //
 v1beta1_eviction_t*
-CoreV1API_createNamespacedPodEviction(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_eviction_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+CoreV1API_createNamespacedPodEviction(apiClient_t *apiClient, char * name , char * namespace , v1beta1_eviction_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create a PodTemplate
 //
 v1_pod_template_t*
-CoreV1API_createNamespacedPodTemplate(apiClient_t *apiClient ,char * namespace ,v1_pod_template_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedPodTemplate(apiClient_t *apiClient, char * namespace , v1_pod_template_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_createNamespacedReplicationController(apiClient_t *apiClient ,char * namespace ,v1_replication_controller_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedReplicationController(apiClient_t *apiClient, char * namespace , v1_replication_controller_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_createNamespacedResourceQuota(apiClient_t *apiClient ,char * namespace ,v1_resource_quota_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedResourceQuota(apiClient_t *apiClient, char * namespace , v1_resource_quota_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Secret
 //
 v1_secret_t*
-CoreV1API_createNamespacedSecret(apiClient_t *apiClient ,char * namespace ,v1_secret_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedSecret(apiClient_t *apiClient, char * namespace , v1_secret_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Service
 //
 v1_service_t*
-CoreV1API_createNamespacedService(apiClient_t *apiClient ,char * namespace ,v1_service_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedService(apiClient_t *apiClient, char * namespace , v1_service_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ServiceAccount
 //
 v1_service_account_t*
-CoreV1API_createNamespacedServiceAccount(apiClient_t *apiClient ,char * namespace ,v1_service_account_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNamespacedServiceAccount(apiClient_t *apiClient, char * namespace , v1_service_account_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create token of a ServiceAccount
 //
 v1_token_request_t*
-CoreV1API_createNamespacedServiceAccountToken(apiClient_t *apiClient ,char * name ,char * namespace ,v1_token_request_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+CoreV1API_createNamespacedServiceAccountToken(apiClient_t *apiClient, char * name , char * namespace , v1_token_request_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create a Node
 //
 v1_node_t*
-CoreV1API_createNode(apiClient_t *apiClient ,v1_node_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createNode(apiClient_t *apiClient, v1_node_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_createPersistentVolume(apiClient_t *apiClient ,v1_persistent_volume_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_createPersistentVolume(apiClient_t *apiClient, v1_persistent_volume_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of ConfigMap
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedConfigMap(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedConfigMap(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Endpoints
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedEndpoints(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedEndpoints(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Event
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedEvent(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedEvent(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of LimitRange
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedLimitRange(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedLimitRange(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of PersistentVolumeClaim
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedPersistentVolumeClaim(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Pod
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedPod(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedPod(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of PodTemplate
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedPodTemplate(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedPodTemplate(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ReplicationController
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedReplicationController(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedReplicationController(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ResourceQuota
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedResourceQuota(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedResourceQuota(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Secret
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedSecret(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedSecret(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ServiceAccount
 //
 v1_status_t*
-CoreV1API_deleteCollectionNamespacedServiceAccount(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNamespacedServiceAccount(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Node
 //
 v1_status_t*
-CoreV1API_deleteCollectionNode(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionNode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of PersistentVolume
 //
 v1_status_t*
-CoreV1API_deleteCollectionPersistentVolume(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+CoreV1API_deleteCollectionPersistentVolume(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a Namespace
 //
 v1_status_t*
-CoreV1API_deleteNamespace(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespace(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ConfigMap
 //
 v1_status_t*
-CoreV1API_deleteNamespacedConfigMap(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedConfigMap(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete Endpoints
 //
 v1_status_t*
-CoreV1API_deleteNamespacedEndpoints(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedEndpoints(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete an Event
 //
 v1_status_t*
-CoreV1API_deleteNamespacedEvent(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a LimitRange
 //
 v1_status_t*
-CoreV1API_deleteNamespacedLimitRange(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedLimitRange(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a PersistentVolumeClaim
 //
 v1_status_t*
-CoreV1API_deleteNamespacedPersistentVolumeClaim(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a Pod
 //
 v1_status_t*
-CoreV1API_deleteNamespacedPod(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedPod(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a PodTemplate
 //
 v1_status_t*
-CoreV1API_deleteNamespacedPodTemplate(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedPodTemplate(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ReplicationController
 //
 v1_status_t*
-CoreV1API_deleteNamespacedReplicationController(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedReplicationController(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ResourceQuota
 //
 v1_status_t*
-CoreV1API_deleteNamespacedResourceQuota(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedResourceQuota(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a Secret
 //
 v1_status_t*
-CoreV1API_deleteNamespacedSecret(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedSecret(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a Service
 //
 v1_status_t*
-CoreV1API_deleteNamespacedService(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedService(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ServiceAccount
 //
 v1_status_t*
-CoreV1API_deleteNamespacedServiceAccount(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNamespacedServiceAccount(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a Node
 //
 v1_status_t*
-CoreV1API_deleteNode(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deleteNode(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a PersistentVolume
 //
 v1_status_t*
-CoreV1API_deletePersistentVolume(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CoreV1API_deletePersistentVolume(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -624,618 +624,618 @@ CoreV1API_getAPIResources(apiClient_t *apiClient);
 // list objects of kind ComponentStatus
 //
 v1_component_status_list_t*
-CoreV1API_listComponentStatus(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listComponentStatus(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ConfigMap
 //
 v1_config_map_list_t*
-CoreV1API_listConfigMapForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listConfigMapForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Endpoints
 //
 v1_endpoints_list_t*
-CoreV1API_listEndpointsForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listEndpointsForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Event
 //
 v1_event_list_t*
-CoreV1API_listEventForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listEventForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind LimitRange
 //
 v1_limit_range_list_t*
-CoreV1API_listLimitRangeForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listLimitRangeForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Namespace
 //
 v1_namespace_list_t*
-CoreV1API_listNamespace(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespace(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ConfigMap
 //
 v1_config_map_list_t*
-CoreV1API_listNamespacedConfigMap(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedConfigMap(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Endpoints
 //
 v1_endpoints_list_t*
-CoreV1API_listNamespacedEndpoints(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedEndpoints(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Event
 //
 v1_event_list_t*
-CoreV1API_listNamespacedEvent(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedEvent(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind LimitRange
 //
 v1_limit_range_list_t*
-CoreV1API_listNamespacedLimitRange(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedLimitRange(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PersistentVolumeClaim
 //
 v1_persistent_volume_claim_list_t*
-CoreV1API_listNamespacedPersistentVolumeClaim(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Pod
 //
 v1_pod_list_t*
-CoreV1API_listNamespacedPod(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedPod(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PodTemplate
 //
 v1_pod_template_list_t*
-CoreV1API_listNamespacedPodTemplate(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedPodTemplate(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ReplicationController
 //
 v1_replication_controller_list_t*
-CoreV1API_listNamespacedReplicationController(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedReplicationController(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ResourceQuota
 //
 v1_resource_quota_list_t*
-CoreV1API_listNamespacedResourceQuota(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedResourceQuota(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Secret
 //
 v1_secret_list_t*
-CoreV1API_listNamespacedSecret(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedSecret(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Service
 //
 v1_service_list_t*
-CoreV1API_listNamespacedService(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedService(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ServiceAccount
 //
 v1_service_account_list_t*
-CoreV1API_listNamespacedServiceAccount(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNamespacedServiceAccount(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Node
 //
 v1_node_list_t*
-CoreV1API_listNode(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listNode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PersistentVolume
 //
 v1_persistent_volume_list_t*
-CoreV1API_listPersistentVolume(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listPersistentVolume(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PersistentVolumeClaim
 //
 v1_persistent_volume_claim_list_t*
-CoreV1API_listPersistentVolumeClaimForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listPersistentVolumeClaimForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Pod
 //
 v1_pod_list_t*
-CoreV1API_listPodForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listPodForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PodTemplate
 //
 v1_pod_template_list_t*
-CoreV1API_listPodTemplateForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listPodTemplateForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ReplicationController
 //
 v1_replication_controller_list_t*
-CoreV1API_listReplicationControllerForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listReplicationControllerForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ResourceQuota
 //
 v1_resource_quota_list_t*
-CoreV1API_listResourceQuotaForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listResourceQuotaForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Secret
 //
 v1_secret_list_t*
-CoreV1API_listSecretForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listSecretForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ServiceAccount
 //
 v1_service_account_list_t*
-CoreV1API_listServiceAccountForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listServiceAccountForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Service
 //
 v1_service_list_t*
-CoreV1API_listServiceForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CoreV1API_listServiceForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_patchNamespace(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespace(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_patchNamespaceStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespaceStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ConfigMap
 //
 v1_config_map_t*
-CoreV1API_patchNamespacedConfigMap(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedConfigMap(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Endpoints
 //
 v1_endpoints_t*
-CoreV1API_patchNamespacedEndpoints(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedEndpoints(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Event
 //
 v1_event_t*
-CoreV1API_patchNamespacedEvent(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified LimitRange
 //
 v1_limit_range_t*
-CoreV1API_patchNamespacedLimitRange(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedLimitRange(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_patchNamespacedPersistentVolumeClaim(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_patchNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Pod
 //
 v1_pod_t*
-CoreV1API_patchNamespacedPod(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedPod(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Pod
 //
 v1_pod_t*
-CoreV1API_patchNamespacedPodStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedPodStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified PodTemplate
 //
 v1_pod_template_t*
-CoreV1API_patchNamespacedPodTemplate(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedPodTemplate(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_patchNamespacedReplicationController(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedReplicationController(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified ReplicationController
 //
 v1_scale_t*
-CoreV1API_patchNamespacedReplicationControllerScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedReplicationControllerScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_patchNamespacedReplicationControllerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedReplicationControllerStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_patchNamespacedResourceQuota(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedResourceQuota(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_patchNamespacedResourceQuotaStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedResourceQuotaStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Secret
 //
 v1_secret_t*
-CoreV1API_patchNamespacedSecret(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedSecret(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Service
 //
 v1_service_t*
-CoreV1API_patchNamespacedService(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedService(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ServiceAccount
 //
 v1_service_account_t*
-CoreV1API_patchNamespacedServiceAccount(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedServiceAccount(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Service
 //
 v1_service_t*
-CoreV1API_patchNamespacedServiceStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNamespacedServiceStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Node
 //
 v1_node_t*
-CoreV1API_patchNode(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNode(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Node
 //
 v1_node_t*
-CoreV1API_patchNodeStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchNodeStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_patchPersistentVolume(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchPersistentVolume(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_patchPersistentVolumeStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+CoreV1API_patchPersistentVolumeStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified ComponentStatus
 //
 v1_component_status_t*
-CoreV1API_readComponentStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+CoreV1API_readComponentStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // read the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_readNamespace(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespace(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_readNamespaceStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+CoreV1API_readNamespaceStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // read the specified ConfigMap
 //
 v1_config_map_t*
-CoreV1API_readNamespacedConfigMap(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedConfigMap(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified Endpoints
 //
 v1_endpoints_t*
-CoreV1API_readNamespacedEndpoints(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedEndpoints(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified Event
 //
 v1_event_t*
-CoreV1API_readNamespacedEvent(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified LimitRange
 //
 v1_limit_range_t*
-CoreV1API_readNamespacedLimitRange(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedLimitRange(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_readNamespacedPersistentVolumeClaim(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_readNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+CoreV1API_readNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified Pod
 //
 v1_pod_t*
-CoreV1API_readNamespacedPod(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedPod(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read log of the specified Pod
 //
 char*
-CoreV1API_readNamespacedPodLog(apiClient_t *apiClient ,char * name ,char * namespace ,char * container ,int follow ,int insecureSkipTLSVerifyBackend ,int limitBytes ,char * pretty ,int previous ,int sinceSeconds ,int tailLines ,int timestamps);
+CoreV1API_readNamespacedPodLog(apiClient_t *apiClient, char * name , char * namespace , char * container , int follow , int insecureSkipTLSVerifyBackend , int limitBytes , char * pretty , int previous , int sinceSeconds , int tailLines , int timestamps );
 
 
 // read status of the specified Pod
 //
 v1_pod_t*
-CoreV1API_readNamespacedPodStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+CoreV1API_readNamespacedPodStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified PodTemplate
 //
 v1_pod_template_t*
-CoreV1API_readNamespacedPodTemplate(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedPodTemplate(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_readNamespacedReplicationController(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedReplicationController(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified ReplicationController
 //
 v1_scale_t*
-CoreV1API_readNamespacedReplicationControllerScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+CoreV1API_readNamespacedReplicationControllerScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_readNamespacedReplicationControllerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+CoreV1API_readNamespacedReplicationControllerStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_readNamespacedResourceQuota(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedResourceQuota(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_readNamespacedResourceQuotaStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+CoreV1API_readNamespacedResourceQuotaStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified Secret
 //
 v1_secret_t*
-CoreV1API_readNamespacedSecret(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedSecret(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified Service
 //
 v1_service_t*
-CoreV1API_readNamespacedService(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedService(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified ServiceAccount
 //
 v1_service_account_t*
-CoreV1API_readNamespacedServiceAccount(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+CoreV1API_readNamespacedServiceAccount(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified Service
 //
 v1_service_t*
-CoreV1API_readNamespacedServiceStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+CoreV1API_readNamespacedServiceStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified Node
 //
 v1_node_t*
-CoreV1API_readNode(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+CoreV1API_readNode(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified Node
 //
 v1_node_t*
-CoreV1API_readNodeStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+CoreV1API_readNodeStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // read the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_readPersistentVolume(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+CoreV1API_readPersistentVolume(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_readPersistentVolumeStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+CoreV1API_readPersistentVolumeStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // replace the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_replaceNamespace(apiClient_t *apiClient ,char * name ,v1_namespace_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespace(apiClient_t *apiClient, char * name , v1_namespace_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace finalize of the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_replaceNamespaceFinalize(apiClient_t *apiClient ,char * name ,v1_namespace_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+CoreV1API_replaceNamespaceFinalize(apiClient_t *apiClient, char * name , v1_namespace_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // replace status of the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_replaceNamespaceStatus(apiClient_t *apiClient ,char * name ,v1_namespace_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespaceStatus(apiClient_t *apiClient, char * name , v1_namespace_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ConfigMap
 //
 v1_config_map_t*
-CoreV1API_replaceNamespacedConfigMap(apiClient_t *apiClient ,char * name ,char * namespace ,v1_config_map_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedConfigMap(apiClient_t *apiClient, char * name , char * namespace , v1_config_map_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Endpoints
 //
 v1_endpoints_t*
-CoreV1API_replaceNamespacedEndpoints(apiClient_t *apiClient ,char * name ,char * namespace ,v1_endpoints_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedEndpoints(apiClient_t *apiClient, char * name , char * namespace , v1_endpoints_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Event
 //
 v1_event_t*
-CoreV1API_replaceNamespacedEvent(apiClient_t *apiClient ,char * name ,char * namespace ,v1_event_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , v1_event_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified LimitRange
 //
 v1_limit_range_t*
-CoreV1API_replaceNamespacedLimitRange(apiClient_t *apiClient ,char * name ,char * namespace ,v1_limit_range_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedLimitRange(apiClient_t *apiClient, char * name , char * namespace , v1_limit_range_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_replaceNamespacedPersistentVolumeClaim(apiClient_t *apiClient ,char * name ,char * namespace ,v1_persistent_volume_claim_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name , char * namespace , v1_persistent_volume_claim_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_replaceNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_persistent_volume_claim_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient, char * name , char * namespace , v1_persistent_volume_claim_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Pod
 //
 v1_pod_t*
-CoreV1API_replaceNamespacedPod(apiClient_t *apiClient ,char * name ,char * namespace ,v1_pod_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedPod(apiClient_t *apiClient, char * name , char * namespace , v1_pod_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified Pod
 //
 v1_pod_t*
-CoreV1API_replaceNamespacedPodStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_pod_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedPodStatus(apiClient_t *apiClient, char * name , char * namespace , v1_pod_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified PodTemplate
 //
 v1_pod_template_t*
-CoreV1API_replaceNamespacedPodTemplate(apiClient_t *apiClient ,char * name ,char * namespace ,v1_pod_template_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedPodTemplate(apiClient_t *apiClient, char * name , char * namespace , v1_pod_template_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_replaceNamespacedReplicationController(apiClient_t *apiClient ,char * name ,char * namespace ,v1_replication_controller_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedReplicationController(apiClient_t *apiClient, char * name , char * namespace , v1_replication_controller_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified ReplicationController
 //
 v1_scale_t*
-CoreV1API_replaceNamespacedReplicationControllerScale(apiClient_t *apiClient ,char * name ,char * namespace ,v1_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedReplicationControllerScale(apiClient_t *apiClient, char * name , char * namespace , v1_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified ReplicationController
 //
 v1_replication_controller_t*
-CoreV1API_replaceNamespacedReplicationControllerStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_replication_controller_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedReplicationControllerStatus(apiClient_t *apiClient, char * name , char * namespace , v1_replication_controller_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_replaceNamespacedResourceQuota(apiClient_t *apiClient ,char * name ,char * namespace ,v1_resource_quota_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedResourceQuota(apiClient_t *apiClient, char * name , char * namespace , v1_resource_quota_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified ResourceQuota
 //
 v1_resource_quota_t*
-CoreV1API_replaceNamespacedResourceQuotaStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_resource_quota_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedResourceQuotaStatus(apiClient_t *apiClient, char * name , char * namespace , v1_resource_quota_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Secret
 //
 v1_secret_t*
-CoreV1API_replaceNamespacedSecret(apiClient_t *apiClient ,char * name ,char * namespace ,v1_secret_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedSecret(apiClient_t *apiClient, char * name , char * namespace , v1_secret_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Service
 //
 v1_service_t*
-CoreV1API_replaceNamespacedService(apiClient_t *apiClient ,char * name ,char * namespace ,v1_service_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedService(apiClient_t *apiClient, char * name , char * namespace , v1_service_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ServiceAccount
 //
 v1_service_account_t*
-CoreV1API_replaceNamespacedServiceAccount(apiClient_t *apiClient ,char * name ,char * namespace ,v1_service_account_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedServiceAccount(apiClient_t *apiClient, char * name , char * namespace , v1_service_account_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified Service
 //
 v1_service_t*
-CoreV1API_replaceNamespacedServiceStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1_service_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNamespacedServiceStatus(apiClient_t *apiClient, char * name , char * namespace , v1_service_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Node
 //
 v1_node_t*
-CoreV1API_replaceNode(apiClient_t *apiClient ,char * name ,v1_node_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNode(apiClient_t *apiClient, char * name , v1_node_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified Node
 //
 v1_node_t*
-CoreV1API_replaceNodeStatus(apiClient_t *apiClient ,char * name ,v1_node_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replaceNodeStatus(apiClient_t *apiClient, char * name , v1_node_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_replacePersistentVolume(apiClient_t *apiClient ,char * name ,v1_persistent_volume_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replacePersistentVolume(apiClient_t *apiClient, char * name , v1_persistent_volume_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified PersistentVolume
 //
 v1_persistent_volume_t*
-CoreV1API_replacePersistentVolumeStatus(apiClient_t *apiClient ,char * name ,v1_persistent_volume_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+CoreV1API_replacePersistentVolumeStatus(apiClient_t *apiClient, char * name , v1_persistent_volume_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/CustomObjectsAPI.c
+++ b/kubernetes/api/CustomObjectsAPI.c
@@ -15,7 +15,7 @@
 // Creates a cluster scoped Custom object
 //
 object_t*
-CustomObjectsAPI_createClusterCustomObject(apiClient_t *apiClient, char * group, char * version, char * plural, object_t * body, char * pretty)
+CustomObjectsAPI_createClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , object_t * body , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -143,7 +143,7 @@ end:
 // Creates a namespace scoped Custom object
 //
 object_t*
-CustomObjectsAPI_createNamespacedCustomObject(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, object_t * body, char * pretty)
+CustomObjectsAPI_createNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , object_t * body , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -282,7 +282,7 @@ end:
 // Deletes the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_deleteClusterCustomObject(apiClient_t *apiClient, char * group, char * version, char * plural, char * name, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CustomObjectsAPI_deleteClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -461,7 +461,7 @@ end:
 // Deletes the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_deleteNamespacedCustomObject(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * name, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+CustomObjectsAPI_deleteNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -651,7 +651,7 @@ end:
 // Returns a cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_getClusterCustomObject(apiClient_t *apiClient, char * group, char * version, char * plural, char * name)
+CustomObjectsAPI_getClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , char * name )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -755,7 +755,7 @@ end:
 // read scale of the specified custom object
 //
 object_t*
-CustomObjectsAPI_getClusterCustomObjectScale(apiClient_t *apiClient, char * group, char * version, char * plural, char * name)
+CustomObjectsAPI_getClusterCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * plural , char * name )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -861,7 +861,7 @@ end:
 // read status of the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_getClusterCustomObjectStatus(apiClient_t *apiClient, char * group, char * version, char * plural, char * name)
+CustomObjectsAPI_getClusterCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * plural , char * name )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -967,7 +967,7 @@ end:
 // Returns a namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_getNamespacedCustomObject(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * name)
+CustomObjectsAPI_getNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -1082,7 +1082,7 @@ end:
 // read scale of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_getNamespacedCustomObjectScale(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * name)
+CustomObjectsAPI_getNamespacedCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -1199,7 +1199,7 @@ end:
 // read status of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_getNamespacedCustomObjectStatus(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * name)
+CustomObjectsAPI_getNamespacedCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -1316,7 +1316,7 @@ end:
 // list or watch cluster scoped custom objects
 //
 object_t*
-CustomObjectsAPI_listClusterCustomObject(apiClient_t *apiClient, char * group, char * version, char * plural, char * pretty, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CustomObjectsAPI_listClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , char * pretty , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1590,7 +1590,7 @@ end:
 // list or watch namespace scoped custom objects
 //
 object_t*
-CustomObjectsAPI_listNamespacedCustomObject(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * pretty, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+CustomObjectsAPI_listNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * pretty , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1875,7 +1875,7 @@ end:
 // patch the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchClusterCustomObject(apiClient_t *apiClient, char * group, char * version, char * plural, char * name, object_t * body)
+CustomObjectsAPI_patchClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -1992,7 +1992,7 @@ end:
 // partially update scale of the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchClusterCustomObjectScale(apiClient_t *apiClient, char * group, char * version, char * plural, char * name, object_t * body)
+CustomObjectsAPI_patchClusterCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -2111,7 +2111,7 @@ end:
 // partially update status of the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchClusterCustomObjectStatus(apiClient_t *apiClient, char * group, char * version, char * plural, char * name, object_t * body)
+CustomObjectsAPI_patchClusterCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -2230,7 +2230,7 @@ end:
 // patch the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchNamespacedCustomObject(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * name, object_t * body)
+CustomObjectsAPI_patchNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -2358,7 +2358,7 @@ end:
 // partially update scale of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchNamespacedCustomObjectScale(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * name, object_t * body)
+CustomObjectsAPI_patchNamespacedCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -2488,7 +2488,7 @@ end:
 // partially update status of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchNamespacedCustomObjectStatus(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * name, object_t * body)
+CustomObjectsAPI_patchNamespacedCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -2618,7 +2618,7 @@ end:
 // replace the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_replaceClusterCustomObject(apiClient_t *apiClient, char * group, char * version, char * plural, char * name, object_t * body)
+CustomObjectsAPI_replaceClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -2733,7 +2733,7 @@ end:
 // replace scale of the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_replaceClusterCustomObjectScale(apiClient_t *apiClient, char * group, char * version, char * plural, char * name, object_t * body)
+CustomObjectsAPI_replaceClusterCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -2853,7 +2853,7 @@ end:
 // replace status of the cluster scoped specified custom object
 //
 object_t*
-CustomObjectsAPI_replaceClusterCustomObjectStatus(apiClient_t *apiClient, char * group, char * version, char * plural, char * name, object_t * body)
+CustomObjectsAPI_replaceClusterCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -2973,7 +2973,7 @@ end:
 // replace the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_replaceNamespacedCustomObject(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * name, object_t * body)
+CustomObjectsAPI_replaceNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -3099,7 +3099,7 @@ end:
 // replace scale of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_replaceNamespacedCustomObjectScale(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * name, object_t * body)
+CustomObjectsAPI_replaceNamespacedCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;
@@ -3230,7 +3230,7 @@ end:
 // replace status of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_replaceNamespacedCustomObjectStatus(apiClient_t *apiClient, char * group, char * version, char * namespace, char * plural, char * name, object_t * body)
+CustomObjectsAPI_replaceNamespacedCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/CustomObjectsAPI.h
+++ b/kubernetes/api/CustomObjectsAPI.h
@@ -11,144 +11,144 @@
 // Creates a cluster scoped Custom object
 //
 object_t*
-CustomObjectsAPI_createClusterCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,object_t * body ,char * pretty);
+CustomObjectsAPI_createClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , object_t * body , char * pretty );
 
 
 // Creates a namespace scoped Custom object
 //
 object_t*
-CustomObjectsAPI_createNamespacedCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,object_t * body ,char * pretty);
+CustomObjectsAPI_createNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , object_t * body , char * pretty );
 
 
 // Deletes the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_deleteClusterCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * name ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CustomObjectsAPI_deleteClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // Deletes the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_deleteNamespacedCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * name ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+CustomObjectsAPI_deleteNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // Returns a cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_getClusterCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * name);
+CustomObjectsAPI_getClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , char * name );
 
 
 // read scale of the specified custom object
 //
 object_t*
-CustomObjectsAPI_getClusterCustomObjectScale(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * name);
+CustomObjectsAPI_getClusterCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * plural , char * name );
 
 
 // read status of the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_getClusterCustomObjectStatus(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * name);
+CustomObjectsAPI_getClusterCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * plural , char * name );
 
 
 // Returns a namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_getNamespacedCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * name);
+CustomObjectsAPI_getNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name );
 
 
 // read scale of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_getNamespacedCustomObjectScale(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * name);
+CustomObjectsAPI_getNamespacedCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name );
 
 
 // read status of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_getNamespacedCustomObjectStatus(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * name);
+CustomObjectsAPI_getNamespacedCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name );
 
 
 // list or watch cluster scoped custom objects
 //
 object_t*
-CustomObjectsAPI_listClusterCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * pretty ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CustomObjectsAPI_listClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , char * pretty , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch namespace scoped custom objects
 //
 object_t*
-CustomObjectsAPI_listNamespacedCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * pretty ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+CustomObjectsAPI_listNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * pretty , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // patch the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchClusterCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_patchClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body );
 
 
 // partially update scale of the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchClusterCustomObjectScale(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_patchClusterCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body );
 
 
 // partially update status of the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchClusterCustomObjectStatus(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_patchClusterCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body );
 
 
 // patch the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchNamespacedCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_patchNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body );
 
 
 // partially update scale of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchNamespacedCustomObjectScale(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_patchNamespacedCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body );
 
 
 // partially update status of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_patchNamespacedCustomObjectStatus(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_patchNamespacedCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body );
 
 
 // replace the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_replaceClusterCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_replaceClusterCustomObject(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body );
 
 
 // replace scale of the specified cluster scoped custom object
 //
 object_t*
-CustomObjectsAPI_replaceClusterCustomObjectScale(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_replaceClusterCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body );
 
 
 // replace status of the cluster scoped specified custom object
 //
 object_t*
-CustomObjectsAPI_replaceClusterCustomObjectStatus(apiClient_t *apiClient ,char * group ,char * version ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_replaceClusterCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * plural , char * name , object_t * body );
 
 
 // replace the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_replaceNamespacedCustomObject(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_replaceNamespacedCustomObject(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body );
 
 
 // replace scale of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_replaceNamespacedCustomObjectScale(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_replaceNamespacedCustomObjectScale(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body );
 
 
 // replace status of the specified namespace scoped custom object
 //
 object_t*
-CustomObjectsAPI_replaceNamespacedCustomObjectStatus(apiClient_t *apiClient ,char * group ,char * version ,char * namespace ,char * plural ,char * name ,object_t * body);
+CustomObjectsAPI_replaceNamespacedCustomObjectStatus(apiClient_t *apiClient, char * group , char * version , char * namespace , char * plural , char * name , object_t * body );
 
 

--- a/kubernetes/api/DiscoveryV1beta1API.c
+++ b/kubernetes/api/DiscoveryV1beta1API.c
@@ -15,7 +15,7 @@
 // create an EndpointSlice
 //
 v1beta1_endpoint_slice_t*
-DiscoveryV1beta1API_createNamespacedEndpointSlice(apiClient_t *apiClient, char * namespace, v1beta1_endpoint_slice_t * body, char * pretty, char * dryRun, char * fieldManager)
+DiscoveryV1beta1API_createNamespacedEndpointSlice(apiClient_t *apiClient, char * namespace , v1beta1_endpoint_slice_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of EndpointSlice
 //
 v1_status_t*
-DiscoveryV1beta1API_deleteCollectionNamespacedEndpointSlice(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+DiscoveryV1beta1API_deleteCollectionNamespacedEndpointSlice(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete an EndpointSlice
 //
 v1_status_t*
-DiscoveryV1beta1API_deleteNamespacedEndpointSlice(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+DiscoveryV1beta1API_deleteNamespacedEndpointSlice(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind EndpointSlice
 //
 v1beta1_endpoint_slice_list_t*
-DiscoveryV1beta1API_listEndpointSliceForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+DiscoveryV1beta1API_listEndpointSliceForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind EndpointSlice
 //
 v1beta1_endpoint_slice_list_t*
-DiscoveryV1beta1API_listNamespacedEndpointSlice(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+DiscoveryV1beta1API_listNamespacedEndpointSlice(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified EndpointSlice
 //
 v1beta1_endpoint_slice_t*
-DiscoveryV1beta1API_patchNamespacedEndpointSlice(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+DiscoveryV1beta1API_patchNamespacedEndpointSlice(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // read the specified EndpointSlice
 //
 v1beta1_endpoint_slice_t*
-DiscoveryV1beta1API_readNamespacedEndpointSlice(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+DiscoveryV1beta1API_readNamespacedEndpointSlice(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1699,7 +1699,7 @@ end:
 // replace the specified EndpointSlice
 //
 v1beta1_endpoint_slice_t*
-DiscoveryV1beta1API_replaceNamespacedEndpointSlice(apiClient_t *apiClient, char * name, char * namespace, v1beta1_endpoint_slice_t * body, char * pretty, char * dryRun, char * fieldManager)
+DiscoveryV1beta1API_replaceNamespacedEndpointSlice(apiClient_t *apiClient, char * name , char * namespace , v1beta1_endpoint_slice_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/DiscoveryV1beta1API.h
+++ b/kubernetes/api/DiscoveryV1beta1API.h
@@ -14,19 +14,19 @@
 // create an EndpointSlice
 //
 v1beta1_endpoint_slice_t*
-DiscoveryV1beta1API_createNamespacedEndpointSlice(apiClient_t *apiClient ,char * namespace ,v1beta1_endpoint_slice_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+DiscoveryV1beta1API_createNamespacedEndpointSlice(apiClient_t *apiClient, char * namespace , v1beta1_endpoint_slice_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of EndpointSlice
 //
 v1_status_t*
-DiscoveryV1beta1API_deleteCollectionNamespacedEndpointSlice(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+DiscoveryV1beta1API_deleteCollectionNamespacedEndpointSlice(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete an EndpointSlice
 //
 v1_status_t*
-DiscoveryV1beta1API_deleteNamespacedEndpointSlice(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+DiscoveryV1beta1API_deleteNamespacedEndpointSlice(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,30 +38,30 @@ DiscoveryV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind EndpointSlice
 //
 v1beta1_endpoint_slice_list_t*
-DiscoveryV1beta1API_listEndpointSliceForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+DiscoveryV1beta1API_listEndpointSliceForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind EndpointSlice
 //
 v1beta1_endpoint_slice_list_t*
-DiscoveryV1beta1API_listNamespacedEndpointSlice(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+DiscoveryV1beta1API_listNamespacedEndpointSlice(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified EndpointSlice
 //
 v1beta1_endpoint_slice_t*
-DiscoveryV1beta1API_patchNamespacedEndpointSlice(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+DiscoveryV1beta1API_patchNamespacedEndpointSlice(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified EndpointSlice
 //
 v1beta1_endpoint_slice_t*
-DiscoveryV1beta1API_readNamespacedEndpointSlice(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+DiscoveryV1beta1API_readNamespacedEndpointSlice(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // replace the specified EndpointSlice
 //
 v1beta1_endpoint_slice_t*
-DiscoveryV1beta1API_replaceNamespacedEndpointSlice(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_endpoint_slice_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+DiscoveryV1beta1API_replaceNamespacedEndpointSlice(apiClient_t *apiClient, char * name , char * namespace , v1beta1_endpoint_slice_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/EventsV1beta1API.c
+++ b/kubernetes/api/EventsV1beta1API.c
@@ -15,7 +15,7 @@
 // create an Event
 //
 v1beta1_event_t*
-EventsV1beta1API_createNamespacedEvent(apiClient_t *apiClient, char * namespace, v1beta1_event_t * body, char * pretty, char * dryRun, char * fieldManager)
+EventsV1beta1API_createNamespacedEvent(apiClient_t *apiClient, char * namespace , v1beta1_event_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of Event
 //
 v1_status_t*
-EventsV1beta1API_deleteCollectionNamespacedEvent(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+EventsV1beta1API_deleteCollectionNamespacedEvent(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete an Event
 //
 v1_status_t*
-EventsV1beta1API_deleteNamespacedEvent(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+EventsV1beta1API_deleteNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind Event
 //
 v1beta1_event_list_t*
-EventsV1beta1API_listEventForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+EventsV1beta1API_listEventForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind Event
 //
 v1beta1_event_list_t*
-EventsV1beta1API_listNamespacedEvent(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+EventsV1beta1API_listNamespacedEvent(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified Event
 //
 v1beta1_event_t*
-EventsV1beta1API_patchNamespacedEvent(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+EventsV1beta1API_patchNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // read the specified Event
 //
 v1beta1_event_t*
-EventsV1beta1API_readNamespacedEvent(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+EventsV1beta1API_readNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1699,7 +1699,7 @@ end:
 // replace the specified Event
 //
 v1beta1_event_t*
-EventsV1beta1API_replaceNamespacedEvent(apiClient_t *apiClient, char * name, char * namespace, v1beta1_event_t * body, char * pretty, char * dryRun, char * fieldManager)
+EventsV1beta1API_replaceNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , v1beta1_event_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/EventsV1beta1API.h
+++ b/kubernetes/api/EventsV1beta1API.h
@@ -14,19 +14,19 @@
 // create an Event
 //
 v1beta1_event_t*
-EventsV1beta1API_createNamespacedEvent(apiClient_t *apiClient ,char * namespace ,v1beta1_event_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+EventsV1beta1API_createNamespacedEvent(apiClient_t *apiClient, char * namespace , v1beta1_event_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of Event
 //
 v1_status_t*
-EventsV1beta1API_deleteCollectionNamespacedEvent(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+EventsV1beta1API_deleteCollectionNamespacedEvent(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete an Event
 //
 v1_status_t*
-EventsV1beta1API_deleteNamespacedEvent(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+EventsV1beta1API_deleteNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,30 +38,30 @@ EventsV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind Event
 //
 v1beta1_event_list_t*
-EventsV1beta1API_listEventForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+EventsV1beta1API_listEventForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Event
 //
 v1beta1_event_list_t*
-EventsV1beta1API_listNamespacedEvent(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+EventsV1beta1API_listNamespacedEvent(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified Event
 //
 v1beta1_event_t*
-EventsV1beta1API_patchNamespacedEvent(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+EventsV1beta1API_patchNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified Event
 //
 v1beta1_event_t*
-EventsV1beta1API_readNamespacedEvent(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+EventsV1beta1API_readNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // replace the specified Event
 //
 v1beta1_event_t*
-EventsV1beta1API_replaceNamespacedEvent(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_event_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+EventsV1beta1API_replaceNamespacedEvent(apiClient_t *apiClient, char * name , char * namespace , v1beta1_event_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/ExtensionsV1beta1API.c
+++ b/kubernetes/api/ExtensionsV1beta1API.c
@@ -15,7 +15,7 @@
 // create a DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_createNamespacedDaemonSet(apiClient_t *apiClient, char * namespace, v1beta1_daemon_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_createNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , v1beta1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // create a Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace, extensions_v1beta1_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace , extensions_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -339,7 +339,7 @@ end:
 // create rollback of a Deployment
 //
 v1_status_t*
-ExtensionsV1beta1API_createNamespacedDeploymentRollback(apiClient_t *apiClient, char * name, char * namespace, extensions_v1beta1_deployment_rollback_t * body, char * dryRun, char * fieldManager, char * pretty)
+ExtensionsV1beta1API_createNamespacedDeploymentRollback(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_deployment_rollback_t * body , char * dryRun , char * fieldManager , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -512,7 +512,7 @@ end:
 // create an Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_createNamespacedIngress(apiClient_t *apiClient, char * namespace, extensions_v1beta1_ingress_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_createNamespacedIngress(apiClient_t *apiClient, char * namespace , extensions_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -674,7 +674,7 @@ end:
 // create a NetworkPolicy
 //
 v1beta1_network_policy_t*
-ExtensionsV1beta1API_createNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace, v1beta1_network_policy_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_createNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , v1beta1_network_policy_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -836,7 +836,7 @@ end:
 // create a ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_createNamespacedReplicaSet(apiClient_t *apiClient, char * namespace, v1beta1_replica_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_createNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , v1beta1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -998,7 +998,7 @@ end:
 // create a PodSecurityPolicy
 //
 extensions_v1beta1_pod_security_policy_t*
-ExtensionsV1beta1API_createPodSecurityPolicy(apiClient_t *apiClient, extensions_v1beta1_pod_security_policy_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_createPodSecurityPolicy(apiClient_t *apiClient, extensions_v1beta1_pod_security_policy_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1149,7 +1149,7 @@ end:
 // delete collection of DaemonSet
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1521,7 +1521,7 @@ end:
 // delete collection of Deployment
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1893,7 +1893,7 @@ end:
 // delete collection of Ingress
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionNamespacedIngress(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteCollectionNamespacedIngress(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2265,7 +2265,7 @@ end:
 // delete collection of NetworkPolicy
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteCollectionNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2637,7 +2637,7 @@ end:
 // delete collection of ReplicaSet
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3009,7 +3009,7 @@ end:
 // delete collection of PodSecurityPolicy
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionPodSecurityPolicy(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteCollectionPodSecurityPolicy(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3370,7 +3370,7 @@ end:
 // delete a DaemonSet
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3580,7 +3580,7 @@ end:
 // delete a Deployment
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3790,7 +3790,7 @@ end:
 // delete an Ingress
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteNamespacedIngress(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4000,7 +4000,7 @@ end:
 // delete a NetworkPolicy
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteNamespacedNetworkPolicy(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4210,7 +4210,7 @@ end:
 // delete a ReplicaSet
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+ExtensionsV1beta1API_deleteNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4420,7 +4420,7 @@ end:
 // delete a PodSecurityPolicy
 //
 v1_status_t*
-ExtensionsV1beta1API_deletePodSecurityPolicy(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+ExtensionsV1beta1API_deletePodSecurityPolicy(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4681,7 +4681,7 @@ end:
 // list or watch objects of kind DaemonSet
 //
 v1beta1_daemon_set_list_t*
-ExtensionsV1beta1API_listDaemonSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listDaemonSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4945,7 +4945,7 @@ end:
 // list or watch objects of kind Deployment
 //
 extensions_v1beta1_deployment_list_t*
-ExtensionsV1beta1API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5209,7 +5209,7 @@ end:
 // list or watch objects of kind Ingress
 //
 extensions_v1beta1_ingress_list_t*
-ExtensionsV1beta1API_listIngressForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listIngressForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5473,7 +5473,7 @@ end:
 // list or watch objects of kind DaemonSet
 //
 v1beta1_daemon_set_list_t*
-ExtensionsV1beta1API_listNamespacedDaemonSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5748,7 +5748,7 @@ end:
 // list or watch objects of kind Deployment
 //
 extensions_v1beta1_deployment_list_t*
-ExtensionsV1beta1API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6023,7 +6023,7 @@ end:
 // list or watch objects of kind Ingress
 //
 extensions_v1beta1_ingress_list_t*
-ExtensionsV1beta1API_listNamespacedIngress(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listNamespacedIngress(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6298,7 +6298,7 @@ end:
 // list or watch objects of kind NetworkPolicy
 //
 v1beta1_network_policy_list_t*
-ExtensionsV1beta1API_listNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6573,7 +6573,7 @@ end:
 // list or watch objects of kind ReplicaSet
 //
 v1beta1_replica_set_list_t*
-ExtensionsV1beta1API_listNamespacedReplicaSet(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6848,7 +6848,7 @@ end:
 // list or watch objects of kind NetworkPolicy
 //
 v1beta1_network_policy_list_t*
-ExtensionsV1beta1API_listNetworkPolicyForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listNetworkPolicyForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7112,7 +7112,7 @@ end:
 // list or watch objects of kind PodSecurityPolicy
 //
 extensions_v1beta1_pod_security_policy_list_t*
-ExtensionsV1beta1API_listPodSecurityPolicy(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listPodSecurityPolicy(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7376,7 +7376,7 @@ end:
 // list or watch objects of kind ReplicaSet
 //
 v1beta1_replica_set_list_t*
-ExtensionsV1beta1API_listReplicaSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+ExtensionsV1beta1API_listReplicaSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7640,7 +7640,7 @@ end:
 // partially update the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_patchNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -7831,7 +7831,7 @@ end:
 // partially update status of the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8022,7 +8022,7 @@ end:
 // partially update the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_patchNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8213,7 +8213,7 @@ end:
 // partially update scale of the specified Deployment
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8404,7 +8404,7 @@ end:
 // partially update status of the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8595,7 +8595,7 @@ end:
 // partially update the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_patchNamespacedIngress(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8786,7 +8786,7 @@ end:
 // partially update status of the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_patchNamespacedIngressStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -8977,7 +8977,7 @@ end:
 // partially update the specified NetworkPolicy
 //
 v1beta1_network_policy_t*
-ExtensionsV1beta1API_patchNamespacedNetworkPolicy(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9168,7 +9168,7 @@ end:
 // partially update the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_patchNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9359,7 +9359,7 @@ end:
 // partially update scale of the specified ReplicaSet
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_patchNamespacedReplicaSetScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9550,7 +9550,7 @@ end:
 // partially update status of the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9741,7 +9741,7 @@ end:
 // partially update scale of the specified ReplicationControllerDummy
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_patchNamespacedReplicationControllerDummyScale(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchNamespacedReplicationControllerDummyScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -9932,7 +9932,7 @@ end:
 // partially update the specified PodSecurityPolicy
 //
 extensions_v1beta1_pod_security_policy_t*
-ExtensionsV1beta1API_patchPodSecurityPolicy(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+ExtensionsV1beta1API_patchPodSecurityPolicy(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10112,7 +10112,7 @@ end:
 // read the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_readNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+ExtensionsV1beta1API_readNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10260,7 +10260,7 @@ end:
 // read status of the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_readNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+ExtensionsV1beta1API_readNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10368,7 +10368,7 @@ end:
 // read the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_readNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+ExtensionsV1beta1API_readNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10516,7 +10516,7 @@ end:
 // read scale of the specified Deployment
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+ExtensionsV1beta1API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10624,7 +10624,7 @@ end:
 // read status of the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+ExtensionsV1beta1API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10732,7 +10732,7 @@ end:
 // read the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_readNamespacedIngress(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+ExtensionsV1beta1API_readNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10880,7 +10880,7 @@ end:
 // read status of the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_readNamespacedIngressStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+ExtensionsV1beta1API_readNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10988,7 +10988,7 @@ end:
 // read the specified NetworkPolicy
 //
 v1beta1_network_policy_t*
-ExtensionsV1beta1API_readNamespacedNetworkPolicy(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+ExtensionsV1beta1API_readNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11136,7 +11136,7 @@ end:
 // read the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_readNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+ExtensionsV1beta1API_readNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11284,7 +11284,7 @@ end:
 // read scale of the specified ReplicaSet
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_readNamespacedReplicaSetScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+ExtensionsV1beta1API_readNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11392,7 +11392,7 @@ end:
 // read status of the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_readNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+ExtensionsV1beta1API_readNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11500,7 +11500,7 @@ end:
 // read scale of the specified ReplicationControllerDummy
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_readNamespacedReplicationControllerDummyScale(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+ExtensionsV1beta1API_readNamespacedReplicationControllerDummyScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11608,7 +11608,7 @@ end:
 // read the specified PodSecurityPolicy
 //
 extensions_v1beta1_pod_security_policy_t*
-ExtensionsV1beta1API_readPodSecurityPolicy(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+ExtensionsV1beta1API_readPodSecurityPolicy(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11745,7 +11745,7 @@ end:
 // replace the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_replaceNamespacedDaemonSet(apiClient_t *apiClient, char * name, char * namespace, v1beta1_daemon_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , v1beta1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -11915,7 +11915,7 @@ end:
 // replace status of the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name, char * namespace, v1beta1_daemon_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12085,7 +12085,7 @@ end:
 // replace the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name, char * namespace, extensions_v1beta1_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12255,7 +12255,7 @@ end:
 // replace scale of the specified Deployment
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name, char * namespace, extensions_v1beta1_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12425,7 +12425,7 @@ end:
 // replace status of the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name, char * namespace, extensions_v1beta1_deployment_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12595,7 +12595,7 @@ end:
 // replace the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_replaceNamespacedIngress(apiClient_t *apiClient, char * name, char * namespace, extensions_v1beta1_ingress_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12765,7 +12765,7 @@ end:
 // replace status of the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_replaceNamespacedIngressStatus(apiClient_t *apiClient, char * name, char * namespace, extensions_v1beta1_ingress_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -12935,7 +12935,7 @@ end:
 // replace the specified NetworkPolicy
 //
 v1beta1_network_policy_t*
-ExtensionsV1beta1API_replaceNamespacedNetworkPolicy(apiClient_t *apiClient, char * name, char * namespace, v1beta1_network_policy_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , v1beta1_network_policy_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -13105,7 +13105,7 @@ end:
 // replace the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_replaceNamespacedReplicaSet(apiClient_t *apiClient, char * name, char * namespace, v1beta1_replica_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , v1beta1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -13275,7 +13275,7 @@ end:
 // replace scale of the specified ReplicaSet
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient, char * name, char * namespace, extensions_v1beta1_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -13445,7 +13445,7 @@ end:
 // replace status of the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name, char * namespace, v1beta1_replica_set_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -13615,7 +13615,7 @@ end:
 // replace scale of the specified ReplicationControllerDummy
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_replaceNamespacedReplicationControllerDummyScale(apiClient_t *apiClient, char * name, char * namespace, extensions_v1beta1_scale_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replaceNamespacedReplicationControllerDummyScale(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_scale_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -13785,7 +13785,7 @@ end:
 // replace the specified PodSecurityPolicy
 //
 extensions_v1beta1_pod_security_policy_t*
-ExtensionsV1beta1API_replacePodSecurityPolicy(apiClient_t *apiClient, char * name, extensions_v1beta1_pod_security_policy_t * body, char * pretty, char * dryRun, char * fieldManager)
+ExtensionsV1beta1API_replacePodSecurityPolicy(apiClient_t *apiClient, char * name , extensions_v1beta1_pod_security_policy_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/ExtensionsV1beta1API.h
+++ b/kubernetes/api/ExtensionsV1beta1API.h
@@ -26,115 +26,115 @@
 // create a DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_createNamespacedDaemonSet(apiClient_t *apiClient ,char * namespace ,v1beta1_daemon_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_createNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , v1beta1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_createNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,extensions_v1beta1_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_createNamespacedDeployment(apiClient_t *apiClient, char * namespace , extensions_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create rollback of a Deployment
 //
 v1_status_t*
-ExtensionsV1beta1API_createNamespacedDeploymentRollback(apiClient_t *apiClient ,char * name ,char * namespace ,extensions_v1beta1_deployment_rollback_t * body ,char * dryRun ,char * fieldManager ,char * pretty);
+ExtensionsV1beta1API_createNamespacedDeploymentRollback(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_deployment_rollback_t * body , char * dryRun , char * fieldManager , char * pretty );
 
 
 // create an Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_createNamespacedIngress(apiClient_t *apiClient ,char * namespace ,extensions_v1beta1_ingress_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_createNamespacedIngress(apiClient_t *apiClient, char * namespace , extensions_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a NetworkPolicy
 //
 v1beta1_network_policy_t*
-ExtensionsV1beta1API_createNamespacedNetworkPolicy(apiClient_t *apiClient ,char * namespace ,v1beta1_network_policy_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_createNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , v1beta1_network_policy_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_createNamespacedReplicaSet(apiClient_t *apiClient ,char * namespace ,v1beta1_replica_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_createNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , v1beta1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a PodSecurityPolicy
 //
 extensions_v1beta1_pod_security_policy_t*
-ExtensionsV1beta1API_createPodSecurityPolicy(apiClient_t *apiClient ,extensions_v1beta1_pod_security_policy_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_createPodSecurityPolicy(apiClient_t *apiClient, extensions_v1beta1_pod_security_policy_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of DaemonSet
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteCollectionNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Deployment
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteCollectionNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Ingress
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionNamespacedIngress(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteCollectionNamespacedIngress(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of NetworkPolicy
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionNamespacedNetworkPolicy(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteCollectionNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ReplicaSet
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteCollectionNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of PodSecurityPolicy
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteCollectionPodSecurityPolicy(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteCollectionPodSecurityPolicy(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a DaemonSet
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a Deployment
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete an Ingress
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteNamespacedIngress(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a NetworkPolicy
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteNamespacedNetworkPolicy(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ReplicaSet
 //
 v1_status_t*
-ExtensionsV1beta1API_deleteNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deleteNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a PodSecurityPolicy
 //
 v1_status_t*
-ExtensionsV1beta1API_deletePodSecurityPolicy(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+ExtensionsV1beta1API_deletePodSecurityPolicy(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -146,300 +146,300 @@ ExtensionsV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind DaemonSet
 //
 v1beta1_daemon_set_list_t*
-ExtensionsV1beta1API_listDaemonSetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listDaemonSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Deployment
 //
 extensions_v1beta1_deployment_list_t*
-ExtensionsV1beta1API_listDeploymentForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listDeploymentForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Ingress
 //
 extensions_v1beta1_ingress_list_t*
-ExtensionsV1beta1API_listIngressForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listIngressForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind DaemonSet
 //
 v1beta1_daemon_set_list_t*
-ExtensionsV1beta1API_listNamespacedDaemonSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listNamespacedDaemonSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Deployment
 //
 extensions_v1beta1_deployment_list_t*
-ExtensionsV1beta1API_listNamespacedDeployment(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listNamespacedDeployment(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Ingress
 //
 extensions_v1beta1_ingress_list_t*
-ExtensionsV1beta1API_listNamespacedIngress(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listNamespacedIngress(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind NetworkPolicy
 //
 v1beta1_network_policy_list_t*
-ExtensionsV1beta1API_listNamespacedNetworkPolicy(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ReplicaSet
 //
 v1beta1_replica_set_list_t*
-ExtensionsV1beta1API_listNamespacedReplicaSet(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listNamespacedReplicaSet(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind NetworkPolicy
 //
 v1beta1_network_policy_list_t*
-ExtensionsV1beta1API_listNetworkPolicyForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listNetworkPolicyForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PodSecurityPolicy
 //
 extensions_v1beta1_pod_security_policy_list_t*
-ExtensionsV1beta1API_listPodSecurityPolicy(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listPodSecurityPolicy(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ReplicaSet
 //
 v1beta1_replica_set_list_t*
-ExtensionsV1beta1API_listReplicaSetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+ExtensionsV1beta1API_listReplicaSetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_patchNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_patchNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified Deployment
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_patchNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_patchNamespacedIngress(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_patchNamespacedIngressStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified NetworkPolicy
 //
 v1beta1_network_policy_t*
-ExtensionsV1beta1API_patchNamespacedNetworkPolicy(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_patchNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified ReplicaSet
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_patchNamespacedReplicaSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update scale of the specified ReplicationControllerDummy
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_patchNamespacedReplicationControllerDummyScale(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchNamespacedReplicationControllerDummyScale(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified PodSecurityPolicy
 //
 extensions_v1beta1_pod_security_policy_t*
-ExtensionsV1beta1API_patchPodSecurityPolicy(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+ExtensionsV1beta1API_patchPodSecurityPolicy(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_readNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+ExtensionsV1beta1API_readNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_readNamespacedDaemonSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+ExtensionsV1beta1API_readNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_readNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+ExtensionsV1beta1API_readNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified Deployment
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_readNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+ExtensionsV1beta1API_readNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_readNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+ExtensionsV1beta1API_readNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_readNamespacedIngress(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+ExtensionsV1beta1API_readNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_readNamespacedIngressStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+ExtensionsV1beta1API_readNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified NetworkPolicy
 //
 v1beta1_network_policy_t*
-ExtensionsV1beta1API_readNamespacedNetworkPolicy(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+ExtensionsV1beta1API_readNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_readNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+ExtensionsV1beta1API_readNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read scale of the specified ReplicaSet
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_readNamespacedReplicaSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+ExtensionsV1beta1API_readNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read status of the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_readNamespacedReplicaSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+ExtensionsV1beta1API_readNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read scale of the specified ReplicationControllerDummy
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_readNamespacedReplicationControllerDummyScale(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+ExtensionsV1beta1API_readNamespacedReplicationControllerDummyScale(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified PodSecurityPolicy
 //
 extensions_v1beta1_pod_security_policy_t*
-ExtensionsV1beta1API_readPodSecurityPolicy(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+ExtensionsV1beta1API_readPodSecurityPolicy(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_replaceNamespacedDaemonSet(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_daemon_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedDaemonSet(apiClient_t *apiClient, char * name , char * namespace , v1beta1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified DaemonSet
 //
 v1beta1_daemon_set_t*
-ExtensionsV1beta1API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_daemon_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedDaemonSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta1_daemon_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_replaceNamespacedDeployment(apiClient_t *apiClient ,char * name ,char * namespace ,extensions_v1beta1_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedDeployment(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified Deployment
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient ,char * name ,char * namespace ,extensions_v1beta1_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedDeploymentScale(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified Deployment
 //
 extensions_v1beta1_deployment_t*
-ExtensionsV1beta1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient ,char * name ,char * namespace ,extensions_v1beta1_deployment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedDeploymentStatus(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_deployment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_replaceNamespacedIngress(apiClient_t *apiClient ,char * name ,char * namespace ,extensions_v1beta1_ingress_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified Ingress
 //
 extensions_v1beta1_ingress_t*
-ExtensionsV1beta1API_replaceNamespacedIngressStatus(apiClient_t *apiClient ,char * name ,char * namespace ,extensions_v1beta1_ingress_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified NetworkPolicy
 //
 v1beta1_network_policy_t*
-ExtensionsV1beta1API_replaceNamespacedNetworkPolicy(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_network_policy_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , v1beta1_network_policy_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_replaceNamespacedReplicaSet(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_replica_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedReplicaSet(apiClient_t *apiClient, char * name , char * namespace , v1beta1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified ReplicaSet
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient ,char * name ,char * namespace ,extensions_v1beta1_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedReplicaSetScale(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified ReplicaSet
 //
 v1beta1_replica_set_t*
-ExtensionsV1beta1API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_replica_set_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta1_replica_set_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace scale of the specified ReplicationControllerDummy
 //
 extensions_v1beta1_scale_t*
-ExtensionsV1beta1API_replaceNamespacedReplicationControllerDummyScale(apiClient_t *apiClient ,char * name ,char * namespace ,extensions_v1beta1_scale_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replaceNamespacedReplicationControllerDummyScale(apiClient_t *apiClient, char * name , char * namespace , extensions_v1beta1_scale_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified PodSecurityPolicy
 //
 extensions_v1beta1_pod_security_policy_t*
-ExtensionsV1beta1API_replacePodSecurityPolicy(apiClient_t *apiClient ,char * name ,extensions_v1beta1_pod_security_policy_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+ExtensionsV1beta1API_replacePodSecurityPolicy(apiClient_t *apiClient, char * name , extensions_v1beta1_pod_security_policy_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/FlowcontrolApiserverV1alpha1API.c
+++ b/kubernetes/api/FlowcontrolApiserverV1alpha1API.c
@@ -15,7 +15,7 @@
 // create a FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_createFlowSchema(apiClient_t *apiClient, v1alpha1_flow_schema_t * body, char * pretty, char * dryRun, char * fieldManager)
+FlowcontrolApiserverV1alpha1API_createFlowSchema(apiClient_t *apiClient, v1alpha1_flow_schema_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // create a PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_createPriorityLevelConfiguration(apiClient_t *apiClient, v1alpha1_priority_level_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+FlowcontrolApiserverV1alpha1API_createPriorityLevelConfiguration(apiClient_t *apiClient, v1alpha1_priority_level_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -317,7 +317,7 @@ end:
 // delete collection of FlowSchema
 //
 v1_status_t*
-FlowcontrolApiserverV1alpha1API_deleteCollectionFlowSchema(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+FlowcontrolApiserverV1alpha1API_deleteCollectionFlowSchema(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -678,7 +678,7 @@ end:
 // delete collection of PriorityLevelConfiguration
 //
 v1_status_t*
-FlowcontrolApiserverV1alpha1API_deleteCollectionPriorityLevelConfiguration(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+FlowcontrolApiserverV1alpha1API_deleteCollectionPriorityLevelConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1039,7 +1039,7 @@ end:
 // delete a FlowSchema
 //
 v1_status_t*
-FlowcontrolApiserverV1alpha1API_deleteFlowSchema(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+FlowcontrolApiserverV1alpha1API_deleteFlowSchema(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1238,7 +1238,7 @@ end:
 // delete a PriorityLevelConfiguration
 //
 v1_status_t*
-FlowcontrolApiserverV1alpha1API_deletePriorityLevelConfiguration(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+FlowcontrolApiserverV1alpha1API_deletePriorityLevelConfiguration(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1499,7 +1499,7 @@ end:
 // list or watch objects of kind FlowSchema
 //
 v1alpha1_flow_schema_list_t*
-FlowcontrolApiserverV1alpha1API_listFlowSchema(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+FlowcontrolApiserverV1alpha1API_listFlowSchema(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1763,7 +1763,7 @@ end:
 // list or watch objects of kind PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_list_t*
-FlowcontrolApiserverV1alpha1API_listPriorityLevelConfiguration(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+FlowcontrolApiserverV1alpha1API_listPriorityLevelConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2027,7 +2027,7 @@ end:
 // partially update the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_patchFlowSchema(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+FlowcontrolApiserverV1alpha1API_patchFlowSchema(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2207,7 +2207,7 @@ end:
 // partially update status of the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_patchFlowSchemaStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+FlowcontrolApiserverV1alpha1API_patchFlowSchemaStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2387,7 +2387,7 @@ end:
 // partially update the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_patchPriorityLevelConfiguration(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+FlowcontrolApiserverV1alpha1API_patchPriorityLevelConfiguration(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2567,7 +2567,7 @@ end:
 // partially update status of the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_patchPriorityLevelConfigurationStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+FlowcontrolApiserverV1alpha1API_patchPriorityLevelConfigurationStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2747,7 +2747,7 @@ end:
 // read the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_readFlowSchema(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+FlowcontrolApiserverV1alpha1API_readFlowSchema(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2884,7 +2884,7 @@ end:
 // read status of the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_readFlowSchemaStatus(apiClient_t *apiClient, char * name, char * pretty)
+FlowcontrolApiserverV1alpha1API_readFlowSchemaStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2981,7 +2981,7 @@ end:
 // read the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_readPriorityLevelConfiguration(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+FlowcontrolApiserverV1alpha1API_readPriorityLevelConfiguration(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3118,7 +3118,7 @@ end:
 // read status of the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_readPriorityLevelConfigurationStatus(apiClient_t *apiClient, char * name, char * pretty)
+FlowcontrolApiserverV1alpha1API_readPriorityLevelConfigurationStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3215,7 +3215,7 @@ end:
 // replace the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_replaceFlowSchema(apiClient_t *apiClient, char * name, v1alpha1_flow_schema_t * body, char * pretty, char * dryRun, char * fieldManager)
+FlowcontrolApiserverV1alpha1API_replaceFlowSchema(apiClient_t *apiClient, char * name , v1alpha1_flow_schema_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3374,7 +3374,7 @@ end:
 // replace status of the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_replaceFlowSchemaStatus(apiClient_t *apiClient, char * name, v1alpha1_flow_schema_t * body, char * pretty, char * dryRun, char * fieldManager)
+FlowcontrolApiserverV1alpha1API_replaceFlowSchemaStatus(apiClient_t *apiClient, char * name , v1alpha1_flow_schema_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3533,7 +3533,7 @@ end:
 // replace the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_replacePriorityLevelConfiguration(apiClient_t *apiClient, char * name, v1alpha1_priority_level_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+FlowcontrolApiserverV1alpha1API_replacePriorityLevelConfiguration(apiClient_t *apiClient, char * name , v1alpha1_priority_level_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3692,7 +3692,7 @@ end:
 // replace status of the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_replacePriorityLevelConfigurationStatus(apiClient_t *apiClient, char * name, v1alpha1_priority_level_configuration_t * body, char * pretty, char * dryRun, char * fieldManager)
+FlowcontrolApiserverV1alpha1API_replacePriorityLevelConfigurationStatus(apiClient_t *apiClient, char * name , v1alpha1_priority_level_configuration_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/FlowcontrolApiserverV1alpha1API.h
+++ b/kubernetes/api/FlowcontrolApiserverV1alpha1API.h
@@ -16,37 +16,37 @@
 // create a FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_createFlowSchema(apiClient_t *apiClient ,v1alpha1_flow_schema_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+FlowcontrolApiserverV1alpha1API_createFlowSchema(apiClient_t *apiClient, v1alpha1_flow_schema_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_createPriorityLevelConfiguration(apiClient_t *apiClient ,v1alpha1_priority_level_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+FlowcontrolApiserverV1alpha1API_createPriorityLevelConfiguration(apiClient_t *apiClient, v1alpha1_priority_level_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of FlowSchema
 //
 v1_status_t*
-FlowcontrolApiserverV1alpha1API_deleteCollectionFlowSchema(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+FlowcontrolApiserverV1alpha1API_deleteCollectionFlowSchema(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of PriorityLevelConfiguration
 //
 v1_status_t*
-FlowcontrolApiserverV1alpha1API_deleteCollectionPriorityLevelConfiguration(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+FlowcontrolApiserverV1alpha1API_deleteCollectionPriorityLevelConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a FlowSchema
 //
 v1_status_t*
-FlowcontrolApiserverV1alpha1API_deleteFlowSchema(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+FlowcontrolApiserverV1alpha1API_deleteFlowSchema(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a PriorityLevelConfiguration
 //
 v1_status_t*
-FlowcontrolApiserverV1alpha1API_deletePriorityLevelConfiguration(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+FlowcontrolApiserverV1alpha1API_deletePriorityLevelConfiguration(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -58,84 +58,84 @@ FlowcontrolApiserverV1alpha1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind FlowSchema
 //
 v1alpha1_flow_schema_list_t*
-FlowcontrolApiserverV1alpha1API_listFlowSchema(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+FlowcontrolApiserverV1alpha1API_listFlowSchema(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_list_t*
-FlowcontrolApiserverV1alpha1API_listPriorityLevelConfiguration(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+FlowcontrolApiserverV1alpha1API_listPriorityLevelConfiguration(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_patchFlowSchema(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+FlowcontrolApiserverV1alpha1API_patchFlowSchema(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_patchFlowSchemaStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+FlowcontrolApiserverV1alpha1API_patchFlowSchemaStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_patchPriorityLevelConfiguration(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+FlowcontrolApiserverV1alpha1API_patchPriorityLevelConfiguration(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_patchPriorityLevelConfigurationStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+FlowcontrolApiserverV1alpha1API_patchPriorityLevelConfigurationStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_readFlowSchema(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+FlowcontrolApiserverV1alpha1API_readFlowSchema(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_readFlowSchemaStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+FlowcontrolApiserverV1alpha1API_readFlowSchemaStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // read the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_readPriorityLevelConfiguration(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+FlowcontrolApiserverV1alpha1API_readPriorityLevelConfiguration(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_readPriorityLevelConfigurationStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+FlowcontrolApiserverV1alpha1API_readPriorityLevelConfigurationStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // replace the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_replaceFlowSchema(apiClient_t *apiClient ,char * name ,v1alpha1_flow_schema_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+FlowcontrolApiserverV1alpha1API_replaceFlowSchema(apiClient_t *apiClient, char * name , v1alpha1_flow_schema_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified FlowSchema
 //
 v1alpha1_flow_schema_t*
-FlowcontrolApiserverV1alpha1API_replaceFlowSchemaStatus(apiClient_t *apiClient ,char * name ,v1alpha1_flow_schema_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+FlowcontrolApiserverV1alpha1API_replaceFlowSchemaStatus(apiClient_t *apiClient, char * name , v1alpha1_flow_schema_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_replacePriorityLevelConfiguration(apiClient_t *apiClient ,char * name ,v1alpha1_priority_level_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+FlowcontrolApiserverV1alpha1API_replacePriorityLevelConfiguration(apiClient_t *apiClient, char * name , v1alpha1_priority_level_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified PriorityLevelConfiguration
 //
 v1alpha1_priority_level_configuration_t*
-FlowcontrolApiserverV1alpha1API_replacePriorityLevelConfigurationStatus(apiClient_t *apiClient ,char * name ,v1alpha1_priority_level_configuration_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+FlowcontrolApiserverV1alpha1API_replacePriorityLevelConfigurationStatus(apiClient_t *apiClient, char * name , v1alpha1_priority_level_configuration_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/LogsAPI.c
+++ b/kubernetes/api/LogsAPI.c
@@ -13,7 +13,7 @@
 
 
 void
-LogsAPI_logFileHandler(apiClient_t *apiClient, char * logpath)
+LogsAPI_logFileHandler(apiClient_t *apiClient, char * logpath )
 {
     list_t    *localVarQueryParameters = NULL;
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/LogsAPI.h
+++ b/kubernetes/api/LogsAPI.h
@@ -7,7 +7,7 @@
 
 
 void
-LogsAPI_logFileHandler(apiClient_t *apiClient ,char * logpath);
+LogsAPI_logFileHandler(apiClient_t *apiClient, char * logpath );
 
 
 void

--- a/kubernetes/api/NetworkingV1API.c
+++ b/kubernetes/api/NetworkingV1API.c
@@ -15,7 +15,7 @@
 // create a NetworkPolicy
 //
 v1_network_policy_t*
-NetworkingV1API_createNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace, v1_network_policy_t * body, char * pretty, char * dryRun, char * fieldManager)
+NetworkingV1API_createNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , v1_network_policy_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of NetworkPolicy
 //
 v1_status_t*
-NetworkingV1API_deleteCollectionNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+NetworkingV1API_deleteCollectionNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete a NetworkPolicy
 //
 v1_status_t*
-NetworkingV1API_deleteNamespacedNetworkPolicy(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+NetworkingV1API_deleteNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind NetworkPolicy
 //
 v1_network_policy_list_t*
-NetworkingV1API_listNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+NetworkingV1API_listNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1096,7 +1096,7 @@ end:
 // list or watch objects of kind NetworkPolicy
 //
 v1_network_policy_list_t*
-NetworkingV1API_listNetworkPolicyForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+NetworkingV1API_listNetworkPolicyForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified NetworkPolicy
 //
 v1_network_policy_t*
-NetworkingV1API_patchNamespacedNetworkPolicy(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+NetworkingV1API_patchNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // read the specified NetworkPolicy
 //
 v1_network_policy_t*
-NetworkingV1API_readNamespacedNetworkPolicy(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+NetworkingV1API_readNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1699,7 +1699,7 @@ end:
 // replace the specified NetworkPolicy
 //
 v1_network_policy_t*
-NetworkingV1API_replaceNamespacedNetworkPolicy(apiClient_t *apiClient, char * name, char * namespace, v1_network_policy_t * body, char * pretty, char * dryRun, char * fieldManager)
+NetworkingV1API_replaceNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , v1_network_policy_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/NetworkingV1API.h
+++ b/kubernetes/api/NetworkingV1API.h
@@ -14,19 +14,19 @@
 // create a NetworkPolicy
 //
 v1_network_policy_t*
-NetworkingV1API_createNamespacedNetworkPolicy(apiClient_t *apiClient ,char * namespace ,v1_network_policy_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+NetworkingV1API_createNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , v1_network_policy_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of NetworkPolicy
 //
 v1_status_t*
-NetworkingV1API_deleteCollectionNamespacedNetworkPolicy(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+NetworkingV1API_deleteCollectionNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a NetworkPolicy
 //
 v1_status_t*
-NetworkingV1API_deleteNamespacedNetworkPolicy(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+NetworkingV1API_deleteNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,30 +38,30 @@ NetworkingV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind NetworkPolicy
 //
 v1_network_policy_list_t*
-NetworkingV1API_listNamespacedNetworkPolicy(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+NetworkingV1API_listNamespacedNetworkPolicy(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind NetworkPolicy
 //
 v1_network_policy_list_t*
-NetworkingV1API_listNetworkPolicyForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+NetworkingV1API_listNetworkPolicyForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified NetworkPolicy
 //
 v1_network_policy_t*
-NetworkingV1API_patchNamespacedNetworkPolicy(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+NetworkingV1API_patchNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified NetworkPolicy
 //
 v1_network_policy_t*
-NetworkingV1API_readNamespacedNetworkPolicy(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+NetworkingV1API_readNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // replace the specified NetworkPolicy
 //
 v1_network_policy_t*
-NetworkingV1API_replaceNamespacedNetworkPolicy(apiClient_t *apiClient ,char * name ,char * namespace ,v1_network_policy_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+NetworkingV1API_replaceNamespacedNetworkPolicy(apiClient_t *apiClient, char * name , char * namespace , v1_network_policy_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/NetworkingV1beta1API.c
+++ b/kubernetes/api/NetworkingV1beta1API.c
@@ -15,7 +15,7 @@
 // create an Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_createNamespacedIngress(apiClient_t *apiClient, char * namespace, networking_v1beta1_ingress_t * body, char * pretty, char * dryRun, char * fieldManager)
+NetworkingV1beta1API_createNamespacedIngress(apiClient_t *apiClient, char * namespace , networking_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of Ingress
 //
 v1_status_t*
-NetworkingV1beta1API_deleteCollectionNamespacedIngress(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+NetworkingV1beta1API_deleteCollectionNamespacedIngress(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete an Ingress
 //
 v1_status_t*
-NetworkingV1beta1API_deleteNamespacedIngress(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+NetworkingV1beta1API_deleteNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind Ingress
 //
 networking_v1beta1_ingress_list_t*
-NetworkingV1beta1API_listIngressForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+NetworkingV1beta1API_listIngressForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1085,7 +1085,7 @@ end:
 // list or watch objects of kind Ingress
 //
 networking_v1beta1_ingress_list_t*
-NetworkingV1beta1API_listNamespacedIngress(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+NetworkingV1beta1API_listNamespacedIngress(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_patchNamespacedIngress(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+NetworkingV1beta1API_patchNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // partially update status of the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_patchNamespacedIngressStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+NetworkingV1beta1API_patchNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1742,7 +1742,7 @@ end:
 // read the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_readNamespacedIngress(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+NetworkingV1beta1API_readNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1890,7 +1890,7 @@ end:
 // read status of the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_readNamespacedIngressStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+NetworkingV1beta1API_readNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1998,7 +1998,7 @@ end:
 // replace the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_replaceNamespacedIngress(apiClient_t *apiClient, char * name, char * namespace, networking_v1beta1_ingress_t * body, char * pretty, char * dryRun, char * fieldManager)
+NetworkingV1beta1API_replaceNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , networking_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2168,7 +2168,7 @@ end:
 // replace status of the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_replaceNamespacedIngressStatus(apiClient_t *apiClient, char * name, char * namespace, networking_v1beta1_ingress_t * body, char * pretty, char * dryRun, char * fieldManager)
+NetworkingV1beta1API_replaceNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , networking_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/NetworkingV1beta1API.h
+++ b/kubernetes/api/NetworkingV1beta1API.h
@@ -14,19 +14,19 @@
 // create an Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_createNamespacedIngress(apiClient_t *apiClient ,char * namespace ,networking_v1beta1_ingress_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+NetworkingV1beta1API_createNamespacedIngress(apiClient_t *apiClient, char * namespace , networking_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of Ingress
 //
 v1_status_t*
-NetworkingV1beta1API_deleteCollectionNamespacedIngress(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+NetworkingV1beta1API_deleteCollectionNamespacedIngress(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete an Ingress
 //
 v1_status_t*
-NetworkingV1beta1API_deleteNamespacedIngress(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+NetworkingV1beta1API_deleteNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,48 +38,48 @@ NetworkingV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind Ingress
 //
 networking_v1beta1_ingress_list_t*
-NetworkingV1beta1API_listIngressForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+NetworkingV1beta1API_listIngressForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Ingress
 //
 networking_v1beta1_ingress_list_t*
-NetworkingV1beta1API_listNamespacedIngress(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+NetworkingV1beta1API_listNamespacedIngress(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_patchNamespacedIngress(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+NetworkingV1beta1API_patchNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_patchNamespacedIngressStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+NetworkingV1beta1API_patchNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_readNamespacedIngress(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+NetworkingV1beta1API_readNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_readNamespacedIngressStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+NetworkingV1beta1API_readNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_replaceNamespacedIngress(apiClient_t *apiClient ,char * name ,char * namespace ,networking_v1beta1_ingress_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+NetworkingV1beta1API_replaceNamespacedIngress(apiClient_t *apiClient, char * name , char * namespace , networking_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified Ingress
 //
 networking_v1beta1_ingress_t*
-NetworkingV1beta1API_replaceNamespacedIngressStatus(apiClient_t *apiClient ,char * name ,char * namespace ,networking_v1beta1_ingress_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+NetworkingV1beta1API_replaceNamespacedIngressStatus(apiClient_t *apiClient, char * name , char * namespace , networking_v1beta1_ingress_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/NodeV1alpha1API.c
+++ b/kubernetes/api/NodeV1alpha1API.c
@@ -15,7 +15,7 @@
 // create a RuntimeClass
 //
 v1alpha1_runtime_class_t*
-NodeV1alpha1API_createRuntimeClass(apiClient_t *apiClient, v1alpha1_runtime_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+NodeV1alpha1API_createRuntimeClass(apiClient_t *apiClient, v1alpha1_runtime_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete collection of RuntimeClass
 //
 v1_status_t*
-NodeV1alpha1API_deleteCollectionRuntimeClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+NodeV1alpha1API_deleteCollectionRuntimeClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -527,7 +527,7 @@ end:
 // delete a RuntimeClass
 //
 v1_status_t*
-NodeV1alpha1API_deleteRuntimeClass(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+NodeV1alpha1API_deleteRuntimeClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind RuntimeClass
 //
 v1alpha1_runtime_class_list_t*
-NodeV1alpha1API_listRuntimeClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+NodeV1alpha1API_listRuntimeClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified RuntimeClass
 //
 v1alpha1_runtime_class_t*
-NodeV1alpha1API_patchRuntimeClass(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+NodeV1alpha1API_patchRuntimeClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // read the specified RuntimeClass
 //
 v1alpha1_runtime_class_t*
-NodeV1alpha1API_readRuntimeClass(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+NodeV1alpha1API_readRuntimeClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1369,7 +1369,7 @@ end:
 // replace the specified RuntimeClass
 //
 v1alpha1_runtime_class_t*
-NodeV1alpha1API_replaceRuntimeClass(apiClient_t *apiClient, char * name, v1alpha1_runtime_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+NodeV1alpha1API_replaceRuntimeClass(apiClient_t *apiClient, char * name , v1alpha1_runtime_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/NodeV1alpha1API.h
+++ b/kubernetes/api/NodeV1alpha1API.h
@@ -14,19 +14,19 @@
 // create a RuntimeClass
 //
 v1alpha1_runtime_class_t*
-NodeV1alpha1API_createRuntimeClass(apiClient_t *apiClient ,v1alpha1_runtime_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+NodeV1alpha1API_createRuntimeClass(apiClient_t *apiClient, v1alpha1_runtime_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of RuntimeClass
 //
 v1_status_t*
-NodeV1alpha1API_deleteCollectionRuntimeClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+NodeV1alpha1API_deleteCollectionRuntimeClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a RuntimeClass
 //
 v1_status_t*
-NodeV1alpha1API_deleteRuntimeClass(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+NodeV1alpha1API_deleteRuntimeClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,24 +38,24 @@ NodeV1alpha1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind RuntimeClass
 //
 v1alpha1_runtime_class_list_t*
-NodeV1alpha1API_listRuntimeClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+NodeV1alpha1API_listRuntimeClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified RuntimeClass
 //
 v1alpha1_runtime_class_t*
-NodeV1alpha1API_patchRuntimeClass(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+NodeV1alpha1API_patchRuntimeClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified RuntimeClass
 //
 v1alpha1_runtime_class_t*
-NodeV1alpha1API_readRuntimeClass(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+NodeV1alpha1API_readRuntimeClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified RuntimeClass
 //
 v1alpha1_runtime_class_t*
-NodeV1alpha1API_replaceRuntimeClass(apiClient_t *apiClient ,char * name ,v1alpha1_runtime_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+NodeV1alpha1API_replaceRuntimeClass(apiClient_t *apiClient, char * name , v1alpha1_runtime_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/NodeV1beta1API.c
+++ b/kubernetes/api/NodeV1beta1API.c
@@ -15,7 +15,7 @@
 // create a RuntimeClass
 //
 v1beta1_runtime_class_t*
-NodeV1beta1API_createRuntimeClass(apiClient_t *apiClient, v1beta1_runtime_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+NodeV1beta1API_createRuntimeClass(apiClient_t *apiClient, v1beta1_runtime_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete collection of RuntimeClass
 //
 v1_status_t*
-NodeV1beta1API_deleteCollectionRuntimeClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+NodeV1beta1API_deleteCollectionRuntimeClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -527,7 +527,7 @@ end:
 // delete a RuntimeClass
 //
 v1_status_t*
-NodeV1beta1API_deleteRuntimeClass(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+NodeV1beta1API_deleteRuntimeClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind RuntimeClass
 //
 v1beta1_runtime_class_list_t*
-NodeV1beta1API_listRuntimeClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+NodeV1beta1API_listRuntimeClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified RuntimeClass
 //
 v1beta1_runtime_class_t*
-NodeV1beta1API_patchRuntimeClass(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+NodeV1beta1API_patchRuntimeClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // read the specified RuntimeClass
 //
 v1beta1_runtime_class_t*
-NodeV1beta1API_readRuntimeClass(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+NodeV1beta1API_readRuntimeClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1369,7 +1369,7 @@ end:
 // replace the specified RuntimeClass
 //
 v1beta1_runtime_class_t*
-NodeV1beta1API_replaceRuntimeClass(apiClient_t *apiClient, char * name, v1beta1_runtime_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+NodeV1beta1API_replaceRuntimeClass(apiClient_t *apiClient, char * name , v1beta1_runtime_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/NodeV1beta1API.h
+++ b/kubernetes/api/NodeV1beta1API.h
@@ -14,19 +14,19 @@
 // create a RuntimeClass
 //
 v1beta1_runtime_class_t*
-NodeV1beta1API_createRuntimeClass(apiClient_t *apiClient ,v1beta1_runtime_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+NodeV1beta1API_createRuntimeClass(apiClient_t *apiClient, v1beta1_runtime_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of RuntimeClass
 //
 v1_status_t*
-NodeV1beta1API_deleteCollectionRuntimeClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+NodeV1beta1API_deleteCollectionRuntimeClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a RuntimeClass
 //
 v1_status_t*
-NodeV1beta1API_deleteRuntimeClass(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+NodeV1beta1API_deleteRuntimeClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,24 +38,24 @@ NodeV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind RuntimeClass
 //
 v1beta1_runtime_class_list_t*
-NodeV1beta1API_listRuntimeClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+NodeV1beta1API_listRuntimeClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified RuntimeClass
 //
 v1beta1_runtime_class_t*
-NodeV1beta1API_patchRuntimeClass(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+NodeV1beta1API_patchRuntimeClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified RuntimeClass
 //
 v1beta1_runtime_class_t*
-NodeV1beta1API_readRuntimeClass(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+NodeV1beta1API_readRuntimeClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified RuntimeClass
 //
 v1beta1_runtime_class_t*
-NodeV1beta1API_replaceRuntimeClass(apiClient_t *apiClient ,char * name ,v1beta1_runtime_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+NodeV1beta1API_replaceRuntimeClass(apiClient_t *apiClient, char * name , v1beta1_runtime_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/PolicyV1beta1API.c
+++ b/kubernetes/api/PolicyV1beta1API.c
@@ -15,7 +15,7 @@
 // create a PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_createNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * namespace, v1beta1_pod_disruption_budget_t * body, char * pretty, char * dryRun, char * fieldManager)
+PolicyV1beta1API_createNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * namespace , v1beta1_pod_disruption_budget_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // create a PodSecurityPolicy
 //
 policy_v1beta1_pod_security_policy_t*
-PolicyV1beta1API_createPodSecurityPolicy(apiClient_t *apiClient, policy_v1beta1_pod_security_policy_t * body, char * pretty, char * dryRun, char * fieldManager)
+PolicyV1beta1API_createPodSecurityPolicy(apiClient_t *apiClient, policy_v1beta1_pod_security_policy_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -328,7 +328,7 @@ end:
 // delete collection of PodDisruptionBudget
 //
 v1_status_t*
-PolicyV1beta1API_deleteCollectionNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+PolicyV1beta1API_deleteCollectionNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -700,7 +700,7 @@ end:
 // delete collection of PodSecurityPolicy
 //
 v1_status_t*
-PolicyV1beta1API_deleteCollectionPodSecurityPolicy(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+PolicyV1beta1API_deleteCollectionPodSecurityPolicy(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1061,7 +1061,7 @@ end:
 // delete a PodDisruptionBudget
 //
 v1_status_t*
-PolicyV1beta1API_deleteNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+PolicyV1beta1API_deleteNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1271,7 +1271,7 @@ end:
 // delete a PodSecurityPolicy
 //
 v1_status_t*
-PolicyV1beta1API_deletePodSecurityPolicy(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+PolicyV1beta1API_deletePodSecurityPolicy(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1532,7 +1532,7 @@ end:
 // list or watch objects of kind PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_list_t*
-PolicyV1beta1API_listNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+PolicyV1beta1API_listNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1807,7 +1807,7 @@ end:
 // list or watch objects of kind PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_list_t*
-PolicyV1beta1API_listPodDisruptionBudgetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+PolicyV1beta1API_listPodDisruptionBudgetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2071,7 +2071,7 @@ end:
 // list or watch objects of kind PodSecurityPolicy
 //
 policy_v1beta1_pod_security_policy_list_t*
-PolicyV1beta1API_listPodSecurityPolicy(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+PolicyV1beta1API_listPodSecurityPolicy(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2335,7 +2335,7 @@ end:
 // partially update the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_patchNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+PolicyV1beta1API_patchNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2526,7 +2526,7 @@ end:
 // partially update status of the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_patchNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+PolicyV1beta1API_patchNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2717,7 +2717,7 @@ end:
 // partially update the specified PodSecurityPolicy
 //
 policy_v1beta1_pod_security_policy_t*
-PolicyV1beta1API_patchPodSecurityPolicy(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+PolicyV1beta1API_patchPodSecurityPolicy(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2897,7 +2897,7 @@ end:
 // read the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_readNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+PolicyV1beta1API_readNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3045,7 +3045,7 @@ end:
 // read status of the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_readNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+PolicyV1beta1API_readNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3153,7 +3153,7 @@ end:
 // read the specified PodSecurityPolicy
 //
 policy_v1beta1_pod_security_policy_t*
-PolicyV1beta1API_readPodSecurityPolicy(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+PolicyV1beta1API_readPodSecurityPolicy(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3290,7 +3290,7 @@ end:
 // replace the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_replaceNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name, char * namespace, v1beta1_pod_disruption_budget_t * body, char * pretty, char * dryRun, char * fieldManager)
+PolicyV1beta1API_replaceNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name , char * namespace , v1beta1_pod_disruption_budget_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3460,7 +3460,7 @@ end:
 // replace status of the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_replaceNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient, char * name, char * namespace, v1beta1_pod_disruption_budget_t * body, char * pretty, char * dryRun, char * fieldManager)
+PolicyV1beta1API_replaceNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta1_pod_disruption_budget_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3630,7 +3630,7 @@ end:
 // replace the specified PodSecurityPolicy
 //
 policy_v1beta1_pod_security_policy_t*
-PolicyV1beta1API_replacePodSecurityPolicy(apiClient_t *apiClient, char * name, policy_v1beta1_pod_security_policy_t * body, char * pretty, char * dryRun, char * fieldManager)
+PolicyV1beta1API_replacePodSecurityPolicy(apiClient_t *apiClient, char * name , policy_v1beta1_pod_security_policy_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/PolicyV1beta1API.h
+++ b/kubernetes/api/PolicyV1beta1API.h
@@ -16,37 +16,37 @@
 // create a PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_createNamespacedPodDisruptionBudget(apiClient_t *apiClient ,char * namespace ,v1beta1_pod_disruption_budget_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+PolicyV1beta1API_createNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * namespace , v1beta1_pod_disruption_budget_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a PodSecurityPolicy
 //
 policy_v1beta1_pod_security_policy_t*
-PolicyV1beta1API_createPodSecurityPolicy(apiClient_t *apiClient ,policy_v1beta1_pod_security_policy_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+PolicyV1beta1API_createPodSecurityPolicy(apiClient_t *apiClient, policy_v1beta1_pod_security_policy_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of PodDisruptionBudget
 //
 v1_status_t*
-PolicyV1beta1API_deleteCollectionNamespacedPodDisruptionBudget(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+PolicyV1beta1API_deleteCollectionNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of PodSecurityPolicy
 //
 v1_status_t*
-PolicyV1beta1API_deleteCollectionPodSecurityPolicy(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+PolicyV1beta1API_deleteCollectionPodSecurityPolicy(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a PodDisruptionBudget
 //
 v1_status_t*
-PolicyV1beta1API_deleteNamespacedPodDisruptionBudget(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+PolicyV1beta1API_deleteNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a PodSecurityPolicy
 //
 v1_status_t*
-PolicyV1beta1API_deletePodSecurityPolicy(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+PolicyV1beta1API_deletePodSecurityPolicy(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -58,72 +58,72 @@ PolicyV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_list_t*
-PolicyV1beta1API_listNamespacedPodDisruptionBudget(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+PolicyV1beta1API_listNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_list_t*
-PolicyV1beta1API_listPodDisruptionBudgetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+PolicyV1beta1API_listPodDisruptionBudgetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PodSecurityPolicy
 //
 policy_v1beta1_pod_security_policy_list_t*
-PolicyV1beta1API_listPodSecurityPolicy(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+PolicyV1beta1API_listPodSecurityPolicy(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_patchNamespacedPodDisruptionBudget(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+PolicyV1beta1API_patchNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_patchNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+PolicyV1beta1API_patchNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified PodSecurityPolicy
 //
 policy_v1beta1_pod_security_policy_t*
-PolicyV1beta1API_patchPodSecurityPolicy(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+PolicyV1beta1API_patchPodSecurityPolicy(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_readNamespacedPodDisruptionBudget(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+PolicyV1beta1API_readNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // read status of the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_readNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+PolicyV1beta1API_readNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified PodSecurityPolicy
 //
 policy_v1beta1_pod_security_policy_t*
-PolicyV1beta1API_readPodSecurityPolicy(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+PolicyV1beta1API_readPodSecurityPolicy(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_replaceNamespacedPodDisruptionBudget(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_pod_disruption_budget_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+PolicyV1beta1API_replaceNamespacedPodDisruptionBudget(apiClient_t *apiClient, char * name , char * namespace , v1beta1_pod_disruption_budget_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified PodDisruptionBudget
 //
 v1beta1_pod_disruption_budget_t*
-PolicyV1beta1API_replaceNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_pod_disruption_budget_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+PolicyV1beta1API_replaceNamespacedPodDisruptionBudgetStatus(apiClient_t *apiClient, char * name , char * namespace , v1beta1_pod_disruption_budget_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified PodSecurityPolicy
 //
 policy_v1beta1_pod_security_policy_t*
-PolicyV1beta1API_replacePodSecurityPolicy(apiClient_t *apiClient ,char * name ,policy_v1beta1_pod_security_policy_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+PolicyV1beta1API_replacePodSecurityPolicy(apiClient_t *apiClient, char * name , policy_v1beta1_pod_security_policy_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/RbacAuthorizationV1API.c
+++ b/kubernetes/api/RbacAuthorizationV1API.c
@@ -15,7 +15,7 @@
 // create a ClusterRole
 //
 v1_cluster_role_t*
-RbacAuthorizationV1API_createClusterRole(apiClient_t *apiClient, v1_cluster_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1API_createClusterRole(apiClient_t *apiClient, v1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // create a ClusterRoleBinding
 //
 v1_cluster_role_binding_t*
-RbacAuthorizationV1API_createClusterRoleBinding(apiClient_t *apiClient, v1_cluster_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1API_createClusterRoleBinding(apiClient_t *apiClient, v1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -317,7 +317,7 @@ end:
 // create a Role
 //
 v1_role_t*
-RbacAuthorizationV1API_createNamespacedRole(apiClient_t *apiClient, char * namespace, v1_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1API_createNamespacedRole(apiClient_t *apiClient, char * namespace , v1_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -479,7 +479,7 @@ end:
 // create a RoleBinding
 //
 v1_role_binding_t*
-RbacAuthorizationV1API_createNamespacedRoleBinding(apiClient_t *apiClient, char * namespace, v1_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1API_createNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , v1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -641,7 +641,7 @@ end:
 // delete a ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteClusterRole(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1API_deleteClusterRole(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -840,7 +840,7 @@ end:
 // delete a ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteClusterRoleBinding(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1API_deleteClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1039,7 +1039,7 @@ end:
 // delete collection of ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteCollectionClusterRole(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1API_deleteCollectionClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1400,7 +1400,7 @@ end:
 // delete collection of ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1761,7 +1761,7 @@ end:
 // delete collection of Role
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteCollectionNamespacedRole(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1API_deleteCollectionNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2133,7 +2133,7 @@ end:
 // delete collection of RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2505,7 +2505,7 @@ end:
 // delete a Role
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1API_deleteNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2715,7 +2715,7 @@ end:
 // delete a RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1API_deleteNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2987,7 +2987,7 @@ end:
 // list or watch objects of kind ClusterRole
 //
 v1_cluster_role_list_t*
-RbacAuthorizationV1API_listClusterRole(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1API_listClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3251,7 +3251,7 @@ end:
 // list or watch objects of kind ClusterRoleBinding
 //
 v1_cluster_role_binding_list_t*
-RbacAuthorizationV1API_listClusterRoleBinding(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1API_listClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3515,7 +3515,7 @@ end:
 // list or watch objects of kind Role
 //
 v1_role_list_t*
-RbacAuthorizationV1API_listNamespacedRole(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1API_listNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3790,7 +3790,7 @@ end:
 // list or watch objects of kind RoleBinding
 //
 v1_role_binding_list_t*
-RbacAuthorizationV1API_listNamespacedRoleBinding(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1API_listNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4065,7 +4065,7 @@ end:
 // list or watch objects of kind RoleBinding
 //
 v1_role_binding_list_t*
-RbacAuthorizationV1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4329,7 +4329,7 @@ end:
 // list or watch objects of kind Role
 //
 v1_role_list_t*
-RbacAuthorizationV1API_listRoleForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1API_listRoleForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4593,7 +4593,7 @@ end:
 // partially update the specified ClusterRole
 //
 v1_cluster_role_t*
-RbacAuthorizationV1API_patchClusterRole(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1API_patchClusterRole(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4773,7 +4773,7 @@ end:
 // partially update the specified ClusterRoleBinding
 //
 v1_cluster_role_binding_t*
-RbacAuthorizationV1API_patchClusterRoleBinding(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1API_patchClusterRoleBinding(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4953,7 +4953,7 @@ end:
 // partially update the specified Role
 //
 v1_role_t*
-RbacAuthorizationV1API_patchNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1API_patchNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5144,7 +5144,7 @@ end:
 // partially update the specified RoleBinding
 //
 v1_role_binding_t*
-RbacAuthorizationV1API_patchNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1API_patchNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5335,7 +5335,7 @@ end:
 // read the specified ClusterRole
 //
 v1_cluster_role_t*
-RbacAuthorizationV1API_readClusterRole(apiClient_t *apiClient, char * name, char * pretty)
+RbacAuthorizationV1API_readClusterRole(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5432,7 +5432,7 @@ end:
 // read the specified ClusterRoleBinding
 //
 v1_cluster_role_binding_t*
-RbacAuthorizationV1API_readClusterRoleBinding(apiClient_t *apiClient, char * name, char * pretty)
+RbacAuthorizationV1API_readClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5529,7 +5529,7 @@ end:
 // read the specified Role
 //
 v1_role_t*
-RbacAuthorizationV1API_readNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+RbacAuthorizationV1API_readNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5637,7 +5637,7 @@ end:
 // read the specified RoleBinding
 //
 v1_role_binding_t*
-RbacAuthorizationV1API_readNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+RbacAuthorizationV1API_readNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5745,7 +5745,7 @@ end:
 // replace the specified ClusterRole
 //
 v1_cluster_role_t*
-RbacAuthorizationV1API_replaceClusterRole(apiClient_t *apiClient, char * name, v1_cluster_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1API_replaceClusterRole(apiClient_t *apiClient, char * name , v1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5904,7 +5904,7 @@ end:
 // replace the specified ClusterRoleBinding
 //
 v1_cluster_role_binding_t*
-RbacAuthorizationV1API_replaceClusterRoleBinding(apiClient_t *apiClient, char * name, v1_cluster_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1API_replaceClusterRoleBinding(apiClient_t *apiClient, char * name , v1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6063,7 +6063,7 @@ end:
 // replace the specified Role
 //
 v1_role_t*
-RbacAuthorizationV1API_replaceNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, v1_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1API_replaceNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , v1_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6233,7 +6233,7 @@ end:
 // replace the specified RoleBinding
 //
 v1_role_binding_t*
-RbacAuthorizationV1API_replaceNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, v1_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1API_replaceNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , v1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/RbacAuthorizationV1API.h
+++ b/kubernetes/api/RbacAuthorizationV1API.h
@@ -20,73 +20,73 @@
 // create a ClusterRole
 //
 v1_cluster_role_t*
-RbacAuthorizationV1API_createClusterRole(apiClient_t *apiClient ,v1_cluster_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1API_createClusterRole(apiClient_t *apiClient, v1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ClusterRoleBinding
 //
 v1_cluster_role_binding_t*
-RbacAuthorizationV1API_createClusterRoleBinding(apiClient_t *apiClient ,v1_cluster_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1API_createClusterRoleBinding(apiClient_t *apiClient, v1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Role
 //
 v1_role_t*
-RbacAuthorizationV1API_createNamespacedRole(apiClient_t *apiClient ,char * namespace ,v1_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1API_createNamespacedRole(apiClient_t *apiClient, char * namespace , v1_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a RoleBinding
 //
 v1_role_binding_t*
-RbacAuthorizationV1API_createNamespacedRoleBinding(apiClient_t *apiClient ,char * namespace ,v1_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1API_createNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , v1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete a ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteClusterRole(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1API_deleteClusterRole(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteClusterRoleBinding(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1API_deleteClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete collection of ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteCollectionClusterRole(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1API_deleteCollectionClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Role
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteCollectionNamespacedRole(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1API_deleteCollectionNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a Role
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1API_deleteNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1API_deleteNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1API_deleteNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -98,108 +98,108 @@ RbacAuthorizationV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind ClusterRole
 //
 v1_cluster_role_list_t*
-RbacAuthorizationV1API_listClusterRole(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1API_listClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ClusterRoleBinding
 //
 v1_cluster_role_binding_list_t*
-RbacAuthorizationV1API_listClusterRoleBinding(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1API_listClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Role
 //
 v1_role_list_t*
-RbacAuthorizationV1API_listNamespacedRole(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1API_listNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind RoleBinding
 //
 v1_role_binding_list_t*
-RbacAuthorizationV1API_listNamespacedRoleBinding(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1API_listNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind RoleBinding
 //
 v1_role_binding_list_t*
-RbacAuthorizationV1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Role
 //
 v1_role_list_t*
-RbacAuthorizationV1API_listRoleForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1API_listRoleForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified ClusterRole
 //
 v1_cluster_role_t*
-RbacAuthorizationV1API_patchClusterRole(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1API_patchClusterRole(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ClusterRoleBinding
 //
 v1_cluster_role_binding_t*
-RbacAuthorizationV1API_patchClusterRoleBinding(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1API_patchClusterRoleBinding(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Role
 //
 v1_role_t*
-RbacAuthorizationV1API_patchNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1API_patchNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified RoleBinding
 //
 v1_role_binding_t*
-RbacAuthorizationV1API_patchNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1API_patchNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified ClusterRole
 //
 v1_cluster_role_t*
-RbacAuthorizationV1API_readClusterRole(apiClient_t *apiClient ,char * name ,char * pretty);
+RbacAuthorizationV1API_readClusterRole(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // read the specified ClusterRoleBinding
 //
 v1_cluster_role_binding_t*
-RbacAuthorizationV1API_readClusterRoleBinding(apiClient_t *apiClient ,char * name ,char * pretty);
+RbacAuthorizationV1API_readClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // read the specified Role
 //
 v1_role_t*
-RbacAuthorizationV1API_readNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+RbacAuthorizationV1API_readNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified RoleBinding
 //
 v1_role_binding_t*
-RbacAuthorizationV1API_readNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+RbacAuthorizationV1API_readNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified ClusterRole
 //
 v1_cluster_role_t*
-RbacAuthorizationV1API_replaceClusterRole(apiClient_t *apiClient ,char * name ,v1_cluster_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1API_replaceClusterRole(apiClient_t *apiClient, char * name , v1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ClusterRoleBinding
 //
 v1_cluster_role_binding_t*
-RbacAuthorizationV1API_replaceClusterRoleBinding(apiClient_t *apiClient ,char * name ,v1_cluster_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1API_replaceClusterRoleBinding(apiClient_t *apiClient, char * name , v1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Role
 //
 v1_role_t*
-RbacAuthorizationV1API_replaceNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,v1_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1API_replaceNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , v1_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified RoleBinding
 //
 v1_role_binding_t*
-RbacAuthorizationV1API_replaceNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,v1_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1API_replaceNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , v1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/RbacAuthorizationV1alpha1API.c
+++ b/kubernetes/api/RbacAuthorizationV1alpha1API.c
@@ -15,7 +15,7 @@
 // create a ClusterRole
 //
 v1alpha1_cluster_role_t*
-RbacAuthorizationV1alpha1API_createClusterRole(apiClient_t *apiClient, v1alpha1_cluster_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1alpha1API_createClusterRole(apiClient_t *apiClient, v1alpha1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // create a ClusterRoleBinding
 //
 v1alpha1_cluster_role_binding_t*
-RbacAuthorizationV1alpha1API_createClusterRoleBinding(apiClient_t *apiClient, v1alpha1_cluster_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1alpha1API_createClusterRoleBinding(apiClient_t *apiClient, v1alpha1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -317,7 +317,7 @@ end:
 // create a Role
 //
 v1alpha1_role_t*
-RbacAuthorizationV1alpha1API_createNamespacedRole(apiClient_t *apiClient, char * namespace, v1alpha1_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1alpha1API_createNamespacedRole(apiClient_t *apiClient, char * namespace , v1alpha1_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -479,7 +479,7 @@ end:
 // create a RoleBinding
 //
 v1alpha1_role_binding_t*
-RbacAuthorizationV1alpha1API_createNamespacedRoleBinding(apiClient_t *apiClient, char * namespace, v1alpha1_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1alpha1API_createNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , v1alpha1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -641,7 +641,7 @@ end:
 // delete a ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteClusterRole(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1alpha1API_deleteClusterRole(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -840,7 +840,7 @@ end:
 // delete a ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteClusterRoleBinding(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1alpha1API_deleteClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1039,7 +1039,7 @@ end:
 // delete collection of ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteCollectionClusterRole(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1alpha1API_deleteCollectionClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1400,7 +1400,7 @@ end:
 // delete collection of ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1alpha1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1761,7 +1761,7 @@ end:
 // delete collection of Role
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteCollectionNamespacedRole(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1alpha1API_deleteCollectionNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2133,7 +2133,7 @@ end:
 // delete collection of RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1alpha1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2505,7 +2505,7 @@ end:
 // delete a Role
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1alpha1API_deleteNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2715,7 +2715,7 @@ end:
 // delete a RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1alpha1API_deleteNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2987,7 +2987,7 @@ end:
 // list or watch objects of kind ClusterRole
 //
 v1alpha1_cluster_role_list_t*
-RbacAuthorizationV1alpha1API_listClusterRole(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1alpha1API_listClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3251,7 +3251,7 @@ end:
 // list or watch objects of kind ClusterRoleBinding
 //
 v1alpha1_cluster_role_binding_list_t*
-RbacAuthorizationV1alpha1API_listClusterRoleBinding(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1alpha1API_listClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3515,7 +3515,7 @@ end:
 // list or watch objects of kind Role
 //
 v1alpha1_role_list_t*
-RbacAuthorizationV1alpha1API_listNamespacedRole(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1alpha1API_listNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3790,7 +3790,7 @@ end:
 // list or watch objects of kind RoleBinding
 //
 v1alpha1_role_binding_list_t*
-RbacAuthorizationV1alpha1API_listNamespacedRoleBinding(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1alpha1API_listNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4065,7 +4065,7 @@ end:
 // list or watch objects of kind RoleBinding
 //
 v1alpha1_role_binding_list_t*
-RbacAuthorizationV1alpha1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1alpha1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4329,7 +4329,7 @@ end:
 // list or watch objects of kind Role
 //
 v1alpha1_role_list_t*
-RbacAuthorizationV1alpha1API_listRoleForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1alpha1API_listRoleForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4593,7 +4593,7 @@ end:
 // partially update the specified ClusterRole
 //
 v1alpha1_cluster_role_t*
-RbacAuthorizationV1alpha1API_patchClusterRole(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1alpha1API_patchClusterRole(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4773,7 +4773,7 @@ end:
 // partially update the specified ClusterRoleBinding
 //
 v1alpha1_cluster_role_binding_t*
-RbacAuthorizationV1alpha1API_patchClusterRoleBinding(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1alpha1API_patchClusterRoleBinding(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4953,7 +4953,7 @@ end:
 // partially update the specified Role
 //
 v1alpha1_role_t*
-RbacAuthorizationV1alpha1API_patchNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1alpha1API_patchNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5144,7 +5144,7 @@ end:
 // partially update the specified RoleBinding
 //
 v1alpha1_role_binding_t*
-RbacAuthorizationV1alpha1API_patchNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1alpha1API_patchNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5335,7 +5335,7 @@ end:
 // read the specified ClusterRole
 //
 v1alpha1_cluster_role_t*
-RbacAuthorizationV1alpha1API_readClusterRole(apiClient_t *apiClient, char * name, char * pretty)
+RbacAuthorizationV1alpha1API_readClusterRole(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5432,7 +5432,7 @@ end:
 // read the specified ClusterRoleBinding
 //
 v1alpha1_cluster_role_binding_t*
-RbacAuthorizationV1alpha1API_readClusterRoleBinding(apiClient_t *apiClient, char * name, char * pretty)
+RbacAuthorizationV1alpha1API_readClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5529,7 +5529,7 @@ end:
 // read the specified Role
 //
 v1alpha1_role_t*
-RbacAuthorizationV1alpha1API_readNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+RbacAuthorizationV1alpha1API_readNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5637,7 +5637,7 @@ end:
 // read the specified RoleBinding
 //
 v1alpha1_role_binding_t*
-RbacAuthorizationV1alpha1API_readNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+RbacAuthorizationV1alpha1API_readNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5745,7 +5745,7 @@ end:
 // replace the specified ClusterRole
 //
 v1alpha1_cluster_role_t*
-RbacAuthorizationV1alpha1API_replaceClusterRole(apiClient_t *apiClient, char * name, v1alpha1_cluster_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1alpha1API_replaceClusterRole(apiClient_t *apiClient, char * name , v1alpha1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5904,7 +5904,7 @@ end:
 // replace the specified ClusterRoleBinding
 //
 v1alpha1_cluster_role_binding_t*
-RbacAuthorizationV1alpha1API_replaceClusterRoleBinding(apiClient_t *apiClient, char * name, v1alpha1_cluster_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1alpha1API_replaceClusterRoleBinding(apiClient_t *apiClient, char * name , v1alpha1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6063,7 +6063,7 @@ end:
 // replace the specified Role
 //
 v1alpha1_role_t*
-RbacAuthorizationV1alpha1API_replaceNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, v1alpha1_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1alpha1API_replaceNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , v1alpha1_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6233,7 +6233,7 @@ end:
 // replace the specified RoleBinding
 //
 v1alpha1_role_binding_t*
-RbacAuthorizationV1alpha1API_replaceNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, v1alpha1_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1alpha1API_replaceNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , v1alpha1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/RbacAuthorizationV1alpha1API.h
+++ b/kubernetes/api/RbacAuthorizationV1alpha1API.h
@@ -20,73 +20,73 @@
 // create a ClusterRole
 //
 v1alpha1_cluster_role_t*
-RbacAuthorizationV1alpha1API_createClusterRole(apiClient_t *apiClient ,v1alpha1_cluster_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1alpha1API_createClusterRole(apiClient_t *apiClient, v1alpha1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ClusterRoleBinding
 //
 v1alpha1_cluster_role_binding_t*
-RbacAuthorizationV1alpha1API_createClusterRoleBinding(apiClient_t *apiClient ,v1alpha1_cluster_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1alpha1API_createClusterRoleBinding(apiClient_t *apiClient, v1alpha1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Role
 //
 v1alpha1_role_t*
-RbacAuthorizationV1alpha1API_createNamespacedRole(apiClient_t *apiClient ,char * namespace ,v1alpha1_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1alpha1API_createNamespacedRole(apiClient_t *apiClient, char * namespace , v1alpha1_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a RoleBinding
 //
 v1alpha1_role_binding_t*
-RbacAuthorizationV1alpha1API_createNamespacedRoleBinding(apiClient_t *apiClient ,char * namespace ,v1alpha1_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1alpha1API_createNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , v1alpha1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete a ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteClusterRole(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1alpha1API_deleteClusterRole(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteClusterRoleBinding(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1alpha1API_deleteClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete collection of ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteCollectionClusterRole(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1alpha1API_deleteCollectionClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1alpha1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Role
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteCollectionNamespacedRole(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1alpha1API_deleteCollectionNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1alpha1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a Role
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1alpha1API_deleteNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1alpha1API_deleteNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1alpha1API_deleteNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -98,108 +98,108 @@ RbacAuthorizationV1alpha1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind ClusterRole
 //
 v1alpha1_cluster_role_list_t*
-RbacAuthorizationV1alpha1API_listClusterRole(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1alpha1API_listClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ClusterRoleBinding
 //
 v1alpha1_cluster_role_binding_list_t*
-RbacAuthorizationV1alpha1API_listClusterRoleBinding(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1alpha1API_listClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Role
 //
 v1alpha1_role_list_t*
-RbacAuthorizationV1alpha1API_listNamespacedRole(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1alpha1API_listNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind RoleBinding
 //
 v1alpha1_role_binding_list_t*
-RbacAuthorizationV1alpha1API_listNamespacedRoleBinding(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1alpha1API_listNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind RoleBinding
 //
 v1alpha1_role_binding_list_t*
-RbacAuthorizationV1alpha1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1alpha1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Role
 //
 v1alpha1_role_list_t*
-RbacAuthorizationV1alpha1API_listRoleForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1alpha1API_listRoleForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified ClusterRole
 //
 v1alpha1_cluster_role_t*
-RbacAuthorizationV1alpha1API_patchClusterRole(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1alpha1API_patchClusterRole(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ClusterRoleBinding
 //
 v1alpha1_cluster_role_binding_t*
-RbacAuthorizationV1alpha1API_patchClusterRoleBinding(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1alpha1API_patchClusterRoleBinding(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Role
 //
 v1alpha1_role_t*
-RbacAuthorizationV1alpha1API_patchNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1alpha1API_patchNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified RoleBinding
 //
 v1alpha1_role_binding_t*
-RbacAuthorizationV1alpha1API_patchNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1alpha1API_patchNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified ClusterRole
 //
 v1alpha1_cluster_role_t*
-RbacAuthorizationV1alpha1API_readClusterRole(apiClient_t *apiClient ,char * name ,char * pretty);
+RbacAuthorizationV1alpha1API_readClusterRole(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // read the specified ClusterRoleBinding
 //
 v1alpha1_cluster_role_binding_t*
-RbacAuthorizationV1alpha1API_readClusterRoleBinding(apiClient_t *apiClient ,char * name ,char * pretty);
+RbacAuthorizationV1alpha1API_readClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // read the specified Role
 //
 v1alpha1_role_t*
-RbacAuthorizationV1alpha1API_readNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+RbacAuthorizationV1alpha1API_readNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified RoleBinding
 //
 v1alpha1_role_binding_t*
-RbacAuthorizationV1alpha1API_readNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+RbacAuthorizationV1alpha1API_readNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified ClusterRole
 //
 v1alpha1_cluster_role_t*
-RbacAuthorizationV1alpha1API_replaceClusterRole(apiClient_t *apiClient ,char * name ,v1alpha1_cluster_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1alpha1API_replaceClusterRole(apiClient_t *apiClient, char * name , v1alpha1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ClusterRoleBinding
 //
 v1alpha1_cluster_role_binding_t*
-RbacAuthorizationV1alpha1API_replaceClusterRoleBinding(apiClient_t *apiClient ,char * name ,v1alpha1_cluster_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1alpha1API_replaceClusterRoleBinding(apiClient_t *apiClient, char * name , v1alpha1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Role
 //
 v1alpha1_role_t*
-RbacAuthorizationV1alpha1API_replaceNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,v1alpha1_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1alpha1API_replaceNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , v1alpha1_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified RoleBinding
 //
 v1alpha1_role_binding_t*
-RbacAuthorizationV1alpha1API_replaceNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,v1alpha1_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1alpha1API_replaceNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , v1alpha1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/RbacAuthorizationV1beta1API.c
+++ b/kubernetes/api/RbacAuthorizationV1beta1API.c
@@ -15,7 +15,7 @@
 // create a ClusterRole
 //
 v1beta1_cluster_role_t*
-RbacAuthorizationV1beta1API_createClusterRole(apiClient_t *apiClient, v1beta1_cluster_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1beta1API_createClusterRole(apiClient_t *apiClient, v1beta1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // create a ClusterRoleBinding
 //
 v1beta1_cluster_role_binding_t*
-RbacAuthorizationV1beta1API_createClusterRoleBinding(apiClient_t *apiClient, v1beta1_cluster_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1beta1API_createClusterRoleBinding(apiClient_t *apiClient, v1beta1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -317,7 +317,7 @@ end:
 // create a Role
 //
 v1beta1_role_t*
-RbacAuthorizationV1beta1API_createNamespacedRole(apiClient_t *apiClient, char * namespace, v1beta1_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1beta1API_createNamespacedRole(apiClient_t *apiClient, char * namespace , v1beta1_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -479,7 +479,7 @@ end:
 // create a RoleBinding
 //
 v1beta1_role_binding_t*
-RbacAuthorizationV1beta1API_createNamespacedRoleBinding(apiClient_t *apiClient, char * namespace, v1beta1_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1beta1API_createNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , v1beta1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -641,7 +641,7 @@ end:
 // delete a ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteClusterRole(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1beta1API_deleteClusterRole(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -840,7 +840,7 @@ end:
 // delete a ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteClusterRoleBinding(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1beta1API_deleteClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1039,7 +1039,7 @@ end:
 // delete collection of ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteCollectionClusterRole(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1beta1API_deleteCollectionClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1400,7 +1400,7 @@ end:
 // delete collection of ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1beta1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1761,7 +1761,7 @@ end:
 // delete collection of Role
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteCollectionNamespacedRole(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1beta1API_deleteCollectionNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2133,7 +2133,7 @@ end:
 // delete collection of RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+RbacAuthorizationV1beta1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2505,7 +2505,7 @@ end:
 // delete a Role
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1beta1API_deleteNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2715,7 +2715,7 @@ end:
 // delete a RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+RbacAuthorizationV1beta1API_deleteNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2987,7 +2987,7 @@ end:
 // list or watch objects of kind ClusterRole
 //
 v1beta1_cluster_role_list_t*
-RbacAuthorizationV1beta1API_listClusterRole(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1beta1API_listClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3251,7 +3251,7 @@ end:
 // list or watch objects of kind ClusterRoleBinding
 //
 v1beta1_cluster_role_binding_list_t*
-RbacAuthorizationV1beta1API_listClusterRoleBinding(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1beta1API_listClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3515,7 +3515,7 @@ end:
 // list or watch objects of kind Role
 //
 v1beta1_role_list_t*
-RbacAuthorizationV1beta1API_listNamespacedRole(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1beta1API_listNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3790,7 +3790,7 @@ end:
 // list or watch objects of kind RoleBinding
 //
 v1beta1_role_binding_list_t*
-RbacAuthorizationV1beta1API_listNamespacedRoleBinding(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1beta1API_listNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4065,7 +4065,7 @@ end:
 // list or watch objects of kind RoleBinding
 //
 v1beta1_role_binding_list_t*
-RbacAuthorizationV1beta1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1beta1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4329,7 +4329,7 @@ end:
 // list or watch objects of kind Role
 //
 v1beta1_role_list_t*
-RbacAuthorizationV1beta1API_listRoleForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+RbacAuthorizationV1beta1API_listRoleForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4593,7 +4593,7 @@ end:
 // partially update the specified ClusterRole
 //
 v1beta1_cluster_role_t*
-RbacAuthorizationV1beta1API_patchClusterRole(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1beta1API_patchClusterRole(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4773,7 +4773,7 @@ end:
 // partially update the specified ClusterRoleBinding
 //
 v1beta1_cluster_role_binding_t*
-RbacAuthorizationV1beta1API_patchClusterRoleBinding(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1beta1API_patchClusterRoleBinding(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4953,7 +4953,7 @@ end:
 // partially update the specified Role
 //
 v1beta1_role_t*
-RbacAuthorizationV1beta1API_patchNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1beta1API_patchNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5144,7 +5144,7 @@ end:
 // partially update the specified RoleBinding
 //
 v1beta1_role_binding_t*
-RbacAuthorizationV1beta1API_patchNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+RbacAuthorizationV1beta1API_patchNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5335,7 +5335,7 @@ end:
 // read the specified ClusterRole
 //
 v1beta1_cluster_role_t*
-RbacAuthorizationV1beta1API_readClusterRole(apiClient_t *apiClient, char * name, char * pretty)
+RbacAuthorizationV1beta1API_readClusterRole(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5432,7 +5432,7 @@ end:
 // read the specified ClusterRoleBinding
 //
 v1beta1_cluster_role_binding_t*
-RbacAuthorizationV1beta1API_readClusterRoleBinding(apiClient_t *apiClient, char * name, char * pretty)
+RbacAuthorizationV1beta1API_readClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5529,7 +5529,7 @@ end:
 // read the specified Role
 //
 v1beta1_role_t*
-RbacAuthorizationV1beta1API_readNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+RbacAuthorizationV1beta1API_readNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5637,7 +5637,7 @@ end:
 // read the specified RoleBinding
 //
 v1beta1_role_binding_t*
-RbacAuthorizationV1beta1API_readNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, char * pretty)
+RbacAuthorizationV1beta1API_readNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5745,7 +5745,7 @@ end:
 // replace the specified ClusterRole
 //
 v1beta1_cluster_role_t*
-RbacAuthorizationV1beta1API_replaceClusterRole(apiClient_t *apiClient, char * name, v1beta1_cluster_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1beta1API_replaceClusterRole(apiClient_t *apiClient, char * name , v1beta1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5904,7 +5904,7 @@ end:
 // replace the specified ClusterRoleBinding
 //
 v1beta1_cluster_role_binding_t*
-RbacAuthorizationV1beta1API_replaceClusterRoleBinding(apiClient_t *apiClient, char * name, v1beta1_cluster_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1beta1API_replaceClusterRoleBinding(apiClient_t *apiClient, char * name , v1beta1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6063,7 +6063,7 @@ end:
 // replace the specified Role
 //
 v1beta1_role_t*
-RbacAuthorizationV1beta1API_replaceNamespacedRole(apiClient_t *apiClient, char * name, char * namespace, v1beta1_role_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1beta1API_replaceNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , v1beta1_role_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -6233,7 +6233,7 @@ end:
 // replace the specified RoleBinding
 //
 v1beta1_role_binding_t*
-RbacAuthorizationV1beta1API_replaceNamespacedRoleBinding(apiClient_t *apiClient, char * name, char * namespace, v1beta1_role_binding_t * body, char * pretty, char * dryRun, char * fieldManager)
+RbacAuthorizationV1beta1API_replaceNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , v1beta1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/RbacAuthorizationV1beta1API.h
+++ b/kubernetes/api/RbacAuthorizationV1beta1API.h
@@ -20,73 +20,73 @@
 // create a ClusterRole
 //
 v1beta1_cluster_role_t*
-RbacAuthorizationV1beta1API_createClusterRole(apiClient_t *apiClient ,v1beta1_cluster_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1beta1API_createClusterRole(apiClient_t *apiClient, v1beta1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a ClusterRoleBinding
 //
 v1beta1_cluster_role_binding_t*
-RbacAuthorizationV1beta1API_createClusterRoleBinding(apiClient_t *apiClient ,v1beta1_cluster_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1beta1API_createClusterRoleBinding(apiClient_t *apiClient, v1beta1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a Role
 //
 v1beta1_role_t*
-RbacAuthorizationV1beta1API_createNamespacedRole(apiClient_t *apiClient ,char * namespace ,v1beta1_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1beta1API_createNamespacedRole(apiClient_t *apiClient, char * namespace , v1beta1_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a RoleBinding
 //
 v1beta1_role_binding_t*
-RbacAuthorizationV1beta1API_createNamespacedRoleBinding(apiClient_t *apiClient ,char * namespace ,v1beta1_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1beta1API_createNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , v1beta1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete a ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteClusterRole(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1beta1API_deleteClusterRole(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteClusterRoleBinding(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1beta1API_deleteClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete collection of ClusterRole
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteCollectionClusterRole(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1beta1API_deleteCollectionClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of ClusterRoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1beta1API_deleteCollectionClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of Role
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteCollectionNamespacedRole(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1beta1API_deleteCollectionNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+RbacAuthorizationV1beta1API_deleteCollectionNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a Role
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1beta1API_deleteNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a RoleBinding
 //
 v1_status_t*
-RbacAuthorizationV1beta1API_deleteNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+RbacAuthorizationV1beta1API_deleteNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -98,108 +98,108 @@ RbacAuthorizationV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind ClusterRole
 //
 v1beta1_cluster_role_list_t*
-RbacAuthorizationV1beta1API_listClusterRole(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1beta1API_listClusterRole(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ClusterRoleBinding
 //
 v1beta1_cluster_role_binding_list_t*
-RbacAuthorizationV1beta1API_listClusterRoleBinding(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1beta1API_listClusterRoleBinding(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Role
 //
 v1beta1_role_list_t*
-RbacAuthorizationV1beta1API_listNamespacedRole(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1beta1API_listNamespacedRole(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind RoleBinding
 //
 v1beta1_role_binding_list_t*
-RbacAuthorizationV1beta1API_listNamespacedRoleBinding(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1beta1API_listNamespacedRoleBinding(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind RoleBinding
 //
 v1beta1_role_binding_list_t*
-RbacAuthorizationV1beta1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1beta1API_listRoleBindingForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Role
 //
 v1beta1_role_list_t*
-RbacAuthorizationV1beta1API_listRoleForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+RbacAuthorizationV1beta1API_listRoleForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified ClusterRole
 //
 v1beta1_cluster_role_t*
-RbacAuthorizationV1beta1API_patchClusterRole(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1beta1API_patchClusterRole(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified ClusterRoleBinding
 //
 v1beta1_cluster_role_binding_t*
-RbacAuthorizationV1beta1API_patchClusterRoleBinding(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1beta1API_patchClusterRoleBinding(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified Role
 //
 v1beta1_role_t*
-RbacAuthorizationV1beta1API_patchNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1beta1API_patchNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified RoleBinding
 //
 v1beta1_role_binding_t*
-RbacAuthorizationV1beta1API_patchNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+RbacAuthorizationV1beta1API_patchNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified ClusterRole
 //
 v1beta1_cluster_role_t*
-RbacAuthorizationV1beta1API_readClusterRole(apiClient_t *apiClient ,char * name ,char * pretty);
+RbacAuthorizationV1beta1API_readClusterRole(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // read the specified ClusterRoleBinding
 //
 v1beta1_cluster_role_binding_t*
-RbacAuthorizationV1beta1API_readClusterRoleBinding(apiClient_t *apiClient ,char * name ,char * pretty);
+RbacAuthorizationV1beta1API_readClusterRoleBinding(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // read the specified Role
 //
 v1beta1_role_t*
-RbacAuthorizationV1beta1API_readNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+RbacAuthorizationV1beta1API_readNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // read the specified RoleBinding
 //
 v1beta1_role_binding_t*
-RbacAuthorizationV1beta1API_readNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty);
+RbacAuthorizationV1beta1API_readNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , char * pretty );
 
 
 // replace the specified ClusterRole
 //
 v1beta1_cluster_role_t*
-RbacAuthorizationV1beta1API_replaceClusterRole(apiClient_t *apiClient ,char * name ,v1beta1_cluster_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1beta1API_replaceClusterRole(apiClient_t *apiClient, char * name , v1beta1_cluster_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified ClusterRoleBinding
 //
 v1beta1_cluster_role_binding_t*
-RbacAuthorizationV1beta1API_replaceClusterRoleBinding(apiClient_t *apiClient ,char * name ,v1beta1_cluster_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1beta1API_replaceClusterRoleBinding(apiClient_t *apiClient, char * name , v1beta1_cluster_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified Role
 //
 v1beta1_role_t*
-RbacAuthorizationV1beta1API_replaceNamespacedRole(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_role_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1beta1API_replaceNamespacedRole(apiClient_t *apiClient, char * name , char * namespace , v1beta1_role_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified RoleBinding
 //
 v1beta1_role_binding_t*
-RbacAuthorizationV1beta1API_replaceNamespacedRoleBinding(apiClient_t *apiClient ,char * name ,char * namespace ,v1beta1_role_binding_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+RbacAuthorizationV1beta1API_replaceNamespacedRoleBinding(apiClient_t *apiClient, char * name , char * namespace , v1beta1_role_binding_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/SchedulingV1API.c
+++ b/kubernetes/api/SchedulingV1API.c
@@ -15,7 +15,7 @@
 // create a PriorityClass
 //
 v1_priority_class_t*
-SchedulingV1API_createPriorityClass(apiClient_t *apiClient, v1_priority_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+SchedulingV1API_createPriorityClass(apiClient_t *apiClient, v1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete collection of PriorityClass
 //
 v1_status_t*
-SchedulingV1API_deleteCollectionPriorityClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+SchedulingV1API_deleteCollectionPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -527,7 +527,7 @@ end:
 // delete a PriorityClass
 //
 v1_status_t*
-SchedulingV1API_deletePriorityClass(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+SchedulingV1API_deletePriorityClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind PriorityClass
 //
 v1_priority_class_list_t*
-SchedulingV1API_listPriorityClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+SchedulingV1API_listPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified PriorityClass
 //
 v1_priority_class_t*
-SchedulingV1API_patchPriorityClass(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+SchedulingV1API_patchPriorityClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // read the specified PriorityClass
 //
 v1_priority_class_t*
-SchedulingV1API_readPriorityClass(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+SchedulingV1API_readPriorityClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1369,7 +1369,7 @@ end:
 // replace the specified PriorityClass
 //
 v1_priority_class_t*
-SchedulingV1API_replacePriorityClass(apiClient_t *apiClient, char * name, v1_priority_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+SchedulingV1API_replacePriorityClass(apiClient_t *apiClient, char * name , v1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/SchedulingV1API.h
+++ b/kubernetes/api/SchedulingV1API.h
@@ -14,19 +14,19 @@
 // create a PriorityClass
 //
 v1_priority_class_t*
-SchedulingV1API_createPriorityClass(apiClient_t *apiClient ,v1_priority_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+SchedulingV1API_createPriorityClass(apiClient_t *apiClient, v1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of PriorityClass
 //
 v1_status_t*
-SchedulingV1API_deleteCollectionPriorityClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+SchedulingV1API_deleteCollectionPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a PriorityClass
 //
 v1_status_t*
-SchedulingV1API_deletePriorityClass(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+SchedulingV1API_deletePriorityClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,24 +38,24 @@ SchedulingV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind PriorityClass
 //
 v1_priority_class_list_t*
-SchedulingV1API_listPriorityClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+SchedulingV1API_listPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified PriorityClass
 //
 v1_priority_class_t*
-SchedulingV1API_patchPriorityClass(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+SchedulingV1API_patchPriorityClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified PriorityClass
 //
 v1_priority_class_t*
-SchedulingV1API_readPriorityClass(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+SchedulingV1API_readPriorityClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified PriorityClass
 //
 v1_priority_class_t*
-SchedulingV1API_replacePriorityClass(apiClient_t *apiClient ,char * name ,v1_priority_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+SchedulingV1API_replacePriorityClass(apiClient_t *apiClient, char * name , v1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/SchedulingV1alpha1API.c
+++ b/kubernetes/api/SchedulingV1alpha1API.c
@@ -15,7 +15,7 @@
 // create a PriorityClass
 //
 v1alpha1_priority_class_t*
-SchedulingV1alpha1API_createPriorityClass(apiClient_t *apiClient, v1alpha1_priority_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+SchedulingV1alpha1API_createPriorityClass(apiClient_t *apiClient, v1alpha1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete collection of PriorityClass
 //
 v1_status_t*
-SchedulingV1alpha1API_deleteCollectionPriorityClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+SchedulingV1alpha1API_deleteCollectionPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -527,7 +527,7 @@ end:
 // delete a PriorityClass
 //
 v1_status_t*
-SchedulingV1alpha1API_deletePriorityClass(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+SchedulingV1alpha1API_deletePriorityClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind PriorityClass
 //
 v1alpha1_priority_class_list_t*
-SchedulingV1alpha1API_listPriorityClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+SchedulingV1alpha1API_listPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified PriorityClass
 //
 v1alpha1_priority_class_t*
-SchedulingV1alpha1API_patchPriorityClass(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+SchedulingV1alpha1API_patchPriorityClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // read the specified PriorityClass
 //
 v1alpha1_priority_class_t*
-SchedulingV1alpha1API_readPriorityClass(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+SchedulingV1alpha1API_readPriorityClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1369,7 +1369,7 @@ end:
 // replace the specified PriorityClass
 //
 v1alpha1_priority_class_t*
-SchedulingV1alpha1API_replacePriorityClass(apiClient_t *apiClient, char * name, v1alpha1_priority_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+SchedulingV1alpha1API_replacePriorityClass(apiClient_t *apiClient, char * name , v1alpha1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/SchedulingV1alpha1API.h
+++ b/kubernetes/api/SchedulingV1alpha1API.h
@@ -14,19 +14,19 @@
 // create a PriorityClass
 //
 v1alpha1_priority_class_t*
-SchedulingV1alpha1API_createPriorityClass(apiClient_t *apiClient ,v1alpha1_priority_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+SchedulingV1alpha1API_createPriorityClass(apiClient_t *apiClient, v1alpha1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of PriorityClass
 //
 v1_status_t*
-SchedulingV1alpha1API_deleteCollectionPriorityClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+SchedulingV1alpha1API_deleteCollectionPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a PriorityClass
 //
 v1_status_t*
-SchedulingV1alpha1API_deletePriorityClass(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+SchedulingV1alpha1API_deletePriorityClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,24 +38,24 @@ SchedulingV1alpha1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind PriorityClass
 //
 v1alpha1_priority_class_list_t*
-SchedulingV1alpha1API_listPriorityClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+SchedulingV1alpha1API_listPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified PriorityClass
 //
 v1alpha1_priority_class_t*
-SchedulingV1alpha1API_patchPriorityClass(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+SchedulingV1alpha1API_patchPriorityClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified PriorityClass
 //
 v1alpha1_priority_class_t*
-SchedulingV1alpha1API_readPriorityClass(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+SchedulingV1alpha1API_readPriorityClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified PriorityClass
 //
 v1alpha1_priority_class_t*
-SchedulingV1alpha1API_replacePriorityClass(apiClient_t *apiClient ,char * name ,v1alpha1_priority_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+SchedulingV1alpha1API_replacePriorityClass(apiClient_t *apiClient, char * name , v1alpha1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/SchedulingV1beta1API.c
+++ b/kubernetes/api/SchedulingV1beta1API.c
@@ -15,7 +15,7 @@
 // create a PriorityClass
 //
 v1beta1_priority_class_t*
-SchedulingV1beta1API_createPriorityClass(apiClient_t *apiClient, v1beta1_priority_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+SchedulingV1beta1API_createPriorityClass(apiClient_t *apiClient, v1beta1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete collection of PriorityClass
 //
 v1_status_t*
-SchedulingV1beta1API_deleteCollectionPriorityClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+SchedulingV1beta1API_deleteCollectionPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -527,7 +527,7 @@ end:
 // delete a PriorityClass
 //
 v1_status_t*
-SchedulingV1beta1API_deletePriorityClass(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+SchedulingV1beta1API_deletePriorityClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind PriorityClass
 //
 v1beta1_priority_class_list_t*
-SchedulingV1beta1API_listPriorityClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+SchedulingV1beta1API_listPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified PriorityClass
 //
 v1beta1_priority_class_t*
-SchedulingV1beta1API_patchPriorityClass(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+SchedulingV1beta1API_patchPriorityClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // read the specified PriorityClass
 //
 v1beta1_priority_class_t*
-SchedulingV1beta1API_readPriorityClass(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+SchedulingV1beta1API_readPriorityClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1369,7 +1369,7 @@ end:
 // replace the specified PriorityClass
 //
 v1beta1_priority_class_t*
-SchedulingV1beta1API_replacePriorityClass(apiClient_t *apiClient, char * name, v1beta1_priority_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+SchedulingV1beta1API_replacePriorityClass(apiClient_t *apiClient, char * name , v1beta1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/SchedulingV1beta1API.h
+++ b/kubernetes/api/SchedulingV1beta1API.h
@@ -14,19 +14,19 @@
 // create a PriorityClass
 //
 v1beta1_priority_class_t*
-SchedulingV1beta1API_createPriorityClass(apiClient_t *apiClient ,v1beta1_priority_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+SchedulingV1beta1API_createPriorityClass(apiClient_t *apiClient, v1beta1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of PriorityClass
 //
 v1_status_t*
-SchedulingV1beta1API_deleteCollectionPriorityClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+SchedulingV1beta1API_deleteCollectionPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a PriorityClass
 //
 v1_status_t*
-SchedulingV1beta1API_deletePriorityClass(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+SchedulingV1beta1API_deletePriorityClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,24 +38,24 @@ SchedulingV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind PriorityClass
 //
 v1beta1_priority_class_list_t*
-SchedulingV1beta1API_listPriorityClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+SchedulingV1beta1API_listPriorityClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified PriorityClass
 //
 v1beta1_priority_class_t*
-SchedulingV1beta1API_patchPriorityClass(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+SchedulingV1beta1API_patchPriorityClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified PriorityClass
 //
 v1beta1_priority_class_t*
-SchedulingV1beta1API_readPriorityClass(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+SchedulingV1beta1API_readPriorityClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified PriorityClass
 //
 v1beta1_priority_class_t*
-SchedulingV1beta1API_replacePriorityClass(apiClient_t *apiClient ,char * name ,v1beta1_priority_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+SchedulingV1beta1API_replacePriorityClass(apiClient_t *apiClient, char * name , v1beta1_priority_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/SettingsV1alpha1API.c
+++ b/kubernetes/api/SettingsV1alpha1API.c
@@ -15,7 +15,7 @@
 // create a PodPreset
 //
 v1alpha1_pod_preset_t*
-SettingsV1alpha1API_createNamespacedPodPreset(apiClient_t *apiClient, char * namespace, v1alpha1_pod_preset_t * body, char * pretty, char * dryRun, char * fieldManager)
+SettingsV1alpha1API_createNamespacedPodPreset(apiClient_t *apiClient, char * namespace , v1alpha1_pod_preset_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -177,7 +177,7 @@ end:
 // delete collection of PodPreset
 //
 v1_status_t*
-SettingsV1alpha1API_deleteCollectionNamespacedPodPreset(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+SettingsV1alpha1API_deleteCollectionNamespacedPodPreset(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -549,7 +549,7 @@ end:
 // delete a PodPreset
 //
 v1_status_t*
-SettingsV1alpha1API_deleteNamespacedPodPreset(apiClient_t *apiClient, char * name, char * namespace, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+SettingsV1alpha1API_deleteNamespacedPodPreset(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -821,7 +821,7 @@ end:
 // list or watch objects of kind PodPreset
 //
 v1alpha1_pod_preset_list_t*
-SettingsV1alpha1API_listNamespacedPodPreset(apiClient_t *apiClient, char * namespace, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+SettingsV1alpha1API_listNamespacedPodPreset(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1096,7 +1096,7 @@ end:
 // list or watch objects of kind PodPreset
 //
 v1alpha1_pod_preset_list_t*
-SettingsV1alpha1API_listPodPresetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * pretty, char * resourceVersion, int timeoutSeconds, int watch)
+SettingsV1alpha1API_listPodPresetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1360,7 +1360,7 @@ end:
 // partially update the specified PodPreset
 //
 v1alpha1_pod_preset_t*
-SettingsV1alpha1API_patchNamespacedPodPreset(apiClient_t *apiClient, char * name, char * namespace, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+SettingsV1alpha1API_patchNamespacedPodPreset(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1551,7 +1551,7 @@ end:
 // read the specified PodPreset
 //
 v1alpha1_pod_preset_t*
-SettingsV1alpha1API_readNamespacedPodPreset(apiClient_t *apiClient, char * name, char * namespace, char * pretty, int exact, int export)
+SettingsV1alpha1API_readNamespacedPodPreset(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1699,7 +1699,7 @@ end:
 // replace the specified PodPreset
 //
 v1alpha1_pod_preset_t*
-SettingsV1alpha1API_replaceNamespacedPodPreset(apiClient_t *apiClient, char * name, char * namespace, v1alpha1_pod_preset_t * body, char * pretty, char * dryRun, char * fieldManager)
+SettingsV1alpha1API_replaceNamespacedPodPreset(apiClient_t *apiClient, char * name , char * namespace , v1alpha1_pod_preset_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/SettingsV1alpha1API.h
+++ b/kubernetes/api/SettingsV1alpha1API.h
@@ -14,19 +14,19 @@
 // create a PodPreset
 //
 v1alpha1_pod_preset_t*
-SettingsV1alpha1API_createNamespacedPodPreset(apiClient_t *apiClient ,char * namespace ,v1alpha1_pod_preset_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+SettingsV1alpha1API_createNamespacedPodPreset(apiClient_t *apiClient, char * namespace , v1alpha1_pod_preset_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of PodPreset
 //
 v1_status_t*
-SettingsV1alpha1API_deleteCollectionNamespacedPodPreset(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+SettingsV1alpha1API_deleteCollectionNamespacedPodPreset(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a PodPreset
 //
 v1_status_t*
-SettingsV1alpha1API_deleteNamespacedPodPreset(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+SettingsV1alpha1API_deleteNamespacedPodPreset(apiClient_t *apiClient, char * name , char * namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,30 +38,30 @@ SettingsV1alpha1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind PodPreset
 //
 v1alpha1_pod_preset_list_t*
-SettingsV1alpha1API_listNamespacedPodPreset(apiClient_t *apiClient ,char * namespace ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+SettingsV1alpha1API_listNamespacedPodPreset(apiClient_t *apiClient, char * namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PodPreset
 //
 v1alpha1_pod_preset_list_t*
-SettingsV1alpha1API_listPodPresetForAllNamespaces(apiClient_t *apiClient ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * pretty ,char * resourceVersion ,int timeoutSeconds ,int watch);
+SettingsV1alpha1API_listPodPresetForAllNamespaces(apiClient_t *apiClient, int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * pretty , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified PodPreset
 //
 v1alpha1_pod_preset_t*
-SettingsV1alpha1API_patchNamespacedPodPreset(apiClient_t *apiClient ,char * name ,char * namespace ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+SettingsV1alpha1API_patchNamespacedPodPreset(apiClient_t *apiClient, char * name , char * namespace , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified PodPreset
 //
 v1alpha1_pod_preset_t*
-SettingsV1alpha1API_readNamespacedPodPreset(apiClient_t *apiClient ,char * name ,char * namespace ,char * pretty ,int exact ,int export);
+SettingsV1alpha1API_readNamespacedPodPreset(apiClient_t *apiClient, char * name , char * namespace , char * pretty , int exact , int export );
 
 
 // replace the specified PodPreset
 //
 v1alpha1_pod_preset_t*
-SettingsV1alpha1API_replaceNamespacedPodPreset(apiClient_t *apiClient ,char * name ,char * namespace ,v1alpha1_pod_preset_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+SettingsV1alpha1API_replaceNamespacedPodPreset(apiClient_t *apiClient, char * name , char * namespace , v1alpha1_pod_preset_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/StorageV1API.c
+++ b/kubernetes/api/StorageV1API.c
@@ -15,7 +15,7 @@
 // create a CSINode
 //
 v1_csi_node_t*
-StorageV1API_createCSINode(apiClient_t *apiClient, v1_csi_node_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1API_createCSINode(apiClient_t *apiClient, v1_csi_node_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // create a StorageClass
 //
 v1_storage_class_t*
-StorageV1API_createStorageClass(apiClient_t *apiClient, v1_storage_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1API_createStorageClass(apiClient_t *apiClient, v1_storage_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -317,7 +317,7 @@ end:
 // create a VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_createVolumeAttachment(apiClient_t *apiClient, v1_volume_attachment_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1API_createVolumeAttachment(apiClient_t *apiClient, v1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -468,7 +468,7 @@ end:
 // delete a CSINode
 //
 v1_status_t*
-StorageV1API_deleteCSINode(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+StorageV1API_deleteCSINode(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -667,7 +667,7 @@ end:
 // delete collection of CSINode
 //
 v1_status_t*
-StorageV1API_deleteCollectionCSINode(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+StorageV1API_deleteCollectionCSINode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1028,7 +1028,7 @@ end:
 // delete collection of StorageClass
 //
 v1_status_t*
-StorageV1API_deleteCollectionStorageClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+StorageV1API_deleteCollectionStorageClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1389,7 +1389,7 @@ end:
 // delete collection of VolumeAttachment
 //
 v1_status_t*
-StorageV1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+StorageV1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1750,7 +1750,7 @@ end:
 // delete a StorageClass
 //
 v1_status_t*
-StorageV1API_deleteStorageClass(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+StorageV1API_deleteStorageClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1949,7 +1949,7 @@ end:
 // delete a VolumeAttachment
 //
 v1_status_t*
-StorageV1API_deleteVolumeAttachment(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+StorageV1API_deleteVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2210,7 +2210,7 @@ end:
 // list or watch objects of kind CSINode
 //
 v1_csi_node_list_t*
-StorageV1API_listCSINode(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+StorageV1API_listCSINode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2474,7 +2474,7 @@ end:
 // list or watch objects of kind StorageClass
 //
 v1_storage_class_list_t*
-StorageV1API_listStorageClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+StorageV1API_listStorageClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2738,7 +2738,7 @@ end:
 // list or watch objects of kind VolumeAttachment
 //
 v1_volume_attachment_list_t*
-StorageV1API_listVolumeAttachment(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+StorageV1API_listVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3002,7 +3002,7 @@ end:
 // partially update the specified CSINode
 //
 v1_csi_node_t*
-StorageV1API_patchCSINode(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+StorageV1API_patchCSINode(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3182,7 +3182,7 @@ end:
 // partially update the specified StorageClass
 //
 v1_storage_class_t*
-StorageV1API_patchStorageClass(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+StorageV1API_patchStorageClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3362,7 +3362,7 @@ end:
 // partially update the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_patchVolumeAttachment(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+StorageV1API_patchVolumeAttachment(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3542,7 +3542,7 @@ end:
 // partially update status of the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_patchVolumeAttachmentStatus(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+StorageV1API_patchVolumeAttachmentStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3722,7 +3722,7 @@ end:
 // read the specified CSINode
 //
 v1_csi_node_t*
-StorageV1API_readCSINode(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+StorageV1API_readCSINode(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3859,7 +3859,7 @@ end:
 // read the specified StorageClass
 //
 v1_storage_class_t*
-StorageV1API_readStorageClass(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+StorageV1API_readStorageClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3996,7 +3996,7 @@ end:
 // read the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_readVolumeAttachment(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+StorageV1API_readVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4133,7 +4133,7 @@ end:
 // read status of the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_readVolumeAttachmentStatus(apiClient_t *apiClient, char * name, char * pretty)
+StorageV1API_readVolumeAttachmentStatus(apiClient_t *apiClient, char * name , char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4230,7 +4230,7 @@ end:
 // replace the specified CSINode
 //
 v1_csi_node_t*
-StorageV1API_replaceCSINode(apiClient_t *apiClient, char * name, v1_csi_node_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1API_replaceCSINode(apiClient_t *apiClient, char * name , v1_csi_node_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4389,7 +4389,7 @@ end:
 // replace the specified StorageClass
 //
 v1_storage_class_t*
-StorageV1API_replaceStorageClass(apiClient_t *apiClient, char * name, v1_storage_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1API_replaceStorageClass(apiClient_t *apiClient, char * name , v1_storage_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4548,7 +4548,7 @@ end:
 // replace the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_replaceVolumeAttachment(apiClient_t *apiClient, char * name, v1_volume_attachment_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1API_replaceVolumeAttachment(apiClient_t *apiClient, char * name , v1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4707,7 +4707,7 @@ end:
 // replace status of the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_replaceVolumeAttachmentStatus(apiClient_t *apiClient, char * name, v1_volume_attachment_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1API_replaceVolumeAttachmentStatus(apiClient_t *apiClient, char * name , v1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/StorageV1API.h
+++ b/kubernetes/api/StorageV1API.h
@@ -18,55 +18,55 @@
 // create a CSINode
 //
 v1_csi_node_t*
-StorageV1API_createCSINode(apiClient_t *apiClient ,v1_csi_node_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1API_createCSINode(apiClient_t *apiClient, v1_csi_node_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a StorageClass
 //
 v1_storage_class_t*
-StorageV1API_createStorageClass(apiClient_t *apiClient ,v1_storage_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1API_createStorageClass(apiClient_t *apiClient, v1_storage_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_createVolumeAttachment(apiClient_t *apiClient ,v1_volume_attachment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1API_createVolumeAttachment(apiClient_t *apiClient, v1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete a CSINode
 //
 v1_status_t*
-StorageV1API_deleteCSINode(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+StorageV1API_deleteCSINode(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete collection of CSINode
 //
 v1_status_t*
-StorageV1API_deleteCollectionCSINode(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+StorageV1API_deleteCollectionCSINode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of StorageClass
 //
 v1_status_t*
-StorageV1API_deleteCollectionStorageClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+StorageV1API_deleteCollectionStorageClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of VolumeAttachment
 //
 v1_status_t*
-StorageV1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+StorageV1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a StorageClass
 //
 v1_status_t*
-StorageV1API_deleteStorageClass(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+StorageV1API_deleteStorageClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a VolumeAttachment
 //
 v1_status_t*
-StorageV1API_deleteVolumeAttachment(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+StorageV1API_deleteVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -78,90 +78,90 @@ StorageV1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind CSINode
 //
 v1_csi_node_list_t*
-StorageV1API_listCSINode(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+StorageV1API_listCSINode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind StorageClass
 //
 v1_storage_class_list_t*
-StorageV1API_listStorageClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+StorageV1API_listStorageClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind VolumeAttachment
 //
 v1_volume_attachment_list_t*
-StorageV1API_listVolumeAttachment(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+StorageV1API_listVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified CSINode
 //
 v1_csi_node_t*
-StorageV1API_patchCSINode(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+StorageV1API_patchCSINode(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified StorageClass
 //
 v1_storage_class_t*
-StorageV1API_patchStorageClass(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+StorageV1API_patchStorageClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_patchVolumeAttachment(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+StorageV1API_patchVolumeAttachment(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update status of the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_patchVolumeAttachmentStatus(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+StorageV1API_patchVolumeAttachmentStatus(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified CSINode
 //
 v1_csi_node_t*
-StorageV1API_readCSINode(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+StorageV1API_readCSINode(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read the specified StorageClass
 //
 v1_storage_class_t*
-StorageV1API_readStorageClass(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+StorageV1API_readStorageClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_readVolumeAttachment(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+StorageV1API_readVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read status of the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_readVolumeAttachmentStatus(apiClient_t *apiClient ,char * name ,char * pretty);
+StorageV1API_readVolumeAttachmentStatus(apiClient_t *apiClient, char * name , char * pretty );
 
 
 // replace the specified CSINode
 //
 v1_csi_node_t*
-StorageV1API_replaceCSINode(apiClient_t *apiClient ,char * name ,v1_csi_node_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1API_replaceCSINode(apiClient_t *apiClient, char * name , v1_csi_node_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified StorageClass
 //
 v1_storage_class_t*
-StorageV1API_replaceStorageClass(apiClient_t *apiClient ,char * name ,v1_storage_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1API_replaceStorageClass(apiClient_t *apiClient, char * name , v1_storage_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_replaceVolumeAttachment(apiClient_t *apiClient ,char * name ,v1_volume_attachment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1API_replaceVolumeAttachment(apiClient_t *apiClient, char * name , v1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace status of the specified VolumeAttachment
 //
 v1_volume_attachment_t*
-StorageV1API_replaceVolumeAttachmentStatus(apiClient_t *apiClient ,char * name ,v1_volume_attachment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1API_replaceVolumeAttachmentStatus(apiClient_t *apiClient, char * name , v1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/StorageV1alpha1API.c
+++ b/kubernetes/api/StorageV1alpha1API.c
@@ -15,7 +15,7 @@
 // create a VolumeAttachment
 //
 v1alpha1_volume_attachment_t*
-StorageV1alpha1API_createVolumeAttachment(apiClient_t *apiClient, v1alpha1_volume_attachment_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1alpha1API_createVolumeAttachment(apiClient_t *apiClient, v1alpha1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // delete collection of VolumeAttachment
 //
 v1_status_t*
-StorageV1alpha1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+StorageV1alpha1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -527,7 +527,7 @@ end:
 // delete a VolumeAttachment
 //
 v1_status_t*
-StorageV1alpha1API_deleteVolumeAttachment(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+StorageV1alpha1API_deleteVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -788,7 +788,7 @@ end:
 // list or watch objects of kind VolumeAttachment
 //
 v1alpha1_volume_attachment_list_t*
-StorageV1alpha1API_listVolumeAttachment(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+StorageV1alpha1API_listVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1052,7 +1052,7 @@ end:
 // partially update the specified VolumeAttachment
 //
 v1alpha1_volume_attachment_t*
-StorageV1alpha1API_patchVolumeAttachment(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+StorageV1alpha1API_patchVolumeAttachment(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1232,7 +1232,7 @@ end:
 // read the specified VolumeAttachment
 //
 v1alpha1_volume_attachment_t*
-StorageV1alpha1API_readVolumeAttachment(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+StorageV1alpha1API_readVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1369,7 +1369,7 @@ end:
 // replace the specified VolumeAttachment
 //
 v1alpha1_volume_attachment_t*
-StorageV1alpha1API_replaceVolumeAttachment(apiClient_t *apiClient, char * name, v1alpha1_volume_attachment_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1alpha1API_replaceVolumeAttachment(apiClient_t *apiClient, char * name , v1alpha1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/StorageV1alpha1API.h
+++ b/kubernetes/api/StorageV1alpha1API.h
@@ -14,19 +14,19 @@
 // create a VolumeAttachment
 //
 v1alpha1_volume_attachment_t*
-StorageV1alpha1API_createVolumeAttachment(apiClient_t *apiClient ,v1alpha1_volume_attachment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1alpha1API_createVolumeAttachment(apiClient_t *apiClient, v1alpha1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete collection of VolumeAttachment
 //
 v1_status_t*
-StorageV1alpha1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+StorageV1alpha1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a VolumeAttachment
 //
 v1_status_t*
-StorageV1alpha1API_deleteVolumeAttachment(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+StorageV1alpha1API_deleteVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -38,24 +38,24 @@ StorageV1alpha1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind VolumeAttachment
 //
 v1alpha1_volume_attachment_list_t*
-StorageV1alpha1API_listVolumeAttachment(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+StorageV1alpha1API_listVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified VolumeAttachment
 //
 v1alpha1_volume_attachment_t*
-StorageV1alpha1API_patchVolumeAttachment(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+StorageV1alpha1API_patchVolumeAttachment(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified VolumeAttachment
 //
 v1alpha1_volume_attachment_t*
-StorageV1alpha1API_readVolumeAttachment(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+StorageV1alpha1API_readVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified VolumeAttachment
 //
 v1alpha1_volume_attachment_t*
-StorageV1alpha1API_replaceVolumeAttachment(apiClient_t *apiClient ,char * name ,v1alpha1_volume_attachment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1alpha1API_replaceVolumeAttachment(apiClient_t *apiClient, char * name , v1alpha1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/api/StorageV1beta1API.c
+++ b/kubernetes/api/StorageV1beta1API.c
@@ -15,7 +15,7 @@
 // create a CSIDriver
 //
 v1beta1_csi_driver_t*
-StorageV1beta1API_createCSIDriver(apiClient_t *apiClient, v1beta1_csi_driver_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1beta1API_createCSIDriver(apiClient_t *apiClient, v1beta1_csi_driver_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -166,7 +166,7 @@ end:
 // create a CSINode
 //
 v1beta1_csi_node_t*
-StorageV1beta1API_createCSINode(apiClient_t *apiClient, v1beta1_csi_node_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1beta1API_createCSINode(apiClient_t *apiClient, v1beta1_csi_node_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -317,7 +317,7 @@ end:
 // create a StorageClass
 //
 v1beta1_storage_class_t*
-StorageV1beta1API_createStorageClass(apiClient_t *apiClient, v1beta1_storage_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1beta1API_createStorageClass(apiClient_t *apiClient, v1beta1_storage_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -468,7 +468,7 @@ end:
 // create a VolumeAttachment
 //
 v1beta1_volume_attachment_t*
-StorageV1beta1API_createVolumeAttachment(apiClient_t *apiClient, v1beta1_volume_attachment_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1beta1API_createVolumeAttachment(apiClient_t *apiClient, v1beta1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -619,7 +619,7 @@ end:
 // delete a CSIDriver
 //
 v1_status_t*
-StorageV1beta1API_deleteCSIDriver(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+StorageV1beta1API_deleteCSIDriver(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -818,7 +818,7 @@ end:
 // delete a CSINode
 //
 v1_status_t*
-StorageV1beta1API_deleteCSINode(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+StorageV1beta1API_deleteCSINode(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1017,7 +1017,7 @@ end:
 // delete collection of CSIDriver
 //
 v1_status_t*
-StorageV1beta1API_deleteCollectionCSIDriver(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+StorageV1beta1API_deleteCollectionCSIDriver(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1378,7 +1378,7 @@ end:
 // delete collection of CSINode
 //
 v1_status_t*
-StorageV1beta1API_deleteCollectionCSINode(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+StorageV1beta1API_deleteCollectionCSINode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1739,7 +1739,7 @@ end:
 // delete collection of StorageClass
 //
 v1_status_t*
-StorageV1beta1API_deleteCollectionStorageClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+StorageV1beta1API_deleteCollectionStorageClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2100,7 +2100,7 @@ end:
 // delete collection of VolumeAttachment
 //
 v1_status_t*
-StorageV1beta1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * dryRun, char * fieldSelector, int gracePeriodSeconds, char * labelSelector, int limit, int orphanDependents, char * propagationPolicy, char * resourceVersion, int timeoutSeconds, int watch, v1_delete_options_t * body)
+StorageV1beta1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2461,7 +2461,7 @@ end:
 // delete a StorageClass
 //
 v1_status_t*
-StorageV1beta1API_deleteStorageClass(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+StorageV1beta1API_deleteStorageClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2660,7 +2660,7 @@ end:
 // delete a VolumeAttachment
 //
 v1_status_t*
-StorageV1beta1API_deleteVolumeAttachment(apiClient_t *apiClient, char * name, char * pretty, char * dryRun, int gracePeriodSeconds, int orphanDependents, char * propagationPolicy, v1_delete_options_t * body)
+StorageV1beta1API_deleteVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -2921,7 +2921,7 @@ end:
 // list or watch objects of kind CSIDriver
 //
 v1beta1_csi_driver_list_t*
-StorageV1beta1API_listCSIDriver(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+StorageV1beta1API_listCSIDriver(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3185,7 +3185,7 @@ end:
 // list or watch objects of kind CSINode
 //
 v1beta1_csi_node_list_t*
-StorageV1beta1API_listCSINode(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+StorageV1beta1API_listCSINode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3449,7 +3449,7 @@ end:
 // list or watch objects of kind StorageClass
 //
 v1beta1_storage_class_list_t*
-StorageV1beta1API_listStorageClass(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+StorageV1beta1API_listStorageClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3713,7 +3713,7 @@ end:
 // list or watch objects of kind VolumeAttachment
 //
 v1beta1_volume_attachment_list_t*
-StorageV1beta1API_listVolumeAttachment(apiClient_t *apiClient, char * pretty, int allowWatchBookmarks, char * _continue, char * fieldSelector, char * labelSelector, int limit, char * resourceVersion, int timeoutSeconds, int watch)
+StorageV1beta1API_listVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -3977,7 +3977,7 @@ end:
 // partially update the specified CSIDriver
 //
 v1beta1_csi_driver_t*
-StorageV1beta1API_patchCSIDriver(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+StorageV1beta1API_patchCSIDriver(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4157,7 +4157,7 @@ end:
 // partially update the specified CSINode
 //
 v1beta1_csi_node_t*
-StorageV1beta1API_patchCSINode(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+StorageV1beta1API_patchCSINode(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4337,7 +4337,7 @@ end:
 // partially update the specified StorageClass
 //
 v1beta1_storage_class_t*
-StorageV1beta1API_patchStorageClass(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+StorageV1beta1API_patchStorageClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4517,7 +4517,7 @@ end:
 // partially update the specified VolumeAttachment
 //
 v1beta1_volume_attachment_t*
-StorageV1beta1API_patchVolumeAttachment(apiClient_t *apiClient, char * name, object_t * body, char * pretty, char * dryRun, char * fieldManager, int force)
+StorageV1beta1API_patchVolumeAttachment(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4697,7 +4697,7 @@ end:
 // read the specified CSIDriver
 //
 v1beta1_csi_driver_t*
-StorageV1beta1API_readCSIDriver(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+StorageV1beta1API_readCSIDriver(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4834,7 +4834,7 @@ end:
 // read the specified CSINode
 //
 v1beta1_csi_node_t*
-StorageV1beta1API_readCSINode(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+StorageV1beta1API_readCSINode(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -4971,7 +4971,7 @@ end:
 // read the specified StorageClass
 //
 v1beta1_storage_class_t*
-StorageV1beta1API_readStorageClass(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+StorageV1beta1API_readStorageClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5108,7 +5108,7 @@ end:
 // read the specified VolumeAttachment
 //
 v1beta1_volume_attachment_t*
-StorageV1beta1API_readVolumeAttachment(apiClient_t *apiClient, char * name, char * pretty, int exact, int export)
+StorageV1beta1API_readVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , int exact , int export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5245,7 +5245,7 @@ end:
 // replace the specified CSIDriver
 //
 v1beta1_csi_driver_t*
-StorageV1beta1API_replaceCSIDriver(apiClient_t *apiClient, char * name, v1beta1_csi_driver_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1beta1API_replaceCSIDriver(apiClient_t *apiClient, char * name , v1beta1_csi_driver_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5404,7 +5404,7 @@ end:
 // replace the specified CSINode
 //
 v1beta1_csi_node_t*
-StorageV1beta1API_replaceCSINode(apiClient_t *apiClient, char * name, v1beta1_csi_node_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1beta1API_replaceCSINode(apiClient_t *apiClient, char * name , v1beta1_csi_node_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5563,7 +5563,7 @@ end:
 // replace the specified StorageClass
 //
 v1beta1_storage_class_t*
-StorageV1beta1API_replaceStorageClass(apiClient_t *apiClient, char * name, v1beta1_storage_class_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1beta1API_replaceStorageClass(apiClient_t *apiClient, char * name , v1beta1_storage_class_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -5722,7 +5722,7 @@ end:
 // replace the specified VolumeAttachment
 //
 v1beta1_volume_attachment_t*
-StorageV1beta1API_replaceVolumeAttachment(apiClient_t *apiClient, char * name, v1beta1_volume_attachment_t * body, char * pretty, char * dryRun, char * fieldManager)
+StorageV1beta1API_replaceVolumeAttachment(apiClient_t *apiClient, char * name , v1beta1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/StorageV1beta1API.h
+++ b/kubernetes/api/StorageV1beta1API.h
@@ -20,73 +20,73 @@
 // create a CSIDriver
 //
 v1beta1_csi_driver_t*
-StorageV1beta1API_createCSIDriver(apiClient_t *apiClient ,v1beta1_csi_driver_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1beta1API_createCSIDriver(apiClient_t *apiClient, v1beta1_csi_driver_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a CSINode
 //
 v1beta1_csi_node_t*
-StorageV1beta1API_createCSINode(apiClient_t *apiClient ,v1beta1_csi_node_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1beta1API_createCSINode(apiClient_t *apiClient, v1beta1_csi_node_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a StorageClass
 //
 v1beta1_storage_class_t*
-StorageV1beta1API_createStorageClass(apiClient_t *apiClient ,v1beta1_storage_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1beta1API_createStorageClass(apiClient_t *apiClient, v1beta1_storage_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // create a VolumeAttachment
 //
 v1beta1_volume_attachment_t*
-StorageV1beta1API_createVolumeAttachment(apiClient_t *apiClient ,v1beta1_volume_attachment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1beta1API_createVolumeAttachment(apiClient_t *apiClient, v1beta1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // delete a CSIDriver
 //
 v1_status_t*
-StorageV1beta1API_deleteCSIDriver(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+StorageV1beta1API_deleteCSIDriver(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a CSINode
 //
 v1_status_t*
-StorageV1beta1API_deleteCSINode(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+StorageV1beta1API_deleteCSINode(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete collection of CSIDriver
 //
 v1_status_t*
-StorageV1beta1API_deleteCollectionCSIDriver(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+StorageV1beta1API_deleteCollectionCSIDriver(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of CSINode
 //
 v1_status_t*
-StorageV1beta1API_deleteCollectionCSINode(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+StorageV1beta1API_deleteCollectionCSINode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of StorageClass
 //
 v1_status_t*
-StorageV1beta1API_deleteCollectionStorageClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+StorageV1beta1API_deleteCollectionStorageClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete collection of VolumeAttachment
 //
 v1_status_t*
-StorageV1beta1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * dryRun ,char * fieldSelector ,int gracePeriodSeconds ,char * labelSelector ,int limit ,int orphanDependents ,char * propagationPolicy ,char * resourceVersion ,int timeoutSeconds ,int watch ,v1_delete_options_t * body);
+StorageV1beta1API_deleteCollectionVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * dryRun , char * fieldSelector , int gracePeriodSeconds , char * labelSelector , int limit , int orphanDependents , char * propagationPolicy , char * resourceVersion , int timeoutSeconds , int watch , v1_delete_options_t * body );
 
 
 // delete a StorageClass
 //
 v1_status_t*
-StorageV1beta1API_deleteStorageClass(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+StorageV1beta1API_deleteStorageClass(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a VolumeAttachment
 //
 v1_status_t*
-StorageV1beta1API_deleteVolumeAttachment(apiClient_t *apiClient ,char * name ,char * pretty ,char * dryRun ,int gracePeriodSeconds ,int orphanDependents ,char * propagationPolicy ,v1_delete_options_t * body);
+StorageV1beta1API_deleteVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // get available resources
@@ -98,96 +98,96 @@ StorageV1beta1API_getAPIResources(apiClient_t *apiClient);
 // list or watch objects of kind CSIDriver
 //
 v1beta1_csi_driver_list_t*
-StorageV1beta1API_listCSIDriver(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+StorageV1beta1API_listCSIDriver(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind CSINode
 //
 v1beta1_csi_node_list_t*
-StorageV1beta1API_listCSINode(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+StorageV1beta1API_listCSINode(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind StorageClass
 //
 v1beta1_storage_class_list_t*
-StorageV1beta1API_listStorageClass(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+StorageV1beta1API_listStorageClass(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind VolumeAttachment
 //
 v1beta1_volume_attachment_list_t*
-StorageV1beta1API_listVolumeAttachment(apiClient_t *apiClient ,char * pretty ,int allowWatchBookmarks ,char * _continue ,char * fieldSelector ,char * labelSelector ,int limit ,char * resourceVersion ,int timeoutSeconds ,int watch);
+StorageV1beta1API_listVolumeAttachment(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified CSIDriver
 //
 v1beta1_csi_driver_t*
-StorageV1beta1API_patchCSIDriver(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+StorageV1beta1API_patchCSIDriver(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified CSINode
 //
 v1beta1_csi_node_t*
-StorageV1beta1API_patchCSINode(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+StorageV1beta1API_patchCSINode(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified StorageClass
 //
 v1beta1_storage_class_t*
-StorageV1beta1API_patchStorageClass(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+StorageV1beta1API_patchStorageClass(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // partially update the specified VolumeAttachment
 //
 v1beta1_volume_attachment_t*
-StorageV1beta1API_patchVolumeAttachment(apiClient_t *apiClient ,char * name ,object_t * body ,char * pretty ,char * dryRun ,char * fieldManager ,int force);
+StorageV1beta1API_patchVolumeAttachment(apiClient_t *apiClient, char * name , object_t * body , char * pretty , char * dryRun , char * fieldManager , int force );
 
 
 // read the specified CSIDriver
 //
 v1beta1_csi_driver_t*
-StorageV1beta1API_readCSIDriver(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+StorageV1beta1API_readCSIDriver(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read the specified CSINode
 //
 v1beta1_csi_node_t*
-StorageV1beta1API_readCSINode(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+StorageV1beta1API_readCSINode(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read the specified StorageClass
 //
 v1beta1_storage_class_t*
-StorageV1beta1API_readStorageClass(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+StorageV1beta1API_readStorageClass(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // read the specified VolumeAttachment
 //
 v1beta1_volume_attachment_t*
-StorageV1beta1API_readVolumeAttachment(apiClient_t *apiClient ,char * name ,char * pretty ,int exact ,int export);
+StorageV1beta1API_readVolumeAttachment(apiClient_t *apiClient, char * name , char * pretty , int exact , int export );
 
 
 // replace the specified CSIDriver
 //
 v1beta1_csi_driver_t*
-StorageV1beta1API_replaceCSIDriver(apiClient_t *apiClient ,char * name ,v1beta1_csi_driver_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1beta1API_replaceCSIDriver(apiClient_t *apiClient, char * name , v1beta1_csi_driver_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified CSINode
 //
 v1beta1_csi_node_t*
-StorageV1beta1API_replaceCSINode(apiClient_t *apiClient ,char * name ,v1beta1_csi_node_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1beta1API_replaceCSINode(apiClient_t *apiClient, char * name , v1beta1_csi_node_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified StorageClass
 //
 v1beta1_storage_class_t*
-StorageV1beta1API_replaceStorageClass(apiClient_t *apiClient ,char * name ,v1beta1_storage_class_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1beta1API_replaceStorageClass(apiClient_t *apiClient, char * name , v1beta1_storage_class_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 
 // replace the specified VolumeAttachment
 //
 v1beta1_volume_attachment_t*
-StorageV1beta1API_replaceVolumeAttachment(apiClient_t *apiClient ,char * name ,v1beta1_volume_attachment_t * body ,char * pretty ,char * dryRun ,char * fieldManager);
+StorageV1beta1API_replaceVolumeAttachment(apiClient_t *apiClient, char * name , v1beta1_volume_attachment_t * body , char * pretty , char * dryRun , char * fieldManager );
 
 

--- a/kubernetes/include/apiClient.h
+++ b/kubernetes/include/apiClient.h
@@ -9,9 +9,17 @@
 #include "../include/list.h"
 #include "../include/keyValuePair.h"
 
+typedef struct sslConfig_t {
+    char *clientCertFile;         /* client certificate */
+    char *clientKeyFile;          /* client private key */
+    char *CACertFile;             /* CA certificate */
+    int  insecureSkipTlsVerify ;  /* 0 -- verify server certificate */
+                                  /* 1 -- skip ssl verify for server certificate */
+} sslConfig_t;
+
 typedef struct apiClient_t {
     char *basePath;
-    char *caPath;
+    sslConfig_t *sslConfig;
     void *dataReceived;
     long response_code;
     list_t *apiKeys;
@@ -26,7 +34,7 @@ typedef struct binary_t
 apiClient_t* apiClient_create();
 
 apiClient_t* apiClient_create_with_base_path(const char *basePath
-, const char *caPath
+, sslConfig_t *sslConfig
 , list_t *apiKeys
 );
 
@@ -34,10 +42,14 @@ void apiClient_free(apiClient_t *apiClient);
 
 void apiClient_invoke(apiClient_t *apiClient,char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, char *bodyParameters, char *requestType);
 
+sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify);
+
+void sslConfig_free(sslConfig_t *sslConfig);
+
 char *strReplace(char *orig, char *rep, char *with);
 
 char *base64encode(const void *b64_encode_this, int encode_this_many_bytes);
 
-char *base64decode(const void *b64_decode_this, int decode_this_many_bytes);
+char *base64decode(const void *b64_decode_this, int decode_this_many_bytes, int *decoded_bytes);
 
 #endif // INCLUDE_API_CLIENT_H

--- a/kubernetes/model/v1_config_map.c
+++ b/kubernetes/model/v1_config_map.c
@@ -71,10 +71,6 @@ cJSON *v1_config_map_convertToJSON(v1_config_map_t *v1_config_map) {
     if (v1_config_map->binary_data) {
     list_ForEach(binary_dataListEntry, v1_config_map->binary_data) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)binary_dataListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -154,11 +150,6 @@ v1_config_map_t *v1_config_map_parseFromJSON(cJSON *v1_config_mapJSON){
     cJSON_ArrayForEach(binary_data_local_map, binary_data)
     {
 		cJSON *localMapObject = binary_data_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(binary_dataList , localMapKeyPair);
     }
     }

--- a/kubernetes/model/v1_json_schema_props.c
+++ b/kubernetes/model/v1_json_schema_props.c
@@ -284,10 +284,6 @@ cJSON *v1_json_schema_props_convertToJSON(v1_json_schema_props_t *v1_json_schema
     if (v1_json_schema_props->definitions) {
     list_ForEach(definitionsListEntry, v1_json_schema_props->definitions) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)definitionsListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -304,10 +300,6 @@ cJSON *v1_json_schema_props_convertToJSON(v1_json_schema_props_t *v1_json_schema
     if (v1_json_schema_props->dependencies) {
     list_ForEach(dependenciesListEntry, v1_json_schema_props->dependencies) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)dependenciesListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -544,10 +536,6 @@ cJSON *v1_json_schema_props_convertToJSON(v1_json_schema_props_t *v1_json_schema
     if (v1_json_schema_props->pattern_properties) {
     list_ForEach(pattern_propertiesListEntry, v1_json_schema_props->pattern_properties) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)pattern_propertiesListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -564,10 +552,6 @@ cJSON *v1_json_schema_props_convertToJSON(v1_json_schema_props_t *v1_json_schema
     if (v1_json_schema_props->properties) {
     list_ForEach(propertiesListEntry, v1_json_schema_props->properties) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)propertiesListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -778,11 +762,6 @@ v1_json_schema_props_t *v1_json_schema_props_parseFromJSON(cJSON *v1_json_schema
     cJSON_ArrayForEach(definitions_local_map, definitions)
     {
 		cJSON *localMapObject = definitions_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(definitionsList , localMapKeyPair);
     }
     }
@@ -800,11 +779,6 @@ v1_json_schema_props_t *v1_json_schema_props_parseFromJSON(cJSON *v1_json_schema
     cJSON_ArrayForEach(dependencies_local_map, dependencies)
     {
 		cJSON *localMapObject = dependencies_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(dependenciesList , localMapKeyPair);
     }
     }
@@ -1038,11 +1012,6 @@ v1_json_schema_props_t *v1_json_schema_props_parseFromJSON(cJSON *v1_json_schema
     cJSON_ArrayForEach(pattern_properties_local_map, pattern_properties)
     {
 		cJSON *localMapObject = pattern_properties_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(pattern_propertiesList , localMapKeyPair);
     }
     }
@@ -1060,11 +1029,6 @@ v1_json_schema_props_t *v1_json_schema_props_parseFromJSON(cJSON *v1_json_schema
     cJSON_ArrayForEach(properties_local_map, properties)
     {
 		cJSON *localMapObject = properties_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(propertiesList , localMapKeyPair);
     }
     }

--- a/kubernetes/model/v1_secret.c
+++ b/kubernetes/model/v1_secret.c
@@ -74,10 +74,6 @@ cJSON *v1_secret_convertToJSON(v1_secret_t *v1_secret) {
     if (v1_secret->data) {
     list_ForEach(dataListEntry, v1_secret->data) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)dataListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -165,11 +161,6 @@ v1_secret_t *v1_secret_parseFromJSON(cJSON *v1_secretJSON){
     cJSON_ArrayForEach(data_local_map, data)
     {
 		cJSON *localMapObject = data_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(dataList , localMapKeyPair);
     }
     }

--- a/kubernetes/model/v1_subject_access_review_spec.c
+++ b/kubernetes/model/v1_subject_access_review_spec.c
@@ -64,10 +64,6 @@ cJSON *v1_subject_access_review_spec_convertToJSON(v1_subject_access_review_spec
     if (v1_subject_access_review_spec->extra) {
     list_ForEach(extraListEntry, v1_subject_access_review_spec->extra) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)extraListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -156,11 +152,6 @@ v1_subject_access_review_spec_t *v1_subject_access_review_spec_parseFromJSON(cJS
     cJSON_ArrayForEach(extra_local_map, extra)
     {
 		cJSON *localMapObject = extra_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(extraList , localMapKeyPair);
     }
     }

--- a/kubernetes/model/v1_user_info.c
+++ b/kubernetes/model/v1_user_info.c
@@ -58,10 +58,6 @@ cJSON *v1_user_info_convertToJSON(v1_user_info_t *v1_user_info) {
     if (v1_user_info->extra) {
     list_ForEach(extraListEntry, v1_user_info->extra) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)extraListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -124,11 +120,6 @@ v1_user_info_t *v1_user_info_parseFromJSON(cJSON *v1_user_infoJSON){
     cJSON_ArrayForEach(extra_local_map, extra)
     {
 		cJSON *localMapObject = extra_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(extraList , localMapKeyPair);
     }
     }

--- a/kubernetes/model/v1beta1_certificate_signing_request_spec.c
+++ b/kubernetes/model/v1beta1_certificate_signing_request_spec.c
@@ -66,10 +66,6 @@ cJSON *v1beta1_certificate_signing_request_spec_convertToJSON(v1beta1_certificat
     if (v1beta1_certificate_signing_request_spec->extra) {
     list_ForEach(extraListEntry, v1beta1_certificate_signing_request_spec->extra) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)extraListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -159,11 +155,6 @@ v1beta1_certificate_signing_request_spec_t *v1beta1_certificate_signing_request_
     cJSON_ArrayForEach(extra_local_map, extra)
     {
 		cJSON *localMapObject = extra_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(extraList , localMapKeyPair);
     }
     }

--- a/kubernetes/model/v1beta1_json_schema_props.c
+++ b/kubernetes/model/v1beta1_json_schema_props.c
@@ -284,10 +284,6 @@ cJSON *v1beta1_json_schema_props_convertToJSON(v1beta1_json_schema_props_t *v1be
     if (v1beta1_json_schema_props->definitions) {
     list_ForEach(definitionsListEntry, v1beta1_json_schema_props->definitions) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)definitionsListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -304,10 +300,6 @@ cJSON *v1beta1_json_schema_props_convertToJSON(v1beta1_json_schema_props_t *v1be
     if (v1beta1_json_schema_props->dependencies) {
     list_ForEach(dependenciesListEntry, v1beta1_json_schema_props->dependencies) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)dependenciesListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -544,10 +536,6 @@ cJSON *v1beta1_json_schema_props_convertToJSON(v1beta1_json_schema_props_t *v1be
     if (v1beta1_json_schema_props->pattern_properties) {
     list_ForEach(pattern_propertiesListEntry, v1beta1_json_schema_props->pattern_properties) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)pattern_propertiesListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -564,10 +552,6 @@ cJSON *v1beta1_json_schema_props_convertToJSON(v1beta1_json_schema_props_t *v1be
     if (v1beta1_json_schema_props->properties) {
     list_ForEach(propertiesListEntry, v1beta1_json_schema_props->properties) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)propertiesListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -778,11 +762,6 @@ v1beta1_json_schema_props_t *v1beta1_json_schema_props_parseFromJSON(cJSON *v1be
     cJSON_ArrayForEach(definitions_local_map, definitions)
     {
 		cJSON *localMapObject = definitions_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(definitionsList , localMapKeyPair);
     }
     }
@@ -800,11 +779,6 @@ v1beta1_json_schema_props_t *v1beta1_json_schema_props_parseFromJSON(cJSON *v1be
     cJSON_ArrayForEach(dependencies_local_map, dependencies)
     {
 		cJSON *localMapObject = dependencies_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(dependenciesList , localMapKeyPair);
     }
     }
@@ -1038,11 +1012,6 @@ v1beta1_json_schema_props_t *v1beta1_json_schema_props_parseFromJSON(cJSON *v1be
     cJSON_ArrayForEach(pattern_properties_local_map, pattern_properties)
     {
 		cJSON *localMapObject = pattern_properties_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(pattern_propertiesList , localMapKeyPair);
     }
     }
@@ -1060,11 +1029,6 @@ v1beta1_json_schema_props_t *v1beta1_json_schema_props_parseFromJSON(cJSON *v1be
     cJSON_ArrayForEach(properties_local_map, properties)
     {
 		cJSON *localMapObject = properties_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(propertiesList , localMapKeyPair);
     }
     }

--- a/kubernetes/model/v1beta1_pod_disruption_budget_status.c
+++ b/kubernetes/model/v1beta1_pod_disruption_budget_status.c
@@ -76,10 +76,6 @@ cJSON *v1beta1_pod_disruption_budget_status_convertToJSON(v1beta1_pod_disruption
     if (v1beta1_pod_disruption_budget_status->disrupted_pods) {
     list_ForEach(disrupted_podsListEntry, v1beta1_pod_disruption_budget_status->disrupted_pods) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)disrupted_podsListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -161,11 +157,6 @@ v1beta1_pod_disruption_budget_status_t *v1beta1_pod_disruption_budget_status_par
     cJSON_ArrayForEach(disrupted_pods_local_map, disrupted_pods)
     {
 		cJSON *localMapObject = disrupted_pods_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(disrupted_podsList , localMapKeyPair);
     }
     }

--- a/kubernetes/model/v1beta1_subject_access_review_spec.c
+++ b/kubernetes/model/v1beta1_subject_access_review_spec.c
@@ -64,10 +64,6 @@ cJSON *v1beta1_subject_access_review_spec_convertToJSON(v1beta1_subject_access_r
     if (v1beta1_subject_access_review_spec->extra) {
     list_ForEach(extraListEntry, v1beta1_subject_access_review_spec->extra) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)extraListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -156,11 +152,6 @@ v1beta1_subject_access_review_spec_t *v1beta1_subject_access_review_spec_parseFr
     cJSON_ArrayForEach(extra_local_map, extra)
     {
 		cJSON *localMapObject = extra_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(extraList , localMapKeyPair);
     }
     }

--- a/kubernetes/model/v1beta1_user_info.c
+++ b/kubernetes/model/v1beta1_user_info.c
@@ -58,10 +58,6 @@ cJSON *v1beta1_user_info_convertToJSON(v1beta1_user_info_t *v1beta1_user_info) {
     if (v1beta1_user_info->extra) {
     list_ForEach(extraListEntry, v1beta1_user_info->extra) {
         keyValuePair_t *localKeyValue = (keyValuePair_t*)extraListEntry->data;
-        if(cJSON_AddNumberToObject(localMapObject, localKeyValue->key, *(double *)localKeyValue->value) == NULL)
-        {
-            goto fail;
-        }
     }
     }
      } 
@@ -124,11 +120,6 @@ v1beta1_user_info_t *v1beta1_user_info_parseFromJSON(cJSON *v1beta1_user_infoJSO
     cJSON_ArrayForEach(extra_local_map, extra)
     {
 		cJSON *localMapObject = extra_local_map;
-        if(!cJSON_IsNumber(localMapObject))
-        {
-            goto end;
-        }
-        localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
         list_addElement(extraList , localMapKeyPair);
     }
     }

--- a/kubernetes/src/apiClient.c
+++ b/kubernetes/src/apiClient.c
@@ -13,7 +13,7 @@ apiClient_t *apiClient_create() {
     curl_global_init(CURL_GLOBAL_ALL);
     apiClient_t *apiClient = malloc(sizeof(apiClient_t));
     apiClient->basePath = strdup("http://localhost");
-    apiClient->caPath = NULL;
+    apiClient->sslConfig = NULL;
     apiClient->dataReceived = NULL;
     apiClient->response_code = 0;
     apiClient->apiKeys = NULL;
@@ -22,7 +22,7 @@ apiClient_t *apiClient_create() {
 }
 
 apiClient_t *apiClient_create_with_base_path(const char *basePath
-, const char *caPath
+, sslConfig_t *sslConfig
 , list_t *apiKeys
 ) {
     curl_global_init(CURL_GLOBAL_ALL);
@@ -33,10 +33,10 @@ apiClient_t *apiClient_create_with_base_path(const char *basePath
         apiClient->basePath = strdup("http://localhost");
     }
 
-    if(caPath){
-        apiClient->caPath = strdup(caPath);
+    if(sslConfig){
+        apiClient->sslConfig = sslConfig;
     }else{
-        apiClient->caPath = NULL;
+        apiClient->sslConfig = NULL;
     }
 
     apiClient->dataReceived = NULL;
@@ -60,9 +60,6 @@ void apiClient_free(apiClient_t *apiClient) {
     if(apiClient->basePath) {
         free(apiClient->basePath);
     }
-    if(apiClient->caPath) {
-        free(apiClient->caPath);
-    }
     if(apiClient->apiKeys) {
         listEntry_t *listEntry = NULL;
         list_ForEach(listEntry, apiClient->apiKeys) {
@@ -79,6 +76,33 @@ void apiClient_free(apiClient_t *apiClient) {
     }
     free(apiClient);
     curl_global_cleanup();
+}
+
+sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify) {
+    sslConfig_t *sslConfig = calloc(1, sizeof(sslConfig_t));
+    if ( clientCertFile ) {
+        sslConfig->clientCertFile = strdup(clientCertFile);
+    }
+    if ( clientKeyFile ) {
+        sslConfig->clientKeyFile = strdup(clientKeyFile);
+    }
+    if ( CACertFile ) {
+        sslConfig->CACertFile = strdup(CACertFile);
+    }
+    sslConfig->insecureSkipTlsVerify = insecureSkipTlsVerify;
+}
+
+void sslConfig_free(sslConfig_t *sslConfig) {
+    if ( sslConfig->clientCertFile ) {
+        free(sslConfig->clientCertFile);
+    }
+    if ( sslConfig->clientKeyFile ) {
+        free(sslConfig->clientKeyFile);
+    }
+    if ( sslConfig->CACertFile ){
+        free(sslConfig->CACertFile);
+    }
+    free(sslConfig);
 }
 
 void replaceSpaceWithPlus(char *stringToProcess) {
@@ -337,13 +361,27 @@ void apiClient_invoke(apiClient_t    *apiClient,
             }
         }
 
-        if( strstr(apiClient->basePath, "https") != NULL ){
-            if (apiClient->caPath) {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, true);
-                curl_easy_setopt(handle, CURLOPT_CAINFO, apiClient->caPath);
+        if ( strstr(apiClient->basePath, "https") != NULL ) {
+            if ( apiClient->sslConfig ) {
+                if( apiClient->sslConfig->clientCertFile ) {
+                    curl_easy_setopt(handle, CURLOPT_SSLCERT, apiClient->sslConfig->clientCertFile);
+                }
+                if( apiClient->sslConfig->clientKeyFile ) {
+                    curl_easy_setopt(handle, CURLOPT_SSLKEY, apiClient->sslConfig->clientKeyFile);
+                }
+                if( apiClient->sslConfig->CACertFile ) {
+                    curl_easy_setopt(handle, CURLOPT_CAINFO, apiClient->sslConfig->CACertFile);
+                }
+                if ( 1 == apiClient->sslConfig->insecureSkipTlsVerify ) {
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
+                } else {
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 1L);
+                    curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 2L);
+                }
             } else {
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, false);
-                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, false);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
+                curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
             }
         }
 
@@ -479,7 +517,7 @@ char *strReplace(char *orig, char *rep, char *with) {
     return result;
 }
 
-char *sbi_base64encode (const void *b64_encode_this, int encode_this_many_bytes){
+char *base64encode(const void *b64_encode_this, int encode_this_many_bytes) {
 #ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     BUF_MEM *mem_bio_mem_ptr;    //Pointer to a "memory BIO" structure holding our base64 data.
@@ -498,7 +536,7 @@ char *sbi_base64encode (const void *b64_encode_this, int encode_this_many_bytes)
 #endif
 }
 
-char *sbi_base64decode (const void *b64_decode_this, int decode_this_many_bytes){
+char *base64decode(const void *b64_decode_this, int decode_this_many_bytes, int *decoded_bytes) {
 #ifdef OPENSSL
     BIO *b64_bio, *mem_bio;      //Declares two OpenSSL BIOs: a base64 filter and a memory BIO.
     char *base64_decoded = calloc( (decode_this_many_bytes*3)/4+1, sizeof(char) ); //+1 = null.
@@ -512,6 +550,7 @@ char *sbi_base64decode (const void *b64_decode_this, int decode_this_many_bytes)
         decoded_byte_index++; //Increment the index until read of BIO decoded data is complete.
     } //Once we're done reading decoded data, BIO_read returns -1 even though there's no error.
     BIO_free_all(b64_bio);  //Destroys all BIOs in chain, starting with b64 (i.e. the 1st one).
+    *decoded_bytes = decoded_byte_index;
     return base64_decoded;        //Returns base-64 decoded data with trailing null terminator.
 #endif
 }


### PR DESCRIPTION
To implement the configuration for kubernetes-client/c,  merge 2 PRs from OpenAPITools/openapi-generator repo:

1. Support SSL client authentication for the c client (#5719)
https://github.com/OpenAPITools/openapi-generator/pull/5719

2. Fix base64 decode funtion (#5642)
https://github.com/OpenAPITools/openapi-generator/pull/5642

/cc @brendandburns