### PR TITLE
[Examples] Fix memory leak in example/list_pod

### DIFF
--- a/examples/exec_provider/list_pod_by_exec_provider.c
+++ b/examples/exec_provider/list_pod_by_exec_provider.c
@@ -28,6 +28,8 @@ void list_pod(apiClient_t * apiClient)
             pod = listEntry->data;
             printf("\tThe pod name: %s\n", pod->metadata->name);
         }
+        v1_pod_list_free(pod_list);
+        pod_list = NULL;
     } else {
         printf("Cannot get any pod.\n");
     }

--- a/examples/list_pod/main.c
+++ b/examples/list_pod/main.c
@@ -28,6 +28,8 @@ void list_pod(apiClient_t * apiClient)
             pod = listEntry->data;
             printf("\tThe pod name: %s\n", pod->metadata->name);
         }
+        v1_pod_list_free(pod_list);
+        pod_list = NULL;
     } else {
         printf("Cannot get any pod.\n");
     }

--- a/examples/list_pod_incluster/main.c
+++ b/examples/list_pod_incluster/main.c
@@ -29,6 +29,8 @@ void list_pod(apiClient_t * apiClient)
             pod = listEntry->data;
             printf("\tThe pod name: %s\n", pod->metadata->name);
         }
+        v1_pod_list_free(pod_list);
+        pod_list = NULL;
     } else {
         printf("Cannot get any pod.\n");
     }


### PR DESCRIPTION
Fix the issue #13 

Release the memory of  ```v1_pod_list_t *pod_list``` when it is not used in example/list_pod.

The check result of valgrind for the new code:
```
==10325== All heap blocks were freed -- no leaks are possible
```