### PR TITLE
[CI/CD] Update build.yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare
-      run: sudo apt-get install -y libcurl4-openssl-dev uncrustify libyaml-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libcurl4-openssl-dev uncrustify libyaml-dev
     - name: Build client library
       run: |
         cd kubernetes


### PR DESCRIPTION
The build check of Github/Actions failed due to the package of libcurl4-openssl-dev changed. 

Add "apt-get update" before "apt-get install" to fix this issue.



