### PR TITLE
[Examples] Fix memory leak in example/create_pod

### DIFF
--- a/examples/create_pod/main.c
+++ b/examples/create_pod/main.c
@@ -38,7 +38,9 @@ void create_a_pod(apiClient_t * apiClient)
 
     /* set volume mounts for container  */
     list_t *volumemounts = list_create();
-    v1_volume_mount_t *volmou = v1_volume_mount_create("/test", NULL, "test", 0, NULL, NULL);
+    v1_volume_mount_t *volmou = calloc(1, sizeof(v1_volume_mount_t));
+    volmou->mount_path = strdup("/test");
+    volmou->name = strdup("test");
     list_addElement(volumemounts, volmou);
     con->volume_mounts = volumemounts;
 
@@ -62,6 +64,7 @@ void create_a_pod(apiClient_t * apiClient)
     printf("code=%ld\n", apiClient->response_code);
 
     v1_pod_free(apod);
+    v1_pod_free(podinfo);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Fix the issue #15 

1. Release the memory of  ```v1_pod_t *podinfo``` when it is not used in example/creat_pod.
2. Do not use the function ```v1_volume_mount_create``` to avoid coredump when ```v1_pod_free(podinfo)``` (The detail is described by #14)

The check result of valgrind for the new code:
```
==19567== All heap blocks were freed -- no leaks are possible
```