### PR TITLE
Fix memory leak when a JSON of model fails to parse

### DIFF
--- a/kubernetes/model/admissionregistration_v1_webhook_client_config.c
+++ b/kubernetes/model/admissionregistration_v1_webhook_client_config.c
@@ -115,6 +115,10 @@ admissionregistration_v1_webhook_client_config_t *admissionregistration_v1_webho
 
     return admissionregistration_v1_webhook_client_config_local_var;
 end:
+    if (service_local_nonprim) {
+        admissionregistration_v1_service_reference_free(service_local_nonprim);
+        service_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/admissionregistration_v1beta1_webhook_client_config.c
+++ b/kubernetes/model/admissionregistration_v1beta1_webhook_client_config.c
@@ -115,6 +115,10 @@ admissionregistration_v1beta1_webhook_client_config_t *admissionregistration_v1b
 
     return admissionregistration_v1beta1_webhook_client_config_local_var;
 end:
+    if (service_local_nonprim) {
+        admissionregistration_v1beta1_service_reference_free(service_local_nonprim);
+        service_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/apiextensions_v1_webhook_client_config.c
+++ b/kubernetes/model/apiextensions_v1_webhook_client_config.c
@@ -115,6 +115,10 @@ apiextensions_v1_webhook_client_config_t *apiextensions_v1_webhook_client_config
 
     return apiextensions_v1_webhook_client_config_local_var;
 end:
+    if (service_local_nonprim) {
+        apiextensions_v1_service_reference_free(service_local_nonprim);
+        service_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/apiextensions_v1beta1_webhook_client_config.c
+++ b/kubernetes/model/apiextensions_v1beta1_webhook_client_config.c
@@ -115,6 +115,10 @@ apiextensions_v1beta1_webhook_client_config_t *apiextensions_v1beta1_webhook_cli
 
     return apiextensions_v1beta1_webhook_client_config_local_var;
 end:
+    if (service_local_nonprim) {
+        apiextensions_v1beta1_service_reference_free(service_local_nonprim);
+        service_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/apps_v1beta1_deployment.c
+++ b/kubernetes/model/apps_v1beta1_deployment.c
@@ -173,6 +173,18 @@ apps_v1beta1_deployment_t *apps_v1beta1_deployment_parseFromJSON(cJSON *apps_v1b
 
     return apps_v1beta1_deployment_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        apps_v1beta1_deployment_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        apps_v1beta1_deployment_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/apps_v1beta1_deployment_list.c
+++ b/kubernetes/model/apps_v1beta1_deployment_list.c
@@ -176,6 +176,10 @@ apps_v1beta1_deployment_list_t *apps_v1beta1_deployment_list_parseFromJSON(cJSON
 
     return apps_v1beta1_deployment_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/apps_v1beta1_deployment_rollback.c
+++ b/kubernetes/model/apps_v1beta1_deployment_rollback.c
@@ -208,6 +208,10 @@ apps_v1beta1_deployment_rollback_t *apps_v1beta1_deployment_rollback_parseFromJS
 
     return apps_v1beta1_deployment_rollback_local_var;
 end:
+    if (rollback_to_local_nonprim) {
+        apps_v1beta1_rollback_config_free(rollback_to_local_nonprim);
+        rollback_to_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/apps_v1beta1_deployment_spec.c
+++ b/kubernetes/model/apps_v1beta1_deployment_spec.c
@@ -257,6 +257,22 @@ apps_v1beta1_deployment_spec_t *apps_v1beta1_deployment_spec_parseFromJSON(cJSON
 
     return apps_v1beta1_deployment_spec_local_var;
 end:
+    if (rollback_to_local_nonprim) {
+        apps_v1beta1_rollback_config_free(rollback_to_local_nonprim);
+        rollback_to_local_nonprim = NULL;
+    }
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (strategy_local_nonprim) {
+        apps_v1beta1_deployment_strategy_free(strategy_local_nonprim);
+        strategy_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/apps_v1beta1_deployment_strategy.c
+++ b/kubernetes/model/apps_v1beta1_deployment_strategy.c
@@ -95,6 +95,10 @@ apps_v1beta1_deployment_strategy_t *apps_v1beta1_deployment_strategy_parseFromJS
 
     return apps_v1beta1_deployment_strategy_local_var;
 end:
+    if (rolling_update_local_nonprim) {
+        apps_v1beta1_rolling_update_deployment_free(rolling_update_local_nonprim);
+        rolling_update_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/apps_v1beta1_scale.c
+++ b/kubernetes/model/apps_v1beta1_scale.c
@@ -173,6 +173,18 @@ apps_v1beta1_scale_t *apps_v1beta1_scale_parseFromJSON(cJSON *apps_v1beta1_scale
 
     return apps_v1beta1_scale_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        apps_v1beta1_scale_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        apps_v1beta1_scale_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_deployment.c
+++ b/kubernetes/model/extensions_v1beta1_deployment.c
@@ -173,6 +173,18 @@ extensions_v1beta1_deployment_t *extensions_v1beta1_deployment_parseFromJSON(cJS
 
     return extensions_v1beta1_deployment_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        extensions_v1beta1_deployment_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        extensions_v1beta1_deployment_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_deployment_list.c
+++ b/kubernetes/model/extensions_v1beta1_deployment_list.c
@@ -176,6 +176,10 @@ extensions_v1beta1_deployment_list_t *extensions_v1beta1_deployment_list_parseFr
 
     return extensions_v1beta1_deployment_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_deployment_rollback.c
+++ b/kubernetes/model/extensions_v1beta1_deployment_rollback.c
@@ -208,6 +208,10 @@ extensions_v1beta1_deployment_rollback_t *extensions_v1beta1_deployment_rollback
 
     return extensions_v1beta1_deployment_rollback_local_var;
 end:
+    if (rollback_to_local_nonprim) {
+        extensions_v1beta1_rollback_config_free(rollback_to_local_nonprim);
+        rollback_to_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_deployment_spec.c
+++ b/kubernetes/model/extensions_v1beta1_deployment_spec.c
@@ -257,6 +257,22 @@ extensions_v1beta1_deployment_spec_t *extensions_v1beta1_deployment_spec_parseFr
 
     return extensions_v1beta1_deployment_spec_local_var;
 end:
+    if (rollback_to_local_nonprim) {
+        extensions_v1beta1_rollback_config_free(rollback_to_local_nonprim);
+        rollback_to_local_nonprim = NULL;
+    }
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (strategy_local_nonprim) {
+        extensions_v1beta1_deployment_strategy_free(strategy_local_nonprim);
+        strategy_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_deployment_strategy.c
+++ b/kubernetes/model/extensions_v1beta1_deployment_strategy.c
@@ -95,6 +95,10 @@ extensions_v1beta1_deployment_strategy_t *extensions_v1beta1_deployment_strategy
 
     return extensions_v1beta1_deployment_strategy_local_var;
 end:
+    if (rolling_update_local_nonprim) {
+        extensions_v1beta1_rolling_update_deployment_free(rolling_update_local_nonprim);
+        rolling_update_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_http_ingress_path.c
+++ b/kubernetes/model/extensions_v1beta1_http_ingress_path.c
@@ -100,6 +100,10 @@ extensions_v1beta1_http_ingress_path_t *extensions_v1beta1_http_ingress_path_par
 
     return extensions_v1beta1_http_ingress_path_local_var;
 end:
+    if (backend_local_nonprim) {
+        extensions_v1beta1_ingress_backend_free(backend_local_nonprim);
+        backend_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_ingress.c
+++ b/kubernetes/model/extensions_v1beta1_ingress.c
@@ -173,6 +173,18 @@ extensions_v1beta1_ingress_t *extensions_v1beta1_ingress_parseFromJSON(cJSON *ex
 
     return extensions_v1beta1_ingress_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        extensions_v1beta1_ingress_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        extensions_v1beta1_ingress_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_ingress_list.c
+++ b/kubernetes/model/extensions_v1beta1_ingress_list.c
@@ -176,6 +176,10 @@ extensions_v1beta1_ingress_list_t *extensions_v1beta1_ingress_list_parseFromJSON
 
     return extensions_v1beta1_ingress_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_ingress_rule.c
+++ b/kubernetes/model/extensions_v1beta1_ingress_rule.c
@@ -95,6 +95,10 @@ extensions_v1beta1_ingress_rule_t *extensions_v1beta1_ingress_rule_parseFromJSON
 
     return extensions_v1beta1_ingress_rule_local_var;
 end:
+    if (http_local_nonprim) {
+        extensions_v1beta1_http_ingress_rule_value_free(http_local_nonprim);
+        http_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_ingress_spec.c
+++ b/kubernetes/model/extensions_v1beta1_ingress_spec.c
@@ -175,6 +175,10 @@ extensions_v1beta1_ingress_spec_t *extensions_v1beta1_ingress_spec_parseFromJSON
 
     return extensions_v1beta1_ingress_spec_local_var;
 end:
+    if (backend_local_nonprim) {
+        extensions_v1beta1_ingress_backend_free(backend_local_nonprim);
+        backend_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_ingress_status.c
+++ b/kubernetes/model/extensions_v1beta1_ingress_status.c
@@ -71,6 +71,10 @@ extensions_v1beta1_ingress_status_t *extensions_v1beta1_ingress_status_parseFrom
 
     return extensions_v1beta1_ingress_status_local_var;
 end:
+    if (load_balancer_local_nonprim) {
+        v1_load_balancer_status_free(load_balancer_local_nonprim);
+        load_balancer_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_pod_security_policy.c
+++ b/kubernetes/model/extensions_v1beta1_pod_security_policy.c
@@ -146,6 +146,14 @@ extensions_v1beta1_pod_security_policy_t *extensions_v1beta1_pod_security_policy
 
     return extensions_v1beta1_pod_security_policy_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        extensions_v1beta1_pod_security_policy_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_pod_security_policy_list.c
+++ b/kubernetes/model/extensions_v1beta1_pod_security_policy_list.c
@@ -176,6 +176,10 @@ extensions_v1beta1_pod_security_policy_list_t *extensions_v1beta1_pod_security_p
 
     return extensions_v1beta1_pod_security_policy_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_pod_security_policy_spec.c
+++ b/kubernetes/model/extensions_v1beta1_pod_security_policy_spec.c
@@ -903,6 +903,30 @@ extensions_v1beta1_pod_security_policy_spec_t *extensions_v1beta1_pod_security_p
 
     return extensions_v1beta1_pod_security_policy_spec_local_var;
 end:
+    if (fs_group_local_nonprim) {
+        extensions_v1beta1_fs_group_strategy_options_free(fs_group_local_nonprim);
+        fs_group_local_nonprim = NULL;
+    }
+    if (run_as_group_local_nonprim) {
+        extensions_v1beta1_run_as_group_strategy_options_free(run_as_group_local_nonprim);
+        run_as_group_local_nonprim = NULL;
+    }
+    if (run_as_user_local_nonprim) {
+        extensions_v1beta1_run_as_user_strategy_options_free(run_as_user_local_nonprim);
+        run_as_user_local_nonprim = NULL;
+    }
+    if (runtime_class_local_nonprim) {
+        extensions_v1beta1_runtime_class_strategy_options_free(runtime_class_local_nonprim);
+        runtime_class_local_nonprim = NULL;
+    }
+    if (se_linux_local_nonprim) {
+        extensions_v1beta1_se_linux_strategy_options_free(se_linux_local_nonprim);
+        se_linux_local_nonprim = NULL;
+    }
+    if (supplemental_groups_local_nonprim) {
+        extensions_v1beta1_supplemental_groups_strategy_options_free(supplemental_groups_local_nonprim);
+        supplemental_groups_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_scale.c
+++ b/kubernetes/model/extensions_v1beta1_scale.c
@@ -173,6 +173,18 @@ extensions_v1beta1_scale_t *extensions_v1beta1_scale_parseFromJSON(cJSON *extens
 
     return extensions_v1beta1_scale_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        extensions_v1beta1_scale_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        extensions_v1beta1_scale_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/extensions_v1beta1_se_linux_strategy_options.c
+++ b/kubernetes/model/extensions_v1beta1_se_linux_strategy_options.c
@@ -100,6 +100,10 @@ extensions_v1beta1_se_linux_strategy_options_t *extensions_v1beta1_se_linux_stra
 
     return extensions_v1beta1_se_linux_strategy_options_local_var;
 end:
+    if (se_linux_options_local_nonprim) {
+        v1_se_linux_options_free(se_linux_options_local_nonprim);
+        se_linux_options_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/flowcontrol_v1alpha1_subject.c
+++ b/kubernetes/model/flowcontrol_v1alpha1_subject.c
@@ -154,6 +154,18 @@ flowcontrol_v1alpha1_subject_t *flowcontrol_v1alpha1_subject_parseFromJSON(cJSON
 
     return flowcontrol_v1alpha1_subject_local_var;
 end:
+    if (group_local_nonprim) {
+        v1alpha1_group_subject_free(group_local_nonprim);
+        group_local_nonprim = NULL;
+    }
+    if (service_account_local_nonprim) {
+        v1alpha1_service_account_subject_free(service_account_local_nonprim);
+        service_account_local_nonprim = NULL;
+    }
+    if (user_local_nonprim) {
+        v1alpha1_user_subject_free(user_local_nonprim);
+        user_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/networking_v1beta1_http_ingress_path.c
+++ b/kubernetes/model/networking_v1beta1_http_ingress_path.c
@@ -100,6 +100,10 @@ networking_v1beta1_http_ingress_path_t *networking_v1beta1_http_ingress_path_par
 
     return networking_v1beta1_http_ingress_path_local_var;
 end:
+    if (backend_local_nonprim) {
+        networking_v1beta1_ingress_backend_free(backend_local_nonprim);
+        backend_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/networking_v1beta1_ingress.c
+++ b/kubernetes/model/networking_v1beta1_ingress.c
@@ -173,6 +173,18 @@ networking_v1beta1_ingress_t *networking_v1beta1_ingress_parseFromJSON(cJSON *ne
 
     return networking_v1beta1_ingress_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        networking_v1beta1_ingress_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        networking_v1beta1_ingress_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/networking_v1beta1_ingress_list.c
+++ b/kubernetes/model/networking_v1beta1_ingress_list.c
@@ -176,6 +176,10 @@ networking_v1beta1_ingress_list_t *networking_v1beta1_ingress_list_parseFromJSON
 
     return networking_v1beta1_ingress_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/networking_v1beta1_ingress_rule.c
+++ b/kubernetes/model/networking_v1beta1_ingress_rule.c
@@ -95,6 +95,10 @@ networking_v1beta1_ingress_rule_t *networking_v1beta1_ingress_rule_parseFromJSON
 
     return networking_v1beta1_ingress_rule_local_var;
 end:
+    if (http_local_nonprim) {
+        networking_v1beta1_http_ingress_rule_value_free(http_local_nonprim);
+        http_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/networking_v1beta1_ingress_spec.c
+++ b/kubernetes/model/networking_v1beta1_ingress_spec.c
@@ -175,6 +175,10 @@ networking_v1beta1_ingress_spec_t *networking_v1beta1_ingress_spec_parseFromJSON
 
     return networking_v1beta1_ingress_spec_local_var;
 end:
+    if (backend_local_nonprim) {
+        networking_v1beta1_ingress_backend_free(backend_local_nonprim);
+        backend_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/networking_v1beta1_ingress_status.c
+++ b/kubernetes/model/networking_v1beta1_ingress_status.c
@@ -71,6 +71,10 @@ networking_v1beta1_ingress_status_t *networking_v1beta1_ingress_status_parseFrom
 
     return networking_v1beta1_ingress_status_local_var;
 end:
+    if (load_balancer_local_nonprim) {
+        v1_load_balancer_status_free(load_balancer_local_nonprim);
+        load_balancer_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/policy_v1beta1_pod_security_policy.c
+++ b/kubernetes/model/policy_v1beta1_pod_security_policy.c
@@ -146,6 +146,14 @@ policy_v1beta1_pod_security_policy_t *policy_v1beta1_pod_security_policy_parseFr
 
     return policy_v1beta1_pod_security_policy_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        policy_v1beta1_pod_security_policy_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/policy_v1beta1_pod_security_policy_list.c
+++ b/kubernetes/model/policy_v1beta1_pod_security_policy_list.c
@@ -176,6 +176,10 @@ policy_v1beta1_pod_security_policy_list_t *policy_v1beta1_pod_security_policy_li
 
     return policy_v1beta1_pod_security_policy_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/policy_v1beta1_pod_security_policy_spec.c
+++ b/kubernetes/model/policy_v1beta1_pod_security_policy_spec.c
@@ -903,6 +903,30 @@ policy_v1beta1_pod_security_policy_spec_t *policy_v1beta1_pod_security_policy_sp
 
     return policy_v1beta1_pod_security_policy_spec_local_var;
 end:
+    if (fs_group_local_nonprim) {
+        policy_v1beta1_fs_group_strategy_options_free(fs_group_local_nonprim);
+        fs_group_local_nonprim = NULL;
+    }
+    if (run_as_group_local_nonprim) {
+        policy_v1beta1_run_as_group_strategy_options_free(run_as_group_local_nonprim);
+        run_as_group_local_nonprim = NULL;
+    }
+    if (run_as_user_local_nonprim) {
+        policy_v1beta1_run_as_user_strategy_options_free(run_as_user_local_nonprim);
+        run_as_user_local_nonprim = NULL;
+    }
+    if (runtime_class_local_nonprim) {
+        policy_v1beta1_runtime_class_strategy_options_free(runtime_class_local_nonprim);
+        runtime_class_local_nonprim = NULL;
+    }
+    if (se_linux_local_nonprim) {
+        policy_v1beta1_se_linux_strategy_options_free(se_linux_local_nonprim);
+        se_linux_local_nonprim = NULL;
+    }
+    if (supplemental_groups_local_nonprim) {
+        policy_v1beta1_supplemental_groups_strategy_options_free(supplemental_groups_local_nonprim);
+        supplemental_groups_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/policy_v1beta1_se_linux_strategy_options.c
+++ b/kubernetes/model/policy_v1beta1_se_linux_strategy_options.c
@@ -100,6 +100,10 @@ policy_v1beta1_se_linux_strategy_options_t *policy_v1beta1_se_linux_strategy_opt
 
     return policy_v1beta1_se_linux_strategy_options_local_var;
 end:
+    if (se_linux_options_local_nonprim) {
+        v1_se_linux_options_free(se_linux_options_local_nonprim);
+        se_linux_options_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_affinity.c
+++ b/kubernetes/model/v1_affinity.c
@@ -125,6 +125,18 @@ v1_affinity_t *v1_affinity_parseFromJSON(cJSON *v1_affinityJSON){
 
     return v1_affinity_local_var;
 end:
+    if (node_affinity_local_nonprim) {
+        v1_node_affinity_free(node_affinity_local_nonprim);
+        node_affinity_local_nonprim = NULL;
+    }
+    if (pod_affinity_local_nonprim) {
+        v1_pod_affinity_free(pod_affinity_local_nonprim);
+        pod_affinity_local_nonprim = NULL;
+    }
+    if (pod_anti_affinity_local_nonprim) {
+        v1_pod_anti_affinity_free(pod_anti_affinity_local_nonprim);
+        pod_anti_affinity_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_api_group.c
+++ b/kubernetes/model/v1_api_group.c
@@ -10,7 +10,7 @@ v1_api_group_t *v1_api_group_create(
     char *kind,
     char *name,
     v1_group_version_for_discovery_t *preferred_version,
-    list_t *server_address_by_client_cid_rs,
+    list_t *server_address_by_client_cidrs,
     list_t *versions
     ) {
     v1_api_group_t *v1_api_group_local_var = malloc(sizeof(v1_api_group_t));
@@ -21,7 +21,7 @@ v1_api_group_t *v1_api_group_create(
     v1_api_group_local_var->kind = kind;
     v1_api_group_local_var->name = name;
     v1_api_group_local_var->preferred_version = preferred_version;
-    v1_api_group_local_var->server_address_by_client_cid_rs = server_address_by_client_cid_rs;
+    v1_api_group_local_var->server_address_by_client_cidrs = server_address_by_client_cidrs;
     v1_api_group_local_var->versions = versions;
 
     return v1_api_group_local_var;
@@ -49,12 +49,12 @@ void v1_api_group_free(v1_api_group_t *v1_api_group) {
         v1_group_version_for_discovery_free(v1_api_group->preferred_version);
         v1_api_group->preferred_version = NULL;
     }
-    if (v1_api_group->server_address_by_client_cid_rs) {
-        list_ForEach(listEntry, v1_api_group->server_address_by_client_cid_rs) {
+    if (v1_api_group->server_address_by_client_cidrs) {
+        list_ForEach(listEntry, v1_api_group->server_address_by_client_cidrs) {
             v1_server_address_by_client_cidr_free(listEntry->data);
         }
-        list_free(v1_api_group->server_address_by_client_cid_rs);
-        v1_api_group->server_address_by_client_cid_rs = NULL;
+        list_free(v1_api_group->server_address_by_client_cidrs);
+        v1_api_group->server_address_by_client_cidrs = NULL;
     }
     if (v1_api_group->versions) {
         list_ForEach(listEntry, v1_api_group->versions) {
@@ -108,21 +108,21 @@ cJSON *v1_api_group_convertToJSON(v1_api_group_t *v1_api_group) {
      } 
 
 
-    // v1_api_group->server_address_by_client_cid_rs
-    if(v1_api_group->server_address_by_client_cid_rs) { 
-    cJSON *server_address_by_client_cid_rs = cJSON_AddArrayToObject(item, "serverAddressByClientCIDRs");
-    if(server_address_by_client_cid_rs == NULL) {
+    // v1_api_group->server_address_by_client_cidrs
+    if(v1_api_group->server_address_by_client_cidrs) { 
+    cJSON *server_address_by_client_cidrs = cJSON_AddArrayToObject(item, "serverAddressByClientCIDRs");
+    if(server_address_by_client_cidrs == NULL) {
     goto fail; //nonprimitive container
     }
 
-    listEntry_t *server_address_by_client_cid_rsListEntry;
-    if (v1_api_group->server_address_by_client_cid_rs) {
-    list_ForEach(server_address_by_client_cid_rsListEntry, v1_api_group->server_address_by_client_cid_rs) {
-    cJSON *itemLocal = v1_server_address_by_client_cidr_convertToJSON(server_address_by_client_cid_rsListEntry->data);
+    listEntry_t *server_address_by_client_cidrsListEntry;
+    if (v1_api_group->server_address_by_client_cidrs) {
+    list_ForEach(server_address_by_client_cidrsListEntry, v1_api_group->server_address_by_client_cidrs) {
+    cJSON *itemLocal = v1_server_address_by_client_cidr_convertToJSON(server_address_by_client_cidrsListEntry->data);
     if(itemLocal == NULL) {
     goto fail;
     }
-    cJSON_AddItemToArray(server_address_by_client_cid_rs, itemLocal);
+    cJSON_AddItemToArray(server_address_by_client_cidrs, itemLocal);
     }
     }
      } 
@@ -198,25 +198,25 @@ v1_api_group_t *v1_api_group_parseFromJSON(cJSON *v1_api_groupJSON){
     preferred_version_local_nonprim = v1_group_version_for_discovery_parseFromJSON(preferred_version); //nonprimitive
     }
 
-    // v1_api_group->server_address_by_client_cid_rs
-    cJSON *server_address_by_client_cid_rs = cJSON_GetObjectItemCaseSensitive(v1_api_groupJSON, "serverAddressByClientCIDRs");
-    list_t *server_address_by_client_cid_rsList;
-    if (server_address_by_client_cid_rs) { 
-    cJSON *server_address_by_client_cid_rs_local_nonprimitive;
-    if(!cJSON_IsArray(server_address_by_client_cid_rs)){
+    // v1_api_group->server_address_by_client_cidrs
+    cJSON *server_address_by_client_cidrs = cJSON_GetObjectItemCaseSensitive(v1_api_groupJSON, "serverAddressByClientCIDRs");
+    list_t *server_address_by_client_cidrsList;
+    if (server_address_by_client_cidrs) { 
+    cJSON *server_address_by_client_cidrs_local_nonprimitive;
+    if(!cJSON_IsArray(server_address_by_client_cidrs)){
         goto end; //nonprimitive container
     }
 
-    server_address_by_client_cid_rsList = list_create();
+    server_address_by_client_cidrsList = list_create();
 
-    cJSON_ArrayForEach(server_address_by_client_cid_rs_local_nonprimitive,server_address_by_client_cid_rs )
+    cJSON_ArrayForEach(server_address_by_client_cidrs_local_nonprimitive,server_address_by_client_cidrs )
     {
-        if(!cJSON_IsObject(server_address_by_client_cid_rs_local_nonprimitive)){
+        if(!cJSON_IsObject(server_address_by_client_cidrs_local_nonprimitive)){
             goto end;
         }
-        v1_server_address_by_client_cidr_t *server_address_by_client_cid_rsItem = v1_server_address_by_client_cidr_parseFromJSON(server_address_by_client_cid_rs_local_nonprimitive);
+        v1_server_address_by_client_cidr_t *server_address_by_client_cidrsItem = v1_server_address_by_client_cidr_parseFromJSON(server_address_by_client_cidrs_local_nonprimitive);
 
-        list_addElement(server_address_by_client_cid_rsList, server_address_by_client_cid_rsItem);
+        list_addElement(server_address_by_client_cidrsList, server_address_by_client_cidrsItem);
     }
     }
 
@@ -251,12 +251,16 @@ v1_api_group_t *v1_api_group_parseFromJSON(cJSON *v1_api_groupJSON){
         kind ? strdup(kind->valuestring) : NULL,
         strdup(name->valuestring),
         preferred_version ? preferred_version_local_nonprim : NULL,
-        server_address_by_client_cid_rs ? server_address_by_client_cid_rsList : NULL,
+        server_address_by_client_cidrs ? server_address_by_client_cidrsList : NULL,
         versionsList
         );
 
     return v1_api_group_local_var;
 end:
+    if (preferred_version_local_nonprim) {
+        v1_group_version_for_discovery_free(preferred_version_local_nonprim);
+        preferred_version_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_api_group.h
+++ b/kubernetes/model/v1_api_group.h
@@ -25,7 +25,7 @@ typedef struct v1_api_group_t {
     char *kind; // string
     char *name; // string
     struct v1_group_version_for_discovery_t *preferred_version; //model
-    list_t *server_address_by_client_cid_rs; //nonprimitive container
+    list_t *server_address_by_client_cidrs; //nonprimitive container
     list_t *versions; //nonprimitive container
 
 } v1_api_group_t;
@@ -35,7 +35,7 @@ v1_api_group_t *v1_api_group_create(
     char *kind,
     char *name,
     v1_group_version_for_discovery_t *preferred_version,
-    list_t *server_address_by_client_cid_rs,
+    list_t *server_address_by_client_cidrs,
     list_t *versions
 );
 

--- a/kubernetes/model/v1_api_service.c
+++ b/kubernetes/model/v1_api_service.c
@@ -173,6 +173,18 @@ v1_api_service_t *v1_api_service_parseFromJSON(cJSON *v1_api_serviceJSON){
 
     return v1_api_service_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_api_service_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_api_service_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_api_service_list.c
+++ b/kubernetes/model/v1_api_service_list.c
@@ -176,6 +176,10 @@ v1_api_service_list_t *v1_api_service_list_parseFromJSON(cJSON *v1_api_service_l
 
     return v1_api_service_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_api_service_spec.c
+++ b/kubernetes/model/v1_api_service_spec.c
@@ -214,6 +214,10 @@ v1_api_service_spec_t *v1_api_service_spec_parseFromJSON(cJSON *v1_api_service_s
 
     return v1_api_service_spec_local_var;
 end:
+    if (service_local_nonprim) {
+        apiregistration_v1_service_reference_free(service_local_nonprim);
+        service_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_api_versions.c
+++ b/kubernetes/model/v1_api_versions.c
@@ -8,7 +8,7 @@
 v1_api_versions_t *v1_api_versions_create(
     char *api_version,
     char *kind,
-    list_t *server_address_by_client_cid_rs,
+    list_t *server_address_by_client_cidrs,
     list_t *versions
     ) {
     v1_api_versions_t *v1_api_versions_local_var = malloc(sizeof(v1_api_versions_t));
@@ -17,7 +17,7 @@ v1_api_versions_t *v1_api_versions_create(
     }
     v1_api_versions_local_var->api_version = api_version;
     v1_api_versions_local_var->kind = kind;
-    v1_api_versions_local_var->server_address_by_client_cid_rs = server_address_by_client_cid_rs;
+    v1_api_versions_local_var->server_address_by_client_cidrs = server_address_by_client_cidrs;
     v1_api_versions_local_var->versions = versions;
 
     return v1_api_versions_local_var;
@@ -37,12 +37,12 @@ void v1_api_versions_free(v1_api_versions_t *v1_api_versions) {
         free(v1_api_versions->kind);
         v1_api_versions->kind = NULL;
     }
-    if (v1_api_versions->server_address_by_client_cid_rs) {
-        list_ForEach(listEntry, v1_api_versions->server_address_by_client_cid_rs) {
+    if (v1_api_versions->server_address_by_client_cidrs) {
+        list_ForEach(listEntry, v1_api_versions->server_address_by_client_cidrs) {
             v1_server_address_by_client_cidr_free(listEntry->data);
         }
-        list_free(v1_api_versions->server_address_by_client_cid_rs);
-        v1_api_versions->server_address_by_client_cid_rs = NULL;
+        list_free(v1_api_versions->server_address_by_client_cidrs);
+        v1_api_versions->server_address_by_client_cidrs = NULL;
     }
     if (v1_api_versions->versions) {
         list_ForEach(listEntry, v1_api_versions->versions) {
@@ -73,24 +73,24 @@ cJSON *v1_api_versions_convertToJSON(v1_api_versions_t *v1_api_versions) {
      } 
 
 
-    // v1_api_versions->server_address_by_client_cid_rs
-    if (!v1_api_versions->server_address_by_client_cid_rs) {
+    // v1_api_versions->server_address_by_client_cidrs
+    if (!v1_api_versions->server_address_by_client_cidrs) {
         goto fail;
     }
     
-    cJSON *server_address_by_client_cid_rs = cJSON_AddArrayToObject(item, "serverAddressByClientCIDRs");
-    if(server_address_by_client_cid_rs == NULL) {
+    cJSON *server_address_by_client_cidrs = cJSON_AddArrayToObject(item, "serverAddressByClientCIDRs");
+    if(server_address_by_client_cidrs == NULL) {
     goto fail; //nonprimitive container
     }
 
-    listEntry_t *server_address_by_client_cid_rsListEntry;
-    if (v1_api_versions->server_address_by_client_cid_rs) {
-    list_ForEach(server_address_by_client_cid_rsListEntry, v1_api_versions->server_address_by_client_cid_rs) {
-    cJSON *itemLocal = v1_server_address_by_client_cidr_convertToJSON(server_address_by_client_cid_rsListEntry->data);
+    listEntry_t *server_address_by_client_cidrsListEntry;
+    if (v1_api_versions->server_address_by_client_cidrs) {
+    list_ForEach(server_address_by_client_cidrsListEntry, v1_api_versions->server_address_by_client_cidrs) {
+    cJSON *itemLocal = v1_server_address_by_client_cidr_convertToJSON(server_address_by_client_cidrsListEntry->data);
     if(itemLocal == NULL) {
     goto fail;
     }
-    cJSON_AddItemToArray(server_address_by_client_cid_rs, itemLocal);
+    cJSON_AddItemToArray(server_address_by_client_cidrs, itemLocal);
     }
     }
 
@@ -143,29 +143,29 @@ v1_api_versions_t *v1_api_versions_parseFromJSON(cJSON *v1_api_versionsJSON){
     }
     }
 
-    // v1_api_versions->server_address_by_client_cid_rs
-    cJSON *server_address_by_client_cid_rs = cJSON_GetObjectItemCaseSensitive(v1_api_versionsJSON, "serverAddressByClientCIDRs");
-    if (!server_address_by_client_cid_rs) {
+    // v1_api_versions->server_address_by_client_cidrs
+    cJSON *server_address_by_client_cidrs = cJSON_GetObjectItemCaseSensitive(v1_api_versionsJSON, "serverAddressByClientCIDRs");
+    if (!server_address_by_client_cidrs) {
         goto end;
     }
 
-    list_t *server_address_by_client_cid_rsList;
+    list_t *server_address_by_client_cidrsList;
     
-    cJSON *server_address_by_client_cid_rs_local_nonprimitive;
-    if(!cJSON_IsArray(server_address_by_client_cid_rs)){
+    cJSON *server_address_by_client_cidrs_local_nonprimitive;
+    if(!cJSON_IsArray(server_address_by_client_cidrs)){
         goto end; //nonprimitive container
     }
 
-    server_address_by_client_cid_rsList = list_create();
+    server_address_by_client_cidrsList = list_create();
 
-    cJSON_ArrayForEach(server_address_by_client_cid_rs_local_nonprimitive,server_address_by_client_cid_rs )
+    cJSON_ArrayForEach(server_address_by_client_cidrs_local_nonprimitive,server_address_by_client_cidrs )
     {
-        if(!cJSON_IsObject(server_address_by_client_cid_rs_local_nonprimitive)){
+        if(!cJSON_IsObject(server_address_by_client_cidrs_local_nonprimitive)){
             goto end;
         }
-        v1_server_address_by_client_cidr_t *server_address_by_client_cid_rsItem = v1_server_address_by_client_cidr_parseFromJSON(server_address_by_client_cid_rs_local_nonprimitive);
+        v1_server_address_by_client_cidr_t *server_address_by_client_cidrsItem = v1_server_address_by_client_cidr_parseFromJSON(server_address_by_client_cidrs_local_nonprimitive);
 
-        list_addElement(server_address_by_client_cid_rsList, server_address_by_client_cid_rsItem);
+        list_addElement(server_address_by_client_cidrsList, server_address_by_client_cidrsItem);
     }
 
     // v1_api_versions->versions
@@ -195,7 +195,7 @@ v1_api_versions_t *v1_api_versions_parseFromJSON(cJSON *v1_api_versionsJSON){
     v1_api_versions_local_var = v1_api_versions_create (
         api_version ? strdup(api_version->valuestring) : NULL,
         kind ? strdup(kind->valuestring) : NULL,
-        server_address_by_client_cid_rsList,
+        server_address_by_client_cidrsList,
         versionsList
         );
 

--- a/kubernetes/model/v1_api_versions.h
+++ b/kubernetes/model/v1_api_versions.h
@@ -22,7 +22,7 @@ typedef struct v1_api_versions_t v1_api_versions_t;
 typedef struct v1_api_versions_t {
     char *api_version; // string
     char *kind; // string
-    list_t *server_address_by_client_cid_rs; //nonprimitive container
+    list_t *server_address_by_client_cidrs; //nonprimitive container
     list_t *versions; //primitive container
 
 } v1_api_versions_t;
@@ -30,7 +30,7 @@ typedef struct v1_api_versions_t {
 v1_api_versions_t *v1_api_versions_create(
     char *api_version,
     char *kind,
-    list_t *server_address_by_client_cid_rs,
+    list_t *server_address_by_client_cidrs,
     list_t *versions
 );
 

--- a/kubernetes/model/v1_binding.c
+++ b/kubernetes/model/v1_binding.c
@@ -151,6 +151,14 @@ v1_binding_t *v1_binding_parseFromJSON(cJSON *v1_bindingJSON){
 
     return v1_binding_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (target_local_nonprim) {
+        v1_object_reference_free(target_local_nonprim);
+        target_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_ceph_fs_persistent_volume_source.c
+++ b/kubernetes/model/v1_ceph_fs_persistent_volume_source.c
@@ -215,6 +215,10 @@ v1_ceph_fs_persistent_volume_source_t *v1_ceph_fs_persistent_volume_source_parse
 
     return v1_ceph_fs_persistent_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_secret_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_ceph_fs_volume_source.c
+++ b/kubernetes/model/v1_ceph_fs_volume_source.c
@@ -215,6 +215,10 @@ v1_ceph_fs_volume_source_t *v1_ceph_fs_volume_source_parseFromJSON(cJSON *v1_cep
 
     return v1_ceph_fs_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_local_object_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_cinder_persistent_volume_source.c
+++ b/kubernetes/model/v1_cinder_persistent_volume_source.c
@@ -144,6 +144,10 @@ v1_cinder_persistent_volume_source_t *v1_cinder_persistent_volume_source_parseFr
 
     return v1_cinder_persistent_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_secret_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_cinder_volume_source.c
+++ b/kubernetes/model/v1_cinder_volume_source.c
@@ -144,6 +144,10 @@ v1_cinder_volume_source_t *v1_cinder_volume_source_parseFromJSON(cJSON *v1_cinde
 
     return v1_cinder_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_local_object_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_cluster_role.c
+++ b/kubernetes/model/v1_cluster_role.c
@@ -198,6 +198,14 @@ v1_cluster_role_t *v1_cluster_role_parseFromJSON(cJSON *v1_cluster_roleJSON){
 
     return v1_cluster_role_local_var;
 end:
+    if (aggregation_rule_local_nonprim) {
+        v1_aggregation_rule_free(aggregation_rule_local_nonprim);
+        aggregation_rule_local_nonprim = NULL;
+    }
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_cluster_role_binding.c
+++ b/kubernetes/model/v1_cluster_role_binding.c
@@ -203,6 +203,14 @@ v1_cluster_role_binding_t *v1_cluster_role_binding_parseFromJSON(cJSON *v1_clust
 
     return v1_cluster_role_binding_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (role_ref_local_nonprim) {
+        v1_role_ref_free(role_ref_local_nonprim);
+        role_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_cluster_role_binding_list.c
+++ b/kubernetes/model/v1_cluster_role_binding_list.c
@@ -176,6 +176,10 @@ v1_cluster_role_binding_list_t *v1_cluster_role_binding_list_parseFromJSON(cJSON
 
     return v1_cluster_role_binding_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_cluster_role_list.c
+++ b/kubernetes/model/v1_cluster_role_list.c
@@ -176,6 +176,10 @@ v1_cluster_role_list_t *v1_cluster_role_list_parseFromJSON(cJSON *v1_cluster_rol
 
     return v1_cluster_role_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_component_status.c
+++ b/kubernetes/model/v1_component_status.c
@@ -171,6 +171,10 @@ v1_component_status_t *v1_component_status_parseFromJSON(cJSON *v1_component_sta
 
     return v1_component_status_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_component_status_list.c
+++ b/kubernetes/model/v1_component_status_list.c
@@ -176,6 +176,10 @@ v1_component_status_list_t *v1_component_status_list_parseFromJSON(cJSON *v1_com
 
     return v1_component_status_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_config_map.c
+++ b/kubernetes/model/v1_config_map.c
@@ -220,6 +220,10 @@ v1_config_map_t *v1_config_map_parseFromJSON(cJSON *v1_config_mapJSON){
 
     return v1_config_map_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_config_map_list.c
+++ b/kubernetes/model/v1_config_map_list.c
@@ -176,6 +176,10 @@ v1_config_map_list_t *v1_config_map_list_parseFromJSON(cJSON *v1_config_map_list
 
     return v1_config_map_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_container.c
+++ b/kubernetes/model/v1_container.c
@@ -769,6 +769,30 @@ v1_container_t *v1_container_parseFromJSON(cJSON *v1_containerJSON){
 
     return v1_container_local_var;
 end:
+    if (lifecycle_local_nonprim) {
+        v1_lifecycle_free(lifecycle_local_nonprim);
+        lifecycle_local_nonprim = NULL;
+    }
+    if (liveness_probe_local_nonprim) {
+        v1_probe_free(liveness_probe_local_nonprim);
+        liveness_probe_local_nonprim = NULL;
+    }
+    if (readiness_probe_local_nonprim) {
+        v1_probe_free(readiness_probe_local_nonprim);
+        readiness_probe_local_nonprim = NULL;
+    }
+    if (resources_local_nonprim) {
+        v1_resource_requirements_free(resources_local_nonprim);
+        resources_local_nonprim = NULL;
+    }
+    if (security_context_local_nonprim) {
+        v1_security_context_free(security_context_local_nonprim);
+        security_context_local_nonprim = NULL;
+    }
+    if (startup_probe_local_nonprim) {
+        v1_probe_free(startup_probe_local_nonprim);
+        startup_probe_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_container_state.c
+++ b/kubernetes/model/v1_container_state.c
@@ -125,6 +125,18 @@ v1_container_state_t *v1_container_state_parseFromJSON(cJSON *v1_container_state
 
     return v1_container_state_local_var;
 end:
+    if (running_local_nonprim) {
+        v1_container_state_running_free(running_local_nonprim);
+        running_local_nonprim = NULL;
+    }
+    if (terminated_local_nonprim) {
+        v1_container_state_terminated_free(terminated_local_nonprim);
+        terminated_local_nonprim = NULL;
+    }
+    if (waiting_local_nonprim) {
+        v1_container_state_waiting_free(waiting_local_nonprim);
+        waiting_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_container_status.c
+++ b/kubernetes/model/v1_container_status.c
@@ -279,6 +279,14 @@ v1_container_status_t *v1_container_status_parseFromJSON(cJSON *v1_container_sta
 
     return v1_container_status_local_var;
 end:
+    if (last_state_local_nonprim) {
+        v1_container_state_free(last_state_local_nonprim);
+        last_state_local_nonprim = NULL;
+    }
+    if (state_local_nonprim) {
+        v1_container_state_free(state_local_nonprim);
+        state_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_controller_revision.c
+++ b/kubernetes/model/v1_controller_revision.c
@@ -171,6 +171,10 @@ v1_controller_revision_t *v1_controller_revision_parseFromJSON(cJSON *v1_control
 
     return v1_controller_revision_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_controller_revision_list.c
+++ b/kubernetes/model/v1_controller_revision_list.c
@@ -176,6 +176,10 @@ v1_controller_revision_list_t *v1_controller_revision_list_parseFromJSON(cJSON *
 
     return v1_controller_revision_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_csi_node.c
+++ b/kubernetes/model/v1_csi_node.c
@@ -151,6 +151,14 @@ v1_csi_node_t *v1_csi_node_parseFromJSON(cJSON *v1_csi_nodeJSON){
 
     return v1_csi_node_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_csi_node_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_csi_node_driver.c
+++ b/kubernetes/model/v1_csi_node_driver.c
@@ -176,6 +176,10 @@ v1_csi_node_driver_t *v1_csi_node_driver_parseFromJSON(cJSON *v1_csi_node_driver
 
     return v1_csi_node_driver_local_var;
 end:
+    if (allocatable_local_nonprim) {
+        v1_volume_node_resources_free(allocatable_local_nonprim);
+        allocatable_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_csi_node_list.c
+++ b/kubernetes/model/v1_csi_node_list.c
@@ -176,6 +176,10 @@ v1_csi_node_list_t *v1_csi_node_list_parseFromJSON(cJSON *v1_csi_node_listJSON){
 
     return v1_csi_node_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_csi_persistent_volume_source.c
+++ b/kubernetes/model/v1_csi_persistent_volume_source.c
@@ -309,6 +309,22 @@ v1_csi_persistent_volume_source_t *v1_csi_persistent_volume_source_parseFromJSON
 
     return v1_csi_persistent_volume_source_local_var;
 end:
+    if (controller_expand_secret_ref_local_nonprim) {
+        v1_secret_reference_free(controller_expand_secret_ref_local_nonprim);
+        controller_expand_secret_ref_local_nonprim = NULL;
+    }
+    if (controller_publish_secret_ref_local_nonprim) {
+        v1_secret_reference_free(controller_publish_secret_ref_local_nonprim);
+        controller_publish_secret_ref_local_nonprim = NULL;
+    }
+    if (node_publish_secret_ref_local_nonprim) {
+        v1_secret_reference_free(node_publish_secret_ref_local_nonprim);
+        node_publish_secret_ref_local_nonprim = NULL;
+    }
+    if (node_stage_secret_ref_local_nonprim) {
+        v1_secret_reference_free(node_stage_secret_ref_local_nonprim);
+        node_stage_secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_csi_volume_source.c
+++ b/kubernetes/model/v1_csi_volume_source.c
@@ -199,6 +199,10 @@ v1_csi_volume_source_t *v1_csi_volume_source_parseFromJSON(cJSON *v1_csi_volume_
 
     return v1_csi_volume_source_local_var;
 end:
+    if (node_publish_secret_ref_local_nonprim) {
+        v1_local_object_reference_free(node_publish_secret_ref_local_nonprim);
+        node_publish_secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_custom_resource_conversion.c
+++ b/kubernetes/model/v1_custom_resource_conversion.c
@@ -100,6 +100,10 @@ v1_custom_resource_conversion_t *v1_custom_resource_conversion_parseFromJSON(cJS
 
     return v1_custom_resource_conversion_local_var;
 end:
+    if (webhook_local_nonprim) {
+        v1_webhook_conversion_free(webhook_local_nonprim);
+        webhook_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_custom_resource_definition.c
+++ b/kubernetes/model/v1_custom_resource_definition.c
@@ -178,6 +178,18 @@ v1_custom_resource_definition_t *v1_custom_resource_definition_parseFromJSON(cJS
 
     return v1_custom_resource_definition_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_custom_resource_definition_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_custom_resource_definition_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_custom_resource_definition_list.c
+++ b/kubernetes/model/v1_custom_resource_definition_list.c
@@ -176,6 +176,10 @@ v1_custom_resource_definition_list_t *v1_custom_resource_definition_list_parseFr
 
     return v1_custom_resource_definition_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_custom_resource_definition_spec.c
+++ b/kubernetes/model/v1_custom_resource_definition_spec.c
@@ -238,6 +238,14 @@ v1_custom_resource_definition_spec_t *v1_custom_resource_definition_spec_parseFr
 
     return v1_custom_resource_definition_spec_local_var;
 end:
+    if (conversion_local_nonprim) {
+        v1_custom_resource_conversion_free(conversion_local_nonprim);
+        conversion_local_nonprim = NULL;
+    }
+    if (names_local_nonprim) {
+        v1_custom_resource_definition_names_free(names_local_nonprim);
+        names_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_custom_resource_definition_status.c
+++ b/kubernetes/model/v1_custom_resource_definition_status.c
@@ -180,6 +180,10 @@ v1_custom_resource_definition_status_t *v1_custom_resource_definition_status_par
 
     return v1_custom_resource_definition_status_local_var;
 end:
+    if (accepted_names_local_nonprim) {
+        v1_custom_resource_definition_names_free(accepted_names_local_nonprim);
+        accepted_names_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_custom_resource_definition_version.c
+++ b/kubernetes/model/v1_custom_resource_definition_version.c
@@ -229,6 +229,14 @@ v1_custom_resource_definition_version_t *v1_custom_resource_definition_version_p
 
     return v1_custom_resource_definition_version_local_var;
 end:
+    if (schema_local_nonprim) {
+        v1_custom_resource_validation_free(schema_local_nonprim);
+        schema_local_nonprim = NULL;
+    }
+    if (subresources_local_nonprim) {
+        v1_custom_resource_subresources_free(subresources_local_nonprim);
+        subresources_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_custom_resource_subresources.c
+++ b/kubernetes/model/v1_custom_resource_subresources.c
@@ -98,6 +98,10 @@ v1_custom_resource_subresources_t *v1_custom_resource_subresources_parseFromJSON
 
     return v1_custom_resource_subresources_local_var;
 end:
+    if (scale_local_nonprim) {
+        v1_custom_resource_subresource_scale_free(scale_local_nonprim);
+        scale_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_custom_resource_validation.c
+++ b/kubernetes/model/v1_custom_resource_validation.c
@@ -71,6 +71,10 @@ v1_custom_resource_validation_t *v1_custom_resource_validation_parseFromJSON(cJS
 
     return v1_custom_resource_validation_local_var;
 end:
+    if (open_apiv3_schema_local_nonprim) {
+        v1_json_schema_props_free(open_apiv3_schema_local_nonprim);
+        open_apiv3_schema_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_daemon_set.c
+++ b/kubernetes/model/v1_daemon_set.c
@@ -173,6 +173,18 @@ v1_daemon_set_t *v1_daemon_set_parseFromJSON(cJSON *v1_daemon_setJSON){
 
     return v1_daemon_set_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_daemon_set_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_daemon_set_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_daemon_set_list.c
+++ b/kubernetes/model/v1_daemon_set_list.c
@@ -176,6 +176,10 @@ v1_daemon_set_list_t *v1_daemon_set_list_parseFromJSON(cJSON *v1_daemon_set_list
 
     return v1_daemon_set_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_daemon_set_spec.c
+++ b/kubernetes/model/v1_daemon_set_spec.c
@@ -175,6 +175,18 @@ v1_daemon_set_spec_t *v1_daemon_set_spec_parseFromJSON(cJSON *v1_daemon_set_spec
 
     return v1_daemon_set_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
+    if (update_strategy_local_nonprim) {
+        v1_daemon_set_update_strategy_free(update_strategy_local_nonprim);
+        update_strategy_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_daemon_set_update_strategy.c
+++ b/kubernetes/model/v1_daemon_set_update_strategy.c
@@ -95,6 +95,10 @@ v1_daemon_set_update_strategy_t *v1_daemon_set_update_strategy_parseFromJSON(cJS
 
     return v1_daemon_set_update_strategy_local_var;
 end:
+    if (rolling_update_local_nonprim) {
+        v1_rolling_update_daemon_set_free(rolling_update_local_nonprim);
+        rolling_update_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_delete_options.c
+++ b/kubernetes/model/v1_delete_options.c
@@ -230,6 +230,10 @@ v1_delete_options_t *v1_delete_options_parseFromJSON(cJSON *v1_delete_optionsJSO
 
     return v1_delete_options_local_var;
 end:
+    if (preconditions_local_nonprim) {
+        v1_preconditions_free(preconditions_local_nonprim);
+        preconditions_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_deployment.c
+++ b/kubernetes/model/v1_deployment.c
@@ -173,6 +173,18 @@ v1_deployment_t *v1_deployment_parseFromJSON(cJSON *v1_deploymentJSON){
 
     return v1_deployment_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_deployment_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_deployment_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_deployment_list.c
+++ b/kubernetes/model/v1_deployment_list.c
@@ -176,6 +176,10 @@ v1_deployment_list_t *v1_deployment_list_parseFromJSON(cJSON *v1_deployment_list
 
     return v1_deployment_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_deployment_spec.c
+++ b/kubernetes/model/v1_deployment_spec.c
@@ -235,6 +235,18 @@ v1_deployment_spec_t *v1_deployment_spec_parseFromJSON(cJSON *v1_deployment_spec
 
     return v1_deployment_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (strategy_local_nonprim) {
+        v1_deployment_strategy_free(strategy_local_nonprim);
+        strategy_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_deployment_strategy.c
+++ b/kubernetes/model/v1_deployment_strategy.c
@@ -95,6 +95,10 @@ v1_deployment_strategy_t *v1_deployment_strategy_parseFromJSON(cJSON *v1_deploym
 
     return v1_deployment_strategy_local_var;
 end:
+    if (rolling_update_local_nonprim) {
+        v1_rolling_update_deployment_free(rolling_update_local_nonprim);
+        rolling_update_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_downward_api_volume_file.c
+++ b/kubernetes/model/v1_downward_api_volume_file.c
@@ -147,6 +147,14 @@ v1_downward_api_volume_file_t *v1_downward_api_volume_file_parseFromJSON(cJSON *
 
     return v1_downward_api_volume_file_local_var;
 end:
+    if (field_ref_local_nonprim) {
+        v1_object_field_selector_free(field_ref_local_nonprim);
+        field_ref_local_nonprim = NULL;
+    }
+    if (resource_field_ref_local_nonprim) {
+        v1_resource_field_selector_free(resource_field_ref_local_nonprim);
+        resource_field_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_endpoint_address.c
+++ b/kubernetes/model/v1_endpoint_address.c
@@ -148,6 +148,10 @@ v1_endpoint_address_t *v1_endpoint_address_parseFromJSON(cJSON *v1_endpoint_addr
 
     return v1_endpoint_address_local_var;
 end:
+    if (target_ref_local_nonprim) {
+        v1_object_reference_free(target_ref_local_nonprim);
+        target_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_endpoints.c
+++ b/kubernetes/model/v1_endpoints.c
@@ -171,6 +171,10 @@ v1_endpoints_t *v1_endpoints_parseFromJSON(cJSON *v1_endpointsJSON){
 
     return v1_endpoints_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_endpoints_list.c
+++ b/kubernetes/model/v1_endpoints_list.c
@@ -176,6 +176,10 @@ v1_endpoints_list_t *v1_endpoints_list_parseFromJSON(cJSON *v1_endpoints_listJSO
 
     return v1_endpoints_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_env_from_source.c
+++ b/kubernetes/model/v1_env_from_source.c
@@ -122,6 +122,14 @@ v1_env_from_source_t *v1_env_from_source_parseFromJSON(cJSON *v1_env_from_source
 
     return v1_env_from_source_local_var;
 end:
+    if (config_map_ref_local_nonprim) {
+        v1_config_map_env_source_free(config_map_ref_local_nonprim);
+        config_map_ref_local_nonprim = NULL;
+    }
+    if (secret_ref_local_nonprim) {
+        v1_secret_env_source_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_env_var.c
+++ b/kubernetes/model/v1_env_var.c
@@ -124,6 +124,10 @@ v1_env_var_t *v1_env_var_parseFromJSON(cJSON *v1_env_varJSON){
 
     return v1_env_var_local_var;
 end:
+    if (value_from_local_nonprim) {
+        v1_env_var_source_free(value_from_local_nonprim);
+        value_from_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_env_var_source.c
+++ b/kubernetes/model/v1_env_var_source.c
@@ -152,6 +152,22 @@ v1_env_var_source_t *v1_env_var_source_parseFromJSON(cJSON *v1_env_var_sourceJSO
 
     return v1_env_var_source_local_var;
 end:
+    if (config_map_key_ref_local_nonprim) {
+        v1_config_map_key_selector_free(config_map_key_ref_local_nonprim);
+        config_map_key_ref_local_nonprim = NULL;
+    }
+    if (field_ref_local_nonprim) {
+        v1_object_field_selector_free(field_ref_local_nonprim);
+        field_ref_local_nonprim = NULL;
+    }
+    if (resource_field_ref_local_nonprim) {
+        v1_resource_field_selector_free(resource_field_ref_local_nonprim);
+        resource_field_ref_local_nonprim = NULL;
+    }
+    if (secret_key_ref_local_nonprim) {
+        v1_secret_key_selector_free(secret_key_ref_local_nonprim);
+        secret_key_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_ephemeral_container.c
+++ b/kubernetes/model/v1_ephemeral_container.c
@@ -793,6 +793,30 @@ v1_ephemeral_container_t *v1_ephemeral_container_parseFromJSON(cJSON *v1_ephemer
 
     return v1_ephemeral_container_local_var;
 end:
+    if (lifecycle_local_nonprim) {
+        v1_lifecycle_free(lifecycle_local_nonprim);
+        lifecycle_local_nonprim = NULL;
+    }
+    if (liveness_probe_local_nonprim) {
+        v1_probe_free(liveness_probe_local_nonprim);
+        liveness_probe_local_nonprim = NULL;
+    }
+    if (readiness_probe_local_nonprim) {
+        v1_probe_free(readiness_probe_local_nonprim);
+        readiness_probe_local_nonprim = NULL;
+    }
+    if (resources_local_nonprim) {
+        v1_resource_requirements_free(resources_local_nonprim);
+        resources_local_nonprim = NULL;
+    }
+    if (security_context_local_nonprim) {
+        v1_security_context_free(security_context_local_nonprim);
+        security_context_local_nonprim = NULL;
+    }
+    if (startup_probe_local_nonprim) {
+        v1_probe_free(startup_probe_local_nonprim);
+        startup_probe_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_event.c
+++ b/kubernetes/model/v1_event.c
@@ -473,6 +473,26 @@ v1_event_t *v1_event_parseFromJSON(cJSON *v1_eventJSON){
 
     return v1_event_local_var;
 end:
+    if (involved_object_local_nonprim) {
+        v1_object_reference_free(involved_object_local_nonprim);
+        involved_object_local_nonprim = NULL;
+    }
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (related_local_nonprim) {
+        v1_object_reference_free(related_local_nonprim);
+        related_local_nonprim = NULL;
+    }
+    if (series_local_nonprim) {
+        v1_event_series_free(series_local_nonprim);
+        series_local_nonprim = NULL;
+    }
+    if (source_local_nonprim) {
+        v1_event_source_free(source_local_nonprim);
+        source_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_event_list.c
+++ b/kubernetes/model/v1_event_list.c
@@ -176,6 +176,10 @@ v1_event_list_t *v1_event_list_parseFromJSON(cJSON *v1_event_listJSON){
 
     return v1_event_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_fc_volume_source.c
+++ b/kubernetes/model/v1_fc_volume_source.c
@@ -9,7 +9,7 @@ v1_fc_volume_source_t *v1_fc_volume_source_create(
     char *fs_type,
     int lun,
     int read_only,
-    list_t *target_ww_ns,
+    list_t *target_wwns,
     list_t *wwids
     ) {
     v1_fc_volume_source_t *v1_fc_volume_source_local_var = malloc(sizeof(v1_fc_volume_source_t));
@@ -19,7 +19,7 @@ v1_fc_volume_source_t *v1_fc_volume_source_create(
     v1_fc_volume_source_local_var->fs_type = fs_type;
     v1_fc_volume_source_local_var->lun = lun;
     v1_fc_volume_source_local_var->read_only = read_only;
-    v1_fc_volume_source_local_var->target_ww_ns = target_ww_ns;
+    v1_fc_volume_source_local_var->target_wwns = target_wwns;
     v1_fc_volume_source_local_var->wwids = wwids;
 
     return v1_fc_volume_source_local_var;
@@ -35,12 +35,12 @@ void v1_fc_volume_source_free(v1_fc_volume_source_t *v1_fc_volume_source) {
         free(v1_fc_volume_source->fs_type);
         v1_fc_volume_source->fs_type = NULL;
     }
-    if (v1_fc_volume_source->target_ww_ns) {
-        list_ForEach(listEntry, v1_fc_volume_source->target_ww_ns) {
+    if (v1_fc_volume_source->target_wwns) {
+        list_ForEach(listEntry, v1_fc_volume_source->target_wwns) {
             free(listEntry->data);
         }
-        list_free(v1_fc_volume_source->target_ww_ns);
-        v1_fc_volume_source->target_ww_ns = NULL;
+        list_free(v1_fc_volume_source->target_wwns);
+        v1_fc_volume_source->target_wwns = NULL;
     }
     if (v1_fc_volume_source->wwids) {
         list_ForEach(listEntry, v1_fc_volume_source->wwids) {
@@ -79,16 +79,16 @@ cJSON *v1_fc_volume_source_convertToJSON(v1_fc_volume_source_t *v1_fc_volume_sou
      } 
 
 
-    // v1_fc_volume_source->target_ww_ns
-    if(v1_fc_volume_source->target_ww_ns) { 
-    cJSON *target_ww_ns = cJSON_AddArrayToObject(item, "targetWWNs");
-    if(target_ww_ns == NULL) {
+    // v1_fc_volume_source->target_wwns
+    if(v1_fc_volume_source->target_wwns) { 
+    cJSON *target_wwns = cJSON_AddArrayToObject(item, "targetWWNs");
+    if(target_wwns == NULL) {
         goto fail; //primitive container
     }
 
-    listEntry_t *target_ww_nsListEntry;
-    list_ForEach(target_ww_nsListEntry, v1_fc_volume_source->target_ww_ns) {
-    if(cJSON_AddStringToObject(target_ww_ns, "", (char*)target_ww_nsListEntry->data) == NULL)
+    listEntry_t *target_wwnsListEntry;
+    list_ForEach(target_wwnsListEntry, v1_fc_volume_source->target_wwns) {
+    if(cJSON_AddStringToObject(target_wwns, "", (char*)target_wwnsListEntry->data) == NULL)
     {
         goto fail;
     }
@@ -151,23 +151,23 @@ v1_fc_volume_source_t *v1_fc_volume_source_parseFromJSON(cJSON *v1_fc_volume_sou
     }
     }
 
-    // v1_fc_volume_source->target_ww_ns
-    cJSON *target_ww_ns = cJSON_GetObjectItemCaseSensitive(v1_fc_volume_sourceJSON, "targetWWNs");
-    list_t *target_ww_nsList;
-    if (target_ww_ns) { 
-    cJSON *target_ww_ns_local;
-    if(!cJSON_IsArray(target_ww_ns)) {
+    // v1_fc_volume_source->target_wwns
+    cJSON *target_wwns = cJSON_GetObjectItemCaseSensitive(v1_fc_volume_sourceJSON, "targetWWNs");
+    list_t *target_wwnsList;
+    if (target_wwns) { 
+    cJSON *target_wwns_local;
+    if(!cJSON_IsArray(target_wwns)) {
         goto end;//primitive container
     }
-    target_ww_nsList = list_create();
+    target_wwnsList = list_create();
 
-    cJSON_ArrayForEach(target_ww_ns_local, target_ww_ns)
+    cJSON_ArrayForEach(target_wwns_local, target_wwns)
     {
-        if(!cJSON_IsString(target_ww_ns_local))
+        if(!cJSON_IsString(target_wwns_local))
         {
             goto end;
         }
-        list_addElement(target_ww_nsList , strdup(target_ww_ns_local->valuestring));
+        list_addElement(target_wwnsList , strdup(target_wwns_local->valuestring));
     }
     }
 
@@ -196,7 +196,7 @@ v1_fc_volume_source_t *v1_fc_volume_source_parseFromJSON(cJSON *v1_fc_volume_sou
         fs_type ? strdup(fs_type->valuestring) : NULL,
         lun ? lun->valuedouble : 0,
         read_only ? read_only->valueint : 0,
-        target_ww_ns ? target_ww_nsList : NULL,
+        target_wwns ? target_wwnsList : NULL,
         wwids ? wwidsList : NULL
         );
 

--- a/kubernetes/model/v1_fc_volume_source.h
+++ b/kubernetes/model/v1_fc_volume_source.h
@@ -22,7 +22,7 @@ typedef struct v1_fc_volume_source_t {
     char *fs_type; // string
     int lun; //numeric
     int read_only; //boolean
-    list_t *target_ww_ns; //primitive container
+    list_t *target_wwns; //primitive container
     list_t *wwids; //primitive container
 
 } v1_fc_volume_source_t;
@@ -31,7 +31,7 @@ v1_fc_volume_source_t *v1_fc_volume_source_create(
     char *fs_type,
     int lun,
     int read_only,
-    list_t *target_ww_ns,
+    list_t *target_wwns,
     list_t *wwids
 );
 

--- a/kubernetes/model/v1_flex_persistent_volume_source.c
+++ b/kubernetes/model/v1_flex_persistent_volume_source.c
@@ -199,6 +199,10 @@ v1_flex_persistent_volume_source_t *v1_flex_persistent_volume_source_parseFromJS
 
     return v1_flex_persistent_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_secret_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_flex_volume_source.c
+++ b/kubernetes/model/v1_flex_volume_source.c
@@ -199,6 +199,10 @@ v1_flex_volume_source_t *v1_flex_volume_source_parseFromJSON(cJSON *v1_flex_volu
 
     return v1_flex_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_local_object_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_handler.c
+++ b/kubernetes/model/v1_handler.c
@@ -125,6 +125,18 @@ v1_handler_t *v1_handler_parseFromJSON(cJSON *v1_handlerJSON){
 
     return v1_handler_local_var;
 end:
+    if (exec_local_nonprim) {
+        v1_exec_action_free(exec_local_nonprim);
+        exec_local_nonprim = NULL;
+    }
+    if (http_get_local_nonprim) {
+        v1_http_get_action_free(http_get_local_nonprim);
+        http_get_local_nonprim = NULL;
+    }
+    if (tcp_socket_local_nonprim) {
+        v1_tcp_socket_action_free(tcp_socket_local_nonprim);
+        tcp_socket_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_horizontal_pod_autoscaler.c
+++ b/kubernetes/model/v1_horizontal_pod_autoscaler.c
@@ -173,6 +173,18 @@ v1_horizontal_pod_autoscaler_t *v1_horizontal_pod_autoscaler_parseFromJSON(cJSON
 
     return v1_horizontal_pod_autoscaler_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_horizontal_pod_autoscaler_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_horizontal_pod_autoscaler_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_horizontal_pod_autoscaler_list.c
+++ b/kubernetes/model/v1_horizontal_pod_autoscaler_list.c
@@ -176,6 +176,10 @@ v1_horizontal_pod_autoscaler_list_t *v1_horizontal_pod_autoscaler_list_parseFrom
 
     return v1_horizontal_pod_autoscaler_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_horizontal_pod_autoscaler_spec.c
+++ b/kubernetes/model/v1_horizontal_pod_autoscaler_spec.c
@@ -141,6 +141,10 @@ v1_horizontal_pod_autoscaler_spec_t *v1_horizontal_pod_autoscaler_spec_parseFrom
 
     return v1_horizontal_pod_autoscaler_spec_local_var;
 end:
+    if (scale_target_ref_local_nonprim) {
+        v1_cross_version_object_reference_free(scale_target_ref_local_nonprim);
+        scale_target_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_iscsi_persistent_volume_source.c
+++ b/kubernetes/model/v1_iscsi_persistent_volume_source.c
@@ -333,6 +333,10 @@ v1_iscsi_persistent_volume_source_t *v1_iscsi_persistent_volume_source_parseFrom
 
     return v1_iscsi_persistent_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_secret_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_iscsi_volume_source.c
+++ b/kubernetes/model/v1_iscsi_volume_source.c
@@ -333,6 +333,10 @@ v1_iscsi_volume_source_t *v1_iscsi_volume_source_parseFromJSON(cJSON *v1_iscsi_v
 
     return v1_iscsi_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_local_object_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_job.c
+++ b/kubernetes/model/v1_job.c
@@ -173,6 +173,18 @@ v1_job_t *v1_job_parseFromJSON(cJSON *v1_jobJSON){
 
     return v1_job_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_job_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_job_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_job_list.c
+++ b/kubernetes/model/v1_job_list.c
@@ -176,6 +176,10 @@ v1_job_list_t *v1_job_list_parseFromJSON(cJSON *v1_job_listJSON){
 
     return v1_job_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_job_spec.c
+++ b/kubernetes/model/v1_job_spec.c
@@ -223,6 +223,14 @@ v1_job_spec_t *v1_job_spec_parseFromJSON(cJSON *v1_job_specJSON){
 
     return v1_job_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_json_schema_props.c
+++ b/kubernetes/model/v1_json_schema_props.c
@@ -1279,6 +1279,14 @@ v1_json_schema_props_t *v1_json_schema_props_parseFromJSON(cJSON *v1_json_schema
 
     return v1_json_schema_props_local_var;
 end:
+    if (external_docs_local_nonprim) {
+        v1_external_documentation_free(external_docs_local_nonprim);
+        external_docs_local_nonprim = NULL;
+    }
+    if (_not_local_nonprim) {
+        v1_json_schema_props_free(_not_local_nonprim);
+        _not_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_lease.c
+++ b/kubernetes/model/v1_lease.c
@@ -146,6 +146,14 @@ v1_lease_t *v1_lease_parseFromJSON(cJSON *v1_leaseJSON){
 
     return v1_lease_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_lease_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_lease_list.c
+++ b/kubernetes/model/v1_lease_list.c
@@ -176,6 +176,10 @@ v1_lease_list_t *v1_lease_list_parseFromJSON(cJSON *v1_lease_listJSON){
 
     return v1_lease_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_lifecycle.c
+++ b/kubernetes/model/v1_lifecycle.c
@@ -98,6 +98,14 @@ v1_lifecycle_t *v1_lifecycle_parseFromJSON(cJSON *v1_lifecycleJSON){
 
     return v1_lifecycle_local_var;
 end:
+    if (post_start_local_nonprim) {
+        v1_handler_free(post_start_local_nonprim);
+        post_start_local_nonprim = NULL;
+    }
+    if (pre_stop_local_nonprim) {
+        v1_handler_free(pre_stop_local_nonprim);
+        pre_stop_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_limit_range.c
+++ b/kubernetes/model/v1_limit_range.c
@@ -146,6 +146,14 @@ v1_limit_range_t *v1_limit_range_parseFromJSON(cJSON *v1_limit_rangeJSON){
 
     return v1_limit_range_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_limit_range_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_limit_range_list.c
+++ b/kubernetes/model/v1_limit_range_list.c
@@ -176,6 +176,10 @@ v1_limit_range_list_t *v1_limit_range_list_parseFromJSON(cJSON *v1_limit_range_l
 
     return v1_limit_range_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_local_subject_access_review.c
+++ b/kubernetes/model/v1_local_subject_access_review.c
@@ -178,6 +178,18 @@ v1_local_subject_access_review_t *v1_local_subject_access_review_parseFromJSON(c
 
     return v1_local_subject_access_review_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_subject_access_review_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_subject_access_review_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_mutating_webhook.c
+++ b/kubernetes/model/v1_mutating_webhook.c
@@ -384,6 +384,18 @@ v1_mutating_webhook_t *v1_mutating_webhook_parseFromJSON(cJSON *v1_mutating_webh
 
     return v1_mutating_webhook_local_var;
 end:
+    if (client_config_local_nonprim) {
+        admissionregistration_v1_webhook_client_config_free(client_config_local_nonprim);
+        client_config_local_nonprim = NULL;
+    }
+    if (namespace_selector_local_nonprim) {
+        v1_label_selector_free(namespace_selector_local_nonprim);
+        namespace_selector_local_nonprim = NULL;
+    }
+    if (object_selector_local_nonprim) {
+        v1_label_selector_free(object_selector_local_nonprim);
+        object_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_mutating_webhook_configuration.c
+++ b/kubernetes/model/v1_mutating_webhook_configuration.c
@@ -171,6 +171,10 @@ v1_mutating_webhook_configuration_t *v1_mutating_webhook_configuration_parseFrom
 
     return v1_mutating_webhook_configuration_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_mutating_webhook_configuration_list.c
+++ b/kubernetes/model/v1_mutating_webhook_configuration_list.c
@@ -176,6 +176,10 @@ v1_mutating_webhook_configuration_list_t *v1_mutating_webhook_configuration_list
 
     return v1_mutating_webhook_configuration_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_namespace.c
+++ b/kubernetes/model/v1_namespace.c
@@ -173,6 +173,18 @@ v1_namespace_t *v1_namespace_parseFromJSON(cJSON *v1_namespaceJSON){
 
     return v1_namespace_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_namespace_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_namespace_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_namespace_list.c
+++ b/kubernetes/model/v1_namespace_list.c
@@ -176,6 +176,10 @@ v1_namespace_list_t *v1_namespace_list_parseFromJSON(cJSON *v1_namespace_listJSO
 
     return v1_namespace_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_network_policy.c
+++ b/kubernetes/model/v1_network_policy.c
@@ -146,6 +146,14 @@ v1_network_policy_t *v1_network_policy_parseFromJSON(cJSON *v1_network_policyJSO
 
     return v1_network_policy_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_network_policy_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_network_policy_list.c
+++ b/kubernetes/model/v1_network_policy_list.c
@@ -176,6 +176,10 @@ v1_network_policy_list_t *v1_network_policy_list_parseFromJSON(cJSON *v1_network
 
     return v1_network_policy_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_network_policy_peer.c
+++ b/kubernetes/model/v1_network_policy_peer.c
@@ -125,6 +125,18 @@ v1_network_policy_peer_t *v1_network_policy_peer_parseFromJSON(cJSON *v1_network
 
     return v1_network_policy_peer_local_var;
 end:
+    if (ip_block_local_nonprim) {
+        v1_ip_block_free(ip_block_local_nonprim);
+        ip_block_local_nonprim = NULL;
+    }
+    if (namespace_selector_local_nonprim) {
+        v1_label_selector_free(namespace_selector_local_nonprim);
+        namespace_selector_local_nonprim = NULL;
+    }
+    if (pod_selector_local_nonprim) {
+        v1_label_selector_free(pod_selector_local_nonprim);
+        pod_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_network_policy_spec.c
+++ b/kubernetes/model/v1_network_policy_spec.c
@@ -227,6 +227,10 @@ v1_network_policy_spec_t *v1_network_policy_spec_parseFromJSON(cJSON *v1_network
 
     return v1_network_policy_spec_local_var;
 end:
+    if (pod_selector_local_nonprim) {
+        v1_label_selector_free(pod_selector_local_nonprim);
+        pod_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_node.c
+++ b/kubernetes/model/v1_node.c
@@ -173,6 +173,18 @@ v1_node_t *v1_node_parseFromJSON(cJSON *v1_nodeJSON){
 
     return v1_node_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_node_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_node_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_node_affinity.c
+++ b/kubernetes/model/v1_node_affinity.c
@@ -123,6 +123,10 @@ v1_node_affinity_t *v1_node_affinity_parseFromJSON(cJSON *v1_node_affinityJSON){
 
     return v1_node_affinity_local_var;
 end:
+    if (required_during_scheduling_ignored_during_execution_local_nonprim) {
+        v1_node_selector_free(required_during_scheduling_ignored_during_execution_local_nonprim);
+        required_during_scheduling_ignored_during_execution_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_node_config_source.c
+++ b/kubernetes/model/v1_node_config_source.c
@@ -71,6 +71,10 @@ v1_node_config_source_t *v1_node_config_source_parseFromJSON(cJSON *v1_node_conf
 
     return v1_node_config_source_local_var;
 end:
+    if (config_map_local_nonprim) {
+        v1_config_map_node_config_source_free(config_map_local_nonprim);
+        config_map_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_node_config_status.c
+++ b/kubernetes/model/v1_node_config_status.c
@@ -149,6 +149,18 @@ v1_node_config_status_t *v1_node_config_status_parseFromJSON(cJSON *v1_node_conf
 
     return v1_node_config_status_local_var;
 end:
+    if (active_local_nonprim) {
+        v1_node_config_source_free(active_local_nonprim);
+        active_local_nonprim = NULL;
+    }
+    if (assigned_local_nonprim) {
+        v1_node_config_source_free(assigned_local_nonprim);
+        assigned_local_nonprim = NULL;
+    }
+    if (last_known_good_local_nonprim) {
+        v1_node_config_source_free(last_known_good_local_nonprim);
+        last_known_good_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_node_daemon_endpoints.c
+++ b/kubernetes/model/v1_node_daemon_endpoints.c
@@ -71,6 +71,10 @@ v1_node_daemon_endpoints_t *v1_node_daemon_endpoints_parseFromJSON(cJSON *v1_nod
 
     return v1_node_daemon_endpoints_local_var;
 end:
+    if (kubelet_endpoint_local_nonprim) {
+        v1_daemon_endpoint_free(kubelet_endpoint_local_nonprim);
+        kubelet_endpoint_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_node_list.c
+++ b/kubernetes/model/v1_node_list.c
@@ -176,6 +176,10 @@ v1_node_list_t *v1_node_list_parseFromJSON(cJSON *v1_node_listJSON){
 
     return v1_node_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_node_spec.h
+++ b/kubernetes/model/v1_node_spec.h
@@ -24,7 +24,7 @@ typedef struct v1_node_spec_t {
     struct v1_node_config_source_t *config_source; //model
     char *external_id; // string
     char *pod_cidr; // string
-    list_t *pod_cid_rs; //primitive container
+    list_t *pod_cidrs; //primitive container
     char *provider_id; // string
     list_t *taints; //nonprimitive container
     int unschedulable; //boolean
@@ -35,7 +35,7 @@ v1_node_spec_t *v1_node_spec_create(
     v1_node_config_source_t *config_source,
     char *external_id,
     char *pod_cidr,
-    list_t *pod_cid_rs,
+    list_t *pod_cidrs,
     char *provider_id,
     list_t *taints,
     int unschedulable

--- a/kubernetes/model/v1_node_status.c
+++ b/kubernetes/model/v1_node_status.c
@@ -514,6 +514,18 @@ v1_node_status_t *v1_node_status_parseFromJSON(cJSON *v1_node_statusJSON){
 
     return v1_node_status_local_var;
 end:
+    if (config_local_nonprim) {
+        v1_node_config_status_free(config_local_nonprim);
+        config_local_nonprim = NULL;
+    }
+    if (daemon_endpoints_local_nonprim) {
+        v1_node_daemon_endpoints_free(daemon_endpoints_local_nonprim);
+        daemon_endpoints_local_nonprim = NULL;
+    }
+    if (node_info_local_nonprim) {
+        v1_node_system_info_free(node_info_local_nonprim);
+        node_info_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_non_resource_rule.c
+++ b/kubernetes/model/v1_non_resource_rule.c
@@ -6,14 +6,14 @@
 
 
 v1_non_resource_rule_t *v1_non_resource_rule_create(
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *verbs
     ) {
     v1_non_resource_rule_t *v1_non_resource_rule_local_var = malloc(sizeof(v1_non_resource_rule_t));
     if (!v1_non_resource_rule_local_var) {
         return NULL;
     }
-    v1_non_resource_rule_local_var->non_resource_ur_ls = non_resource_ur_ls;
+    v1_non_resource_rule_local_var->non_resource_urls = non_resource_urls;
     v1_non_resource_rule_local_var->verbs = verbs;
 
     return v1_non_resource_rule_local_var;
@@ -25,12 +25,12 @@ void v1_non_resource_rule_free(v1_non_resource_rule_t *v1_non_resource_rule) {
         return ;
     }
     listEntry_t *listEntry;
-    if (v1_non_resource_rule->non_resource_ur_ls) {
-        list_ForEach(listEntry, v1_non_resource_rule->non_resource_ur_ls) {
+    if (v1_non_resource_rule->non_resource_urls) {
+        list_ForEach(listEntry, v1_non_resource_rule->non_resource_urls) {
             free(listEntry->data);
         }
-        list_free(v1_non_resource_rule->non_resource_ur_ls);
-        v1_non_resource_rule->non_resource_ur_ls = NULL;
+        list_free(v1_non_resource_rule->non_resource_urls);
+        v1_non_resource_rule->non_resource_urls = NULL;
     }
     if (v1_non_resource_rule->verbs) {
         list_ForEach(listEntry, v1_non_resource_rule->verbs) {
@@ -45,16 +45,16 @@ void v1_non_resource_rule_free(v1_non_resource_rule_t *v1_non_resource_rule) {
 cJSON *v1_non_resource_rule_convertToJSON(v1_non_resource_rule_t *v1_non_resource_rule) {
     cJSON *item = cJSON_CreateObject();
 
-    // v1_non_resource_rule->non_resource_ur_ls
-    if(v1_non_resource_rule->non_resource_ur_ls) { 
-    cJSON *non_resource_ur_ls = cJSON_AddArrayToObject(item, "nonResourceURLs");
-    if(non_resource_ur_ls == NULL) {
+    // v1_non_resource_rule->non_resource_urls
+    if(v1_non_resource_rule->non_resource_urls) { 
+    cJSON *non_resource_urls = cJSON_AddArrayToObject(item, "nonResourceURLs");
+    if(non_resource_urls == NULL) {
         goto fail; //primitive container
     }
 
-    listEntry_t *non_resource_ur_lsListEntry;
-    list_ForEach(non_resource_ur_lsListEntry, v1_non_resource_rule->non_resource_ur_ls) {
-    if(cJSON_AddStringToObject(non_resource_ur_ls, "", (char*)non_resource_ur_lsListEntry->data) == NULL)
+    listEntry_t *non_resource_urlsListEntry;
+    list_ForEach(non_resource_urlsListEntry, v1_non_resource_rule->non_resource_urls) {
+    if(cJSON_AddStringToObject(non_resource_urls, "", (char*)non_resource_urlsListEntry->data) == NULL)
     {
         goto fail;
     }
@@ -92,23 +92,23 @@ v1_non_resource_rule_t *v1_non_resource_rule_parseFromJSON(cJSON *v1_non_resourc
 
     v1_non_resource_rule_t *v1_non_resource_rule_local_var = NULL;
 
-    // v1_non_resource_rule->non_resource_ur_ls
-    cJSON *non_resource_ur_ls = cJSON_GetObjectItemCaseSensitive(v1_non_resource_ruleJSON, "nonResourceURLs");
-    list_t *non_resource_ur_lsList;
-    if (non_resource_ur_ls) { 
-    cJSON *non_resource_ur_ls_local;
-    if(!cJSON_IsArray(non_resource_ur_ls)) {
+    // v1_non_resource_rule->non_resource_urls
+    cJSON *non_resource_urls = cJSON_GetObjectItemCaseSensitive(v1_non_resource_ruleJSON, "nonResourceURLs");
+    list_t *non_resource_urlsList;
+    if (non_resource_urls) { 
+    cJSON *non_resource_urls_local;
+    if(!cJSON_IsArray(non_resource_urls)) {
         goto end;//primitive container
     }
-    non_resource_ur_lsList = list_create();
+    non_resource_urlsList = list_create();
 
-    cJSON_ArrayForEach(non_resource_ur_ls_local, non_resource_ur_ls)
+    cJSON_ArrayForEach(non_resource_urls_local, non_resource_urls)
     {
-        if(!cJSON_IsString(non_resource_ur_ls_local))
+        if(!cJSON_IsString(non_resource_urls_local))
         {
             goto end;
         }
-        list_addElement(non_resource_ur_lsList , strdup(non_resource_ur_ls_local->valuestring));
+        list_addElement(non_resource_urlsList , strdup(non_resource_urls_local->valuestring));
     }
     }
 
@@ -137,7 +137,7 @@ v1_non_resource_rule_t *v1_non_resource_rule_parseFromJSON(cJSON *v1_non_resourc
 
 
     v1_non_resource_rule_local_var = v1_non_resource_rule_create (
-        non_resource_ur_ls ? non_resource_ur_lsList : NULL,
+        non_resource_urls ? non_resource_urlsList : NULL,
         verbsList
         );
 

--- a/kubernetes/model/v1_non_resource_rule.h
+++ b/kubernetes/model/v1_non_resource_rule.h
@@ -19,13 +19,13 @@ typedef struct v1_non_resource_rule_t v1_non_resource_rule_t;
 
 
 typedef struct v1_non_resource_rule_t {
-    list_t *non_resource_ur_ls; //primitive container
+    list_t *non_resource_urls; //primitive container
     list_t *verbs; //primitive container
 
 } v1_non_resource_rule_t;
 
 v1_non_resource_rule_t *v1_non_resource_rule_create(
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *verbs
 );
 

--- a/kubernetes/model/v1_persistent_volume.c
+++ b/kubernetes/model/v1_persistent_volume.c
@@ -173,6 +173,18 @@ v1_persistent_volume_t *v1_persistent_volume_parseFromJSON(cJSON *v1_persistent_
 
     return v1_persistent_volume_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_persistent_volume_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_persistent_volume_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_persistent_volume_claim.c
+++ b/kubernetes/model/v1_persistent_volume_claim.c
@@ -173,6 +173,18 @@ v1_persistent_volume_claim_t *v1_persistent_volume_claim_parseFromJSON(cJSON *v1
 
     return v1_persistent_volume_claim_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_persistent_volume_claim_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_persistent_volume_claim_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_persistent_volume_claim_list.c
+++ b/kubernetes/model/v1_persistent_volume_claim_list.c
@@ -176,6 +176,10 @@ v1_persistent_volume_claim_list_t *v1_persistent_volume_claim_list_parseFromJSON
 
     return v1_persistent_volume_claim_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_persistent_volume_claim_spec.c
+++ b/kubernetes/model/v1_persistent_volume_claim_spec.c
@@ -244,6 +244,18 @@ v1_persistent_volume_claim_spec_t *v1_persistent_volume_claim_spec_parseFromJSON
 
     return v1_persistent_volume_claim_spec_local_var;
 end:
+    if (data_source_local_nonprim) {
+        v1_typed_local_object_reference_free(data_source_local_nonprim);
+        data_source_local_nonprim = NULL;
+    }
+    if (resources_local_nonprim) {
+        v1_resource_requirements_free(resources_local_nonprim);
+        resources_local_nonprim = NULL;
+    }
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_persistent_volume_list.c
+++ b/kubernetes/model/v1_persistent_volume_list.c
@@ -176,6 +176,10 @@ v1_persistent_volume_list_t *v1_persistent_volume_list_parseFromJSON(cJSON *v1_p
 
     return v1_persistent_volume_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_persistent_volume_spec.c
+++ b/kubernetes/model/v1_persistent_volume_spec.c
@@ -913,6 +913,102 @@ v1_persistent_volume_spec_t *v1_persistent_volume_spec_parseFromJSON(cJSON *v1_p
 
     return v1_persistent_volume_spec_local_var;
 end:
+    if (aws_elastic_block_store_local_nonprim) {
+        v1_aws_elastic_block_store_volume_source_free(aws_elastic_block_store_local_nonprim);
+        aws_elastic_block_store_local_nonprim = NULL;
+    }
+    if (azure_disk_local_nonprim) {
+        v1_azure_disk_volume_source_free(azure_disk_local_nonprim);
+        azure_disk_local_nonprim = NULL;
+    }
+    if (azure_file_local_nonprim) {
+        v1_azure_file_persistent_volume_source_free(azure_file_local_nonprim);
+        azure_file_local_nonprim = NULL;
+    }
+    if (cephfs_local_nonprim) {
+        v1_ceph_fs_persistent_volume_source_free(cephfs_local_nonprim);
+        cephfs_local_nonprim = NULL;
+    }
+    if (cinder_local_nonprim) {
+        v1_cinder_persistent_volume_source_free(cinder_local_nonprim);
+        cinder_local_nonprim = NULL;
+    }
+    if (claim_ref_local_nonprim) {
+        v1_object_reference_free(claim_ref_local_nonprim);
+        claim_ref_local_nonprim = NULL;
+    }
+    if (csi_local_nonprim) {
+        v1_csi_persistent_volume_source_free(csi_local_nonprim);
+        csi_local_nonprim = NULL;
+    }
+    if (fc_local_nonprim) {
+        v1_fc_volume_source_free(fc_local_nonprim);
+        fc_local_nonprim = NULL;
+    }
+    if (flex_volume_local_nonprim) {
+        v1_flex_persistent_volume_source_free(flex_volume_local_nonprim);
+        flex_volume_local_nonprim = NULL;
+    }
+    if (flocker_local_nonprim) {
+        v1_flocker_volume_source_free(flocker_local_nonprim);
+        flocker_local_nonprim = NULL;
+    }
+    if (gce_persistent_disk_local_nonprim) {
+        v1_gce_persistent_disk_volume_source_free(gce_persistent_disk_local_nonprim);
+        gce_persistent_disk_local_nonprim = NULL;
+    }
+    if (glusterfs_local_nonprim) {
+        v1_glusterfs_persistent_volume_source_free(glusterfs_local_nonprim);
+        glusterfs_local_nonprim = NULL;
+    }
+    if (host_path_local_nonprim) {
+        v1_host_path_volume_source_free(host_path_local_nonprim);
+        host_path_local_nonprim = NULL;
+    }
+    if (iscsi_local_nonprim) {
+        v1_iscsi_persistent_volume_source_free(iscsi_local_nonprim);
+        iscsi_local_nonprim = NULL;
+    }
+    if (local_local_nonprim) {
+        v1_local_volume_source_free(local_local_nonprim);
+        local_local_nonprim = NULL;
+    }
+    if (nfs_local_nonprim) {
+        v1_nfs_volume_source_free(nfs_local_nonprim);
+        nfs_local_nonprim = NULL;
+    }
+    if (node_affinity_local_nonprim) {
+        v1_volume_node_affinity_free(node_affinity_local_nonprim);
+        node_affinity_local_nonprim = NULL;
+    }
+    if (photon_persistent_disk_local_nonprim) {
+        v1_photon_persistent_disk_volume_source_free(photon_persistent_disk_local_nonprim);
+        photon_persistent_disk_local_nonprim = NULL;
+    }
+    if (portworx_volume_local_nonprim) {
+        v1_portworx_volume_source_free(portworx_volume_local_nonprim);
+        portworx_volume_local_nonprim = NULL;
+    }
+    if (quobyte_local_nonprim) {
+        v1_quobyte_volume_source_free(quobyte_local_nonprim);
+        quobyte_local_nonprim = NULL;
+    }
+    if (rbd_local_nonprim) {
+        v1_rbd_persistent_volume_source_free(rbd_local_nonprim);
+        rbd_local_nonprim = NULL;
+    }
+    if (scale_io_local_nonprim) {
+        v1_scale_io_persistent_volume_source_free(scale_io_local_nonprim);
+        scale_io_local_nonprim = NULL;
+    }
+    if (storageos_local_nonprim) {
+        v1_storage_os_persistent_volume_source_free(storageos_local_nonprim);
+        storageos_local_nonprim = NULL;
+    }
+    if (vsphere_volume_local_nonprim) {
+        v1_vsphere_virtual_disk_volume_source_free(vsphere_volume_local_nonprim);
+        vsphere_volume_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_pod.c
+++ b/kubernetes/model/v1_pod.c
@@ -173,6 +173,18 @@ v1_pod_t *v1_pod_parseFromJSON(cJSON *v1_podJSON){
 
     return v1_pod_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_pod_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_pod_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_pod_affinity_term.c
+++ b/kubernetes/model/v1_pod_affinity_term.c
@@ -147,6 +147,10 @@ v1_pod_affinity_term_t *v1_pod_affinity_term_parseFromJSON(cJSON *v1_pod_affinit
 
     return v1_pod_affinity_term_local_var;
 end:
+    if (label_selector_local_nonprim) {
+        v1_label_selector_free(label_selector_local_nonprim);
+        label_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_pod_list.c
+++ b/kubernetes/model/v1_pod_list.c
@@ -176,6 +176,10 @@ v1_pod_list_t *v1_pod_list_parseFromJSON(cJSON *v1_pod_listJSON){
 
     return v1_pod_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_pod_security_context.c
+++ b/kubernetes/model/v1_pod_security_context.c
@@ -277,6 +277,14 @@ v1_pod_security_context_t *v1_pod_security_context_parseFromJSON(cJSON *v1_pod_s
 
     return v1_pod_security_context_local_var;
 end:
+    if (se_linux_options_local_nonprim) {
+        v1_se_linux_options_free(se_linux_options_local_nonprim);
+        se_linux_options_local_nonprim = NULL;
+    }
+    if (windows_options_local_nonprim) {
+        v1_windows_security_context_options_free(windows_options_local_nonprim);
+        windows_options_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_pod_spec.c
+++ b/kubernetes/model/v1_pod_spec.c
@@ -1152,6 +1152,18 @@ v1_pod_spec_t *v1_pod_spec_parseFromJSON(cJSON *v1_pod_specJSON){
 
     return v1_pod_spec_local_var;
 end:
+    if (affinity_local_nonprim) {
+        v1_affinity_free(affinity_local_nonprim);
+        affinity_local_nonprim = NULL;
+    }
+    if (dns_config_local_nonprim) {
+        v1_pod_dns_config_free(dns_config_local_nonprim);
+        dns_config_local_nonprim = NULL;
+    }
+    if (security_context_local_nonprim) {
+        v1_pod_security_context_free(security_context_local_nonprim);
+        security_context_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_pod_status.c
+++ b/kubernetes/model/v1_pod_status.c
@@ -15,7 +15,7 @@ v1_pod_status_t *v1_pod_status_create(
     char *nominated_node_name,
     char *phase,
     char *pod_ip,
-    list_t *pod_i_ps,
+    list_t *pod_ips,
     char *qos_class,
     char *reason,
     char *start_time
@@ -33,7 +33,7 @@ v1_pod_status_t *v1_pod_status_create(
     v1_pod_status_local_var->nominated_node_name = nominated_node_name;
     v1_pod_status_local_var->phase = phase;
     v1_pod_status_local_var->pod_ip = pod_ip;
-    v1_pod_status_local_var->pod_i_ps = pod_i_ps;
+    v1_pod_status_local_var->pod_ips = pod_ips;
     v1_pod_status_local_var->qos_class = qos_class;
     v1_pod_status_local_var->reason = reason;
     v1_pod_status_local_var->start_time = start_time;
@@ -95,12 +95,12 @@ void v1_pod_status_free(v1_pod_status_t *v1_pod_status) {
         free(v1_pod_status->pod_ip);
         v1_pod_status->pod_ip = NULL;
     }
-    if (v1_pod_status->pod_i_ps) {
-        list_ForEach(listEntry, v1_pod_status->pod_i_ps) {
+    if (v1_pod_status->pod_ips) {
+        list_ForEach(listEntry, v1_pod_status->pod_ips) {
             v1_pod_ip_free(listEntry->data);
         }
-        list_free(v1_pod_status->pod_i_ps);
-        v1_pod_status->pod_i_ps = NULL;
+        list_free(v1_pod_status->pod_ips);
+        v1_pod_status->pod_ips = NULL;
     }
     if (v1_pod_status->qos_class) {
         free(v1_pod_status->qos_class);
@@ -240,21 +240,21 @@ cJSON *v1_pod_status_convertToJSON(v1_pod_status_t *v1_pod_status) {
      } 
 
 
-    // v1_pod_status->pod_i_ps
-    if(v1_pod_status->pod_i_ps) { 
-    cJSON *pod_i_ps = cJSON_AddArrayToObject(item, "podIPs");
-    if(pod_i_ps == NULL) {
+    // v1_pod_status->pod_ips
+    if(v1_pod_status->pod_ips) { 
+    cJSON *pod_ips = cJSON_AddArrayToObject(item, "podIPs");
+    if(pod_ips == NULL) {
     goto fail; //nonprimitive container
     }
 
-    listEntry_t *pod_i_psListEntry;
-    if (v1_pod_status->pod_i_ps) {
-    list_ForEach(pod_i_psListEntry, v1_pod_status->pod_i_ps) {
-    cJSON *itemLocal = v1_pod_ip_convertToJSON(pod_i_psListEntry->data);
+    listEntry_t *pod_ipsListEntry;
+    if (v1_pod_status->pod_ips) {
+    list_ForEach(pod_ipsListEntry, v1_pod_status->pod_ips) {
+    cJSON *itemLocal = v1_pod_ip_convertToJSON(pod_ipsListEntry->data);
     if(itemLocal == NULL) {
     goto fail;
     }
-    cJSON_AddItemToArray(pod_i_ps, itemLocal);
+    cJSON_AddItemToArray(pod_ips, itemLocal);
     }
     }
      } 
@@ -428,25 +428,25 @@ v1_pod_status_t *v1_pod_status_parseFromJSON(cJSON *v1_pod_statusJSON){
     }
     }
 
-    // v1_pod_status->pod_i_ps
-    cJSON *pod_i_ps = cJSON_GetObjectItemCaseSensitive(v1_pod_statusJSON, "podIPs");
-    list_t *pod_i_psList;
-    if (pod_i_ps) { 
-    cJSON *pod_i_ps_local_nonprimitive;
-    if(!cJSON_IsArray(pod_i_ps)){
+    // v1_pod_status->pod_ips
+    cJSON *pod_ips = cJSON_GetObjectItemCaseSensitive(v1_pod_statusJSON, "podIPs");
+    list_t *pod_ipsList;
+    if (pod_ips) { 
+    cJSON *pod_ips_local_nonprimitive;
+    if(!cJSON_IsArray(pod_ips)){
         goto end; //nonprimitive container
     }
 
-    pod_i_psList = list_create();
+    pod_ipsList = list_create();
 
-    cJSON_ArrayForEach(pod_i_ps_local_nonprimitive,pod_i_ps )
+    cJSON_ArrayForEach(pod_ips_local_nonprimitive,pod_ips )
     {
-        if(!cJSON_IsObject(pod_i_ps_local_nonprimitive)){
+        if(!cJSON_IsObject(pod_ips_local_nonprimitive)){
             goto end;
         }
-        v1_pod_ip_t *pod_i_psItem = v1_pod_ip_parseFromJSON(pod_i_ps_local_nonprimitive);
+        v1_pod_ip_t *pod_ipsItem = v1_pod_ip_parseFromJSON(pod_ips_local_nonprimitive);
 
-        list_addElement(pod_i_psList, pod_i_psItem);
+        list_addElement(pod_ipsList, pod_ipsItem);
     }
     }
 
@@ -488,7 +488,7 @@ v1_pod_status_t *v1_pod_status_parseFromJSON(cJSON *v1_pod_statusJSON){
         nominated_node_name ? strdup(nominated_node_name->valuestring) : NULL,
         phase ? strdup(phase->valuestring) : NULL,
         pod_ip ? strdup(pod_ip->valuestring) : NULL,
-        pod_i_ps ? pod_i_psList : NULL,
+        pod_ips ? pod_ipsList : NULL,
         qos_class ? strdup(qos_class->valuestring) : NULL,
         reason ? strdup(reason->valuestring) : NULL,
         start_time ? strdup(start_time->valuestring) : NULL

--- a/kubernetes/model/v1_pod_status.h
+++ b/kubernetes/model/v1_pod_status.h
@@ -31,7 +31,7 @@ typedef struct v1_pod_status_t {
     char *nominated_node_name; // string
     char *phase; // string
     char *pod_ip; // string
-    list_t *pod_i_ps; //nonprimitive container
+    list_t *pod_ips; //nonprimitive container
     char *qos_class; // string
     char *reason; // string
     char *start_time; //date time
@@ -48,7 +48,7 @@ v1_pod_status_t *v1_pod_status_create(
     char *nominated_node_name,
     char *phase,
     char *pod_ip,
-    list_t *pod_i_ps,
+    list_t *pod_ips,
     char *qos_class,
     char *reason,
     char *start_time

--- a/kubernetes/model/v1_pod_template.c
+++ b/kubernetes/model/v1_pod_template.c
@@ -146,6 +146,14 @@ v1_pod_template_t *v1_pod_template_parseFromJSON(cJSON *v1_pod_templateJSON){
 
     return v1_pod_template_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_pod_template_list.c
+++ b/kubernetes/model/v1_pod_template_list.c
@@ -176,6 +176,10 @@ v1_pod_template_list_t *v1_pod_template_list_parseFromJSON(cJSON *v1_pod_templat
 
     return v1_pod_template_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_pod_template_spec.c
+++ b/kubernetes/model/v1_pod_template_spec.c
@@ -98,6 +98,14 @@ v1_pod_template_spec_t *v1_pod_template_spec_parseFromJSON(cJSON *v1_pod_templat
 
     return v1_pod_template_spec_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_pod_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_policy_rule.c
+++ b/kubernetes/model/v1_policy_rule.c
@@ -7,7 +7,7 @@
 
 v1_policy_rule_t *v1_policy_rule_create(
     list_t *api_groups,
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *resource_names,
     list_t *resources,
     list_t *verbs
@@ -17,7 +17,7 @@ v1_policy_rule_t *v1_policy_rule_create(
         return NULL;
     }
     v1_policy_rule_local_var->api_groups = api_groups;
-    v1_policy_rule_local_var->non_resource_ur_ls = non_resource_ur_ls;
+    v1_policy_rule_local_var->non_resource_urls = non_resource_urls;
     v1_policy_rule_local_var->resource_names = resource_names;
     v1_policy_rule_local_var->resources = resources;
     v1_policy_rule_local_var->verbs = verbs;
@@ -38,12 +38,12 @@ void v1_policy_rule_free(v1_policy_rule_t *v1_policy_rule) {
         list_free(v1_policy_rule->api_groups);
         v1_policy_rule->api_groups = NULL;
     }
-    if (v1_policy_rule->non_resource_ur_ls) {
-        list_ForEach(listEntry, v1_policy_rule->non_resource_ur_ls) {
+    if (v1_policy_rule->non_resource_urls) {
+        list_ForEach(listEntry, v1_policy_rule->non_resource_urls) {
             free(listEntry->data);
         }
-        list_free(v1_policy_rule->non_resource_ur_ls);
-        v1_policy_rule->non_resource_ur_ls = NULL;
+        list_free(v1_policy_rule->non_resource_urls);
+        v1_policy_rule->non_resource_urls = NULL;
     }
     if (v1_policy_rule->resource_names) {
         list_ForEach(listEntry, v1_policy_rule->resource_names) {
@@ -89,16 +89,16 @@ cJSON *v1_policy_rule_convertToJSON(v1_policy_rule_t *v1_policy_rule) {
      } 
 
 
-    // v1_policy_rule->non_resource_ur_ls
-    if(v1_policy_rule->non_resource_ur_ls) { 
-    cJSON *non_resource_ur_ls = cJSON_AddArrayToObject(item, "nonResourceURLs");
-    if(non_resource_ur_ls == NULL) {
+    // v1_policy_rule->non_resource_urls
+    if(v1_policy_rule->non_resource_urls) { 
+    cJSON *non_resource_urls = cJSON_AddArrayToObject(item, "nonResourceURLs");
+    if(non_resource_urls == NULL) {
         goto fail; //primitive container
     }
 
-    listEntry_t *non_resource_ur_lsListEntry;
-    list_ForEach(non_resource_ur_lsListEntry, v1_policy_rule->non_resource_ur_ls) {
-    if(cJSON_AddStringToObject(non_resource_ur_ls, "", (char*)non_resource_ur_lsListEntry->data) == NULL)
+    listEntry_t *non_resource_urlsListEntry;
+    list_ForEach(non_resource_urlsListEntry, v1_policy_rule->non_resource_urls) {
+    if(cJSON_AddStringToObject(non_resource_urls, "", (char*)non_resource_urlsListEntry->data) == NULL)
     {
         goto fail;
     }
@@ -190,23 +190,23 @@ v1_policy_rule_t *v1_policy_rule_parseFromJSON(cJSON *v1_policy_ruleJSON){
     }
     }
 
-    // v1_policy_rule->non_resource_ur_ls
-    cJSON *non_resource_ur_ls = cJSON_GetObjectItemCaseSensitive(v1_policy_ruleJSON, "nonResourceURLs");
-    list_t *non_resource_ur_lsList;
-    if (non_resource_ur_ls) { 
-    cJSON *non_resource_ur_ls_local;
-    if(!cJSON_IsArray(non_resource_ur_ls)) {
+    // v1_policy_rule->non_resource_urls
+    cJSON *non_resource_urls = cJSON_GetObjectItemCaseSensitive(v1_policy_ruleJSON, "nonResourceURLs");
+    list_t *non_resource_urlsList;
+    if (non_resource_urls) { 
+    cJSON *non_resource_urls_local;
+    if(!cJSON_IsArray(non_resource_urls)) {
         goto end;//primitive container
     }
-    non_resource_ur_lsList = list_create();
+    non_resource_urlsList = list_create();
 
-    cJSON_ArrayForEach(non_resource_ur_ls_local, non_resource_ur_ls)
+    cJSON_ArrayForEach(non_resource_urls_local, non_resource_urls)
     {
-        if(!cJSON_IsString(non_resource_ur_ls_local))
+        if(!cJSON_IsString(non_resource_urls_local))
         {
             goto end;
         }
-        list_addElement(non_resource_ur_lsList , strdup(non_resource_ur_ls_local->valuestring));
+        list_addElement(non_resource_urlsList , strdup(non_resource_urls_local->valuestring));
     }
     }
 
@@ -276,7 +276,7 @@ v1_policy_rule_t *v1_policy_rule_parseFromJSON(cJSON *v1_policy_ruleJSON){
 
     v1_policy_rule_local_var = v1_policy_rule_create (
         api_groups ? api_groupsList : NULL,
-        non_resource_ur_ls ? non_resource_ur_lsList : NULL,
+        non_resource_urls ? non_resource_urlsList : NULL,
         resource_names ? resource_namesList : NULL,
         resources ? resourcesList : NULL,
         verbsList

--- a/kubernetes/model/v1_policy_rule.h
+++ b/kubernetes/model/v1_policy_rule.h
@@ -20,7 +20,7 @@ typedef struct v1_policy_rule_t v1_policy_rule_t;
 
 typedef struct v1_policy_rule_t {
     list_t *api_groups; //primitive container
-    list_t *non_resource_ur_ls; //primitive container
+    list_t *non_resource_urls; //primitive container
     list_t *resource_names; //primitive container
     list_t *resources; //primitive container
     list_t *verbs; //primitive container
@@ -29,7 +29,7 @@ typedef struct v1_policy_rule_t {
 
 v1_policy_rule_t *v1_policy_rule_create(
     list_t *api_groups,
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *resource_names,
     list_t *resources,
     list_t *verbs

--- a/kubernetes/model/v1_preferred_scheduling_term.c
+++ b/kubernetes/model/v1_preferred_scheduling_term.c
@@ -101,6 +101,10 @@ v1_preferred_scheduling_term_t *v1_preferred_scheduling_term_parseFromJSON(cJSON
 
     return v1_preferred_scheduling_term_local_var;
 end:
+    if (preference_local_nonprim) {
+        v1_node_selector_term_free(preference_local_nonprim);
+        preference_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_priority_class.c
+++ b/kubernetes/model/v1_priority_class.c
@@ -212,6 +212,10 @@ v1_priority_class_t *v1_priority_class_parseFromJSON(cJSON *v1_priority_classJSO
 
     return v1_priority_class_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_priority_class_list.c
+++ b/kubernetes/model/v1_priority_class_list.c
@@ -176,6 +176,10 @@ v1_priority_class_list_t *v1_priority_class_list_parseFromJSON(cJSON *v1_priorit
 
     return v1_priority_class_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_probe.c
+++ b/kubernetes/model/v1_probe.c
@@ -225,6 +225,18 @@ v1_probe_t *v1_probe_parseFromJSON(cJSON *v1_probeJSON){
 
     return v1_probe_local_var;
 end:
+    if (exec_local_nonprim) {
+        v1_exec_action_free(exec_local_nonprim);
+        exec_local_nonprim = NULL;
+    }
+    if (http_get_local_nonprim) {
+        v1_http_get_action_free(http_get_local_nonprim);
+        http_get_local_nonprim = NULL;
+    }
+    if (tcp_socket_local_nonprim) {
+        v1_tcp_socket_action_free(tcp_socket_local_nonprim);
+        tcp_socket_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_rbd_persistent_volume_source.c
+++ b/kubernetes/model/v1_rbd_persistent_volume_source.c
@@ -268,6 +268,10 @@ v1_rbd_persistent_volume_source_t *v1_rbd_persistent_volume_source_parseFromJSON
 
     return v1_rbd_persistent_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_secret_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_rbd_volume_source.c
+++ b/kubernetes/model/v1_rbd_volume_source.c
@@ -268,6 +268,10 @@ v1_rbd_volume_source_t *v1_rbd_volume_source_parseFromJSON(cJSON *v1_rbd_volume_
 
     return v1_rbd_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_local_object_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_replica_set.c
+++ b/kubernetes/model/v1_replica_set.c
@@ -173,6 +173,18 @@ v1_replica_set_t *v1_replica_set_parseFromJSON(cJSON *v1_replica_setJSON){
 
     return v1_replica_set_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_replica_set_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_replica_set_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_replica_set_list.c
+++ b/kubernetes/model/v1_replica_set_list.c
@@ -176,6 +176,10 @@ v1_replica_set_list_t *v1_replica_set_list_parseFromJSON(cJSON *v1_replica_set_l
 
     return v1_replica_set_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_replica_set_spec.c
+++ b/kubernetes/model/v1_replica_set_spec.c
@@ -143,6 +143,14 @@ v1_replica_set_spec_t *v1_replica_set_spec_parseFromJSON(cJSON *v1_replica_set_s
 
     return v1_replica_set_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_replication_controller.c
+++ b/kubernetes/model/v1_replication_controller.c
@@ -173,6 +173,18 @@ v1_replication_controller_t *v1_replication_controller_parseFromJSON(cJSON *v1_r
 
     return v1_replication_controller_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_replication_controller_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_replication_controller_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_replication_controller_list.c
+++ b/kubernetes/model/v1_replication_controller_list.c
@@ -176,6 +176,10 @@ v1_replication_controller_list_t *v1_replication_controller_list_parseFromJSON(c
 
     return v1_replication_controller_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_replication_controller_spec.c
+++ b/kubernetes/model/v1_replication_controller_spec.c
@@ -166,6 +166,10 @@ v1_replication_controller_spec_t *v1_replication_controller_spec_parseFromJSON(c
 
     return v1_replication_controller_spec_local_var;
 end:
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_resource_quota.c
+++ b/kubernetes/model/v1_resource_quota.c
@@ -173,6 +173,18 @@ v1_resource_quota_t *v1_resource_quota_parseFromJSON(cJSON *v1_resource_quotaJSO
 
     return v1_resource_quota_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_resource_quota_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_resource_quota_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_resource_quota_list.c
+++ b/kubernetes/model/v1_resource_quota_list.c
@@ -176,6 +176,10 @@ v1_resource_quota_list_t *v1_resource_quota_list_parseFromJSON(cJSON *v1_resourc
 
     return v1_resource_quota_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_resource_quota_spec.c
+++ b/kubernetes/model/v1_resource_quota_spec.c
@@ -173,6 +173,10 @@ v1_resource_quota_spec_t *v1_resource_quota_spec_parseFromJSON(cJSON *v1_resourc
 
     return v1_resource_quota_spec_local_var;
 end:
+    if (scope_selector_local_nonprim) {
+        v1_scope_selector_free(scope_selector_local_nonprim);
+        scope_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_role.c
+++ b/kubernetes/model/v1_role.c
@@ -171,6 +171,10 @@ v1_role_t *v1_role_parseFromJSON(cJSON *v1_roleJSON){
 
     return v1_role_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_role_binding.c
+++ b/kubernetes/model/v1_role_binding.c
@@ -203,6 +203,14 @@ v1_role_binding_t *v1_role_binding_parseFromJSON(cJSON *v1_role_bindingJSON){
 
     return v1_role_binding_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (role_ref_local_nonprim) {
+        v1_role_ref_free(role_ref_local_nonprim);
+        role_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_role_binding_list.c
+++ b/kubernetes/model/v1_role_binding_list.c
@@ -176,6 +176,10 @@ v1_role_binding_list_t *v1_role_binding_list_parseFromJSON(cJSON *v1_role_bindin
 
     return v1_role_binding_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_role_list.c
+++ b/kubernetes/model/v1_role_list.c
@@ -176,6 +176,10 @@ v1_role_list_t *v1_role_list_parseFromJSON(cJSON *v1_role_listJSON){
 
     return v1_role_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_scale.c
+++ b/kubernetes/model/v1_scale.c
@@ -173,6 +173,18 @@ v1_scale_t *v1_scale_parseFromJSON(cJSON *v1_scaleJSON){
 
     return v1_scale_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_scale_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_scale_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_scale_io_persistent_volume_source.c
+++ b/kubernetes/model/v1_scale_io_persistent_volume_source.c
@@ -294,6 +294,10 @@ v1_scale_io_persistent_volume_source_t *v1_scale_io_persistent_volume_source_par
 
     return v1_scale_io_persistent_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_secret_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_scale_io_volume_source.c
+++ b/kubernetes/model/v1_scale_io_volume_source.c
@@ -294,6 +294,10 @@ v1_scale_io_volume_source_t *v1_scale_io_volume_source_parseFromJSON(cJSON *v1_s
 
     return v1_scale_io_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_local_object_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_secret.c
+++ b/kubernetes/model/v1_secret.c
@@ -244,6 +244,10 @@ v1_secret_t *v1_secret_parseFromJSON(cJSON *v1_secretJSON){
 
     return v1_secret_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_secret_list.c
+++ b/kubernetes/model/v1_secret_list.c
@@ -176,6 +176,10 @@ v1_secret_list_t *v1_secret_list_parseFromJSON(cJSON *v1_secret_listJSON){
 
     return v1_secret_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_security_context.c
+++ b/kubernetes/model/v1_security_context.c
@@ -269,6 +269,18 @@ v1_security_context_t *v1_security_context_parseFromJSON(cJSON *v1_security_cont
 
     return v1_security_context_local_var;
 end:
+    if (capabilities_local_nonprim) {
+        v1_capabilities_free(capabilities_local_nonprim);
+        capabilities_local_nonprim = NULL;
+    }
+    if (se_linux_options_local_nonprim) {
+        v1_se_linux_options_free(se_linux_options_local_nonprim);
+        se_linux_options_local_nonprim = NULL;
+    }
+    if (windows_options_local_nonprim) {
+        v1_windows_security_context_options_free(windows_options_local_nonprim);
+        windows_options_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_self_subject_access_review.c
+++ b/kubernetes/model/v1_self_subject_access_review.c
@@ -178,6 +178,18 @@ v1_self_subject_access_review_t *v1_self_subject_access_review_parseFromJSON(cJS
 
     return v1_self_subject_access_review_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_self_subject_access_review_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_subject_access_review_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_self_subject_access_review_spec.c
+++ b/kubernetes/model/v1_self_subject_access_review_spec.c
@@ -98,6 +98,14 @@ v1_self_subject_access_review_spec_t *v1_self_subject_access_review_spec_parseFr
 
     return v1_self_subject_access_review_spec_local_var;
 end:
+    if (non_resource_attributes_local_nonprim) {
+        v1_non_resource_attributes_free(non_resource_attributes_local_nonprim);
+        non_resource_attributes_local_nonprim = NULL;
+    }
+    if (resource_attributes_local_nonprim) {
+        v1_resource_attributes_free(resource_attributes_local_nonprim);
+        resource_attributes_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_self_subject_rules_review.c
+++ b/kubernetes/model/v1_self_subject_rules_review.c
@@ -178,6 +178,18 @@ v1_self_subject_rules_review_t *v1_self_subject_rules_review_parseFromJSON(cJSON
 
     return v1_self_subject_rules_review_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_self_subject_rules_review_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_subject_rules_review_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_service.c
+++ b/kubernetes/model/v1_service.c
@@ -173,6 +173,18 @@ v1_service_t *v1_service_parseFromJSON(cJSON *v1_serviceJSON){
 
     return v1_service_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_service_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_service_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_service_account.c
+++ b/kubernetes/model/v1_service_account.c
@@ -243,6 +243,10 @@ v1_service_account_t *v1_service_account_parseFromJSON(cJSON *v1_service_account
 
     return v1_service_account_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_service_account_list.c
+++ b/kubernetes/model/v1_service_account_list.c
@@ -176,6 +176,10 @@ v1_service_account_list_t *v1_service_account_list_parseFromJSON(cJSON *v1_servi
 
     return v1_service_account_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_service_list.c
+++ b/kubernetes/model/v1_service_list.c
@@ -176,6 +176,10 @@ v1_service_list_t *v1_service_list_parseFromJSON(cJSON *v1_service_listJSON){
 
     return v1_service_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_service_spec.h
+++ b/kubernetes/model/v1_service_spec.h
@@ -22,7 +22,7 @@ typedef struct v1_service_spec_t v1_service_spec_t;
 
 typedef struct v1_service_spec_t {
     char *cluster_ip; // string
-    list_t *external_i_ps; //primitive container
+    list_t *external_ips; //primitive container
     char *external_name; // string
     char *external_traffic_policy; // string
     int health_check_node_port; //numeric
@@ -41,7 +41,7 @@ typedef struct v1_service_spec_t {
 
 v1_service_spec_t *v1_service_spec_create(
     char *cluster_ip,
-    list_t *external_i_ps,
+    list_t *external_ips,
     char *external_name,
     char *external_traffic_policy,
     int health_check_node_port,

--- a/kubernetes/model/v1_service_status.c
+++ b/kubernetes/model/v1_service_status.c
@@ -71,6 +71,10 @@ v1_service_status_t *v1_service_status_parseFromJSON(cJSON *v1_service_statusJSO
 
     return v1_service_status_local_var;
 end:
+    if (load_balancer_local_nonprim) {
+        v1_load_balancer_status_free(load_balancer_local_nonprim);
+        load_balancer_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_session_affinity_config.c
+++ b/kubernetes/model/v1_session_affinity_config.c
@@ -71,6 +71,10 @@ v1_session_affinity_config_t *v1_session_affinity_config_parseFromJSON(cJSON *v1
 
     return v1_session_affinity_config_local_var;
 end:
+    if (client_ip_local_nonprim) {
+        v1_client_ip_config_free(client_ip_local_nonprim);
+        client_ip_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_stateful_set.c
+++ b/kubernetes/model/v1_stateful_set.c
@@ -173,6 +173,18 @@ v1_stateful_set_t *v1_stateful_set_parseFromJSON(cJSON *v1_stateful_setJSON){
 
     return v1_stateful_set_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_stateful_set_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_stateful_set_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_stateful_set_list.c
+++ b/kubernetes/model/v1_stateful_set_list.c
@@ -176,6 +176,10 @@ v1_stateful_set_list_t *v1_stateful_set_list_parseFromJSON(cJSON *v1_stateful_se
 
     return v1_stateful_set_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_stateful_set_spec.c
+++ b/kubernetes/model/v1_stateful_set_spec.c
@@ -280,6 +280,18 @@ v1_stateful_set_spec_t *v1_stateful_set_spec_parseFromJSON(cJSON *v1_stateful_se
 
     return v1_stateful_set_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
+    if (update_strategy_local_nonprim) {
+        v1_stateful_set_update_strategy_free(update_strategy_local_nonprim);
+        update_strategy_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_stateful_set_update_strategy.c
+++ b/kubernetes/model/v1_stateful_set_update_strategy.c
@@ -95,6 +95,10 @@ v1_stateful_set_update_strategy_t *v1_stateful_set_update_strategy_parseFromJSON
 
     return v1_stateful_set_update_strategy_local_var;
 end:
+    if (rolling_update_local_nonprim) {
+        v1_rolling_update_stateful_set_strategy_free(rolling_update_local_nonprim);
+        rolling_update_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_status.c
+++ b/kubernetes/model/v1_status.c
@@ -238,6 +238,14 @@ v1_status_t *v1_status_parseFromJSON(cJSON *v1_statusJSON){
 
     return v1_status_local_var;
 end:
+    if (details_local_nonprim) {
+        v1_status_details_free(details_local_nonprim);
+        details_local_nonprim = NULL;
+    }
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_storage_class.c
+++ b/kubernetes/model/v1_storage_class.c
@@ -370,6 +370,10 @@ v1_storage_class_t *v1_storage_class_parseFromJSON(cJSON *v1_storage_classJSON){
 
     return v1_storage_class_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_storage_class_list.c
+++ b/kubernetes/model/v1_storage_class_list.c
@@ -176,6 +176,10 @@ v1_storage_class_list_t *v1_storage_class_list_parseFromJSON(cJSON *v1_storage_c
 
     return v1_storage_class_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_storage_os_persistent_volume_source.c
+++ b/kubernetes/model/v1_storage_os_persistent_volume_source.c
@@ -163,6 +163,10 @@ v1_storage_os_persistent_volume_source_t *v1_storage_os_persistent_volume_source
 
     return v1_storage_os_persistent_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_object_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_storage_os_volume_source.c
+++ b/kubernetes/model/v1_storage_os_volume_source.c
@@ -163,6 +163,10 @@ v1_storage_os_volume_source_t *v1_storage_os_volume_source_parseFromJSON(cJSON *
 
     return v1_storage_os_volume_source_local_var;
 end:
+    if (secret_ref_local_nonprim) {
+        v1_local_object_reference_free(secret_ref_local_nonprim);
+        secret_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_subject_access_review.c
+++ b/kubernetes/model/v1_subject_access_review.c
@@ -178,6 +178,18 @@ v1_subject_access_review_t *v1_subject_access_review_parseFromJSON(cJSON *v1_sub
 
     return v1_subject_access_review_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_subject_access_review_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_subject_access_review_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_subject_access_review_spec.c
+++ b/kubernetes/model/v1_subject_access_review_spec.c
@@ -239,6 +239,14 @@ v1_subject_access_review_spec_t *v1_subject_access_review_spec_parseFromJSON(cJS
 
     return v1_subject_access_review_spec_local_var;
 end:
+    if (non_resource_attributes_local_nonprim) {
+        v1_non_resource_attributes_free(non_resource_attributes_local_nonprim);
+        non_resource_attributes_local_nonprim = NULL;
+    }
+    if (resource_attributes_local_nonprim) {
+        v1_resource_attributes_free(resource_attributes_local_nonprim);
+        resource_attributes_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_token_request.c
+++ b/kubernetes/model/v1_token_request.c
@@ -178,6 +178,18 @@ v1_token_request_t *v1_token_request_parseFromJSON(cJSON *v1_token_requestJSON){
 
     return v1_token_request_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_token_request_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_token_request_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_token_request_spec.c
+++ b/kubernetes/model/v1_token_request_spec.c
@@ -143,6 +143,10 @@ v1_token_request_spec_t *v1_token_request_spec_parseFromJSON(cJSON *v1_token_req
 
     return v1_token_request_spec_local_var;
 end:
+    if (bound_object_ref_local_nonprim) {
+        v1_bound_object_reference_free(bound_object_ref_local_nonprim);
+        bound_object_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_token_review.c
+++ b/kubernetes/model/v1_token_review.c
@@ -178,6 +178,18 @@ v1_token_review_t *v1_token_review_parseFromJSON(cJSON *v1_token_reviewJSON){
 
     return v1_token_review_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_token_review_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_token_review_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_token_review_status.c
+++ b/kubernetes/model/v1_token_review_status.c
@@ -162,6 +162,10 @@ v1_token_review_status_t *v1_token_review_status_parseFromJSON(cJSON *v1_token_r
 
     return v1_token_review_status_local_var;
 end:
+    if (user_local_nonprim) {
+        v1_user_info_free(user_local_nonprim);
+        user_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_topology_spread_constraint.c
+++ b/kubernetes/model/v1_topology_spread_constraint.c
@@ -154,6 +154,10 @@ v1_topology_spread_constraint_t *v1_topology_spread_constraint_parseFromJSON(cJS
 
     return v1_topology_spread_constraint_local_var;
 end:
+    if (label_selector_local_nonprim) {
+        v1_label_selector_free(label_selector_local_nonprim);
+        label_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_validating_webhook.c
+++ b/kubernetes/model/v1_validating_webhook.c
@@ -360,6 +360,18 @@ v1_validating_webhook_t *v1_validating_webhook_parseFromJSON(cJSON *v1_validatin
 
     return v1_validating_webhook_local_var;
 end:
+    if (client_config_local_nonprim) {
+        admissionregistration_v1_webhook_client_config_free(client_config_local_nonprim);
+        client_config_local_nonprim = NULL;
+    }
+    if (namespace_selector_local_nonprim) {
+        v1_label_selector_free(namespace_selector_local_nonprim);
+        namespace_selector_local_nonprim = NULL;
+    }
+    if (object_selector_local_nonprim) {
+        v1_label_selector_free(object_selector_local_nonprim);
+        object_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_validating_webhook_configuration.c
+++ b/kubernetes/model/v1_validating_webhook_configuration.c
@@ -171,6 +171,10 @@ v1_validating_webhook_configuration_t *v1_validating_webhook_configuration_parse
 
     return v1_validating_webhook_configuration_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_validating_webhook_configuration_list.c
+++ b/kubernetes/model/v1_validating_webhook_configuration_list.c
@@ -176,6 +176,10 @@ v1_validating_webhook_configuration_list_t *v1_validating_webhook_configuration_
 
     return v1_validating_webhook_configuration_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_volume.c
+++ b/kubernetes/model/v1_volume.c
@@ -829,6 +829,118 @@ v1_volume_t *v1_volume_parseFromJSON(cJSON *v1_volumeJSON){
 
     return v1_volume_local_var;
 end:
+    if (aws_elastic_block_store_local_nonprim) {
+        v1_aws_elastic_block_store_volume_source_free(aws_elastic_block_store_local_nonprim);
+        aws_elastic_block_store_local_nonprim = NULL;
+    }
+    if (azure_disk_local_nonprim) {
+        v1_azure_disk_volume_source_free(azure_disk_local_nonprim);
+        azure_disk_local_nonprim = NULL;
+    }
+    if (azure_file_local_nonprim) {
+        v1_azure_file_volume_source_free(azure_file_local_nonprim);
+        azure_file_local_nonprim = NULL;
+    }
+    if (cephfs_local_nonprim) {
+        v1_ceph_fs_volume_source_free(cephfs_local_nonprim);
+        cephfs_local_nonprim = NULL;
+    }
+    if (cinder_local_nonprim) {
+        v1_cinder_volume_source_free(cinder_local_nonprim);
+        cinder_local_nonprim = NULL;
+    }
+    if (config_map_local_nonprim) {
+        v1_config_map_volume_source_free(config_map_local_nonprim);
+        config_map_local_nonprim = NULL;
+    }
+    if (csi_local_nonprim) {
+        v1_csi_volume_source_free(csi_local_nonprim);
+        csi_local_nonprim = NULL;
+    }
+    if (downward_api_local_nonprim) {
+        v1_downward_api_volume_source_free(downward_api_local_nonprim);
+        downward_api_local_nonprim = NULL;
+    }
+    if (empty_dir_local_nonprim) {
+        v1_empty_dir_volume_source_free(empty_dir_local_nonprim);
+        empty_dir_local_nonprim = NULL;
+    }
+    if (fc_local_nonprim) {
+        v1_fc_volume_source_free(fc_local_nonprim);
+        fc_local_nonprim = NULL;
+    }
+    if (flex_volume_local_nonprim) {
+        v1_flex_volume_source_free(flex_volume_local_nonprim);
+        flex_volume_local_nonprim = NULL;
+    }
+    if (flocker_local_nonprim) {
+        v1_flocker_volume_source_free(flocker_local_nonprim);
+        flocker_local_nonprim = NULL;
+    }
+    if (gce_persistent_disk_local_nonprim) {
+        v1_gce_persistent_disk_volume_source_free(gce_persistent_disk_local_nonprim);
+        gce_persistent_disk_local_nonprim = NULL;
+    }
+    if (git_repo_local_nonprim) {
+        v1_git_repo_volume_source_free(git_repo_local_nonprim);
+        git_repo_local_nonprim = NULL;
+    }
+    if (glusterfs_local_nonprim) {
+        v1_glusterfs_volume_source_free(glusterfs_local_nonprim);
+        glusterfs_local_nonprim = NULL;
+    }
+    if (host_path_local_nonprim) {
+        v1_host_path_volume_source_free(host_path_local_nonprim);
+        host_path_local_nonprim = NULL;
+    }
+    if (iscsi_local_nonprim) {
+        v1_iscsi_volume_source_free(iscsi_local_nonprim);
+        iscsi_local_nonprim = NULL;
+    }
+    if (nfs_local_nonprim) {
+        v1_nfs_volume_source_free(nfs_local_nonprim);
+        nfs_local_nonprim = NULL;
+    }
+    if (persistent_volume_claim_local_nonprim) {
+        v1_persistent_volume_claim_volume_source_free(persistent_volume_claim_local_nonprim);
+        persistent_volume_claim_local_nonprim = NULL;
+    }
+    if (photon_persistent_disk_local_nonprim) {
+        v1_photon_persistent_disk_volume_source_free(photon_persistent_disk_local_nonprim);
+        photon_persistent_disk_local_nonprim = NULL;
+    }
+    if (portworx_volume_local_nonprim) {
+        v1_portworx_volume_source_free(portworx_volume_local_nonprim);
+        portworx_volume_local_nonprim = NULL;
+    }
+    if (projected_local_nonprim) {
+        v1_projected_volume_source_free(projected_local_nonprim);
+        projected_local_nonprim = NULL;
+    }
+    if (quobyte_local_nonprim) {
+        v1_quobyte_volume_source_free(quobyte_local_nonprim);
+        quobyte_local_nonprim = NULL;
+    }
+    if (rbd_local_nonprim) {
+        v1_rbd_volume_source_free(rbd_local_nonprim);
+        rbd_local_nonprim = NULL;
+    }
+    if (scale_io_local_nonprim) {
+        v1_scale_io_volume_source_free(scale_io_local_nonprim);
+        scale_io_local_nonprim = NULL;
+    }
+    if (secret_local_nonprim) {
+        v1_secret_volume_source_free(secret_local_nonprim);
+        secret_local_nonprim = NULL;
+    }
+    if (storageos_local_nonprim) {
+        v1_storage_os_volume_source_free(storageos_local_nonprim);
+        storageos_local_nonprim = NULL;
+    }
+    if (vsphere_volume_local_nonprim) {
+        v1_vsphere_virtual_disk_volume_source_free(vsphere_volume_local_nonprim);
+        vsphere_volume_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_volume_attachment.c
+++ b/kubernetes/model/v1_volume_attachment.c
@@ -178,6 +178,18 @@ v1_volume_attachment_t *v1_volume_attachment_parseFromJSON(cJSON *v1_volume_atta
 
     return v1_volume_attachment_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_volume_attachment_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1_volume_attachment_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_volume_attachment_list.c
+++ b/kubernetes/model/v1_volume_attachment_list.c
@@ -176,6 +176,10 @@ v1_volume_attachment_list_t *v1_volume_attachment_list_parseFromJSON(cJSON *v1_v
 
     return v1_volume_attachment_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_volume_attachment_source.c
+++ b/kubernetes/model/v1_volume_attachment_source.c
@@ -95,6 +95,10 @@ v1_volume_attachment_source_t *v1_volume_attachment_source_parseFromJSON(cJSON *
 
     return v1_volume_attachment_source_local_var;
 end:
+    if (inline_volume_spec_local_nonprim) {
+        v1_persistent_volume_spec_free(inline_volume_spec_local_nonprim);
+        inline_volume_spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_volume_attachment_spec.c
+++ b/kubernetes/model/v1_volume_attachment_spec.c
@@ -134,6 +134,10 @@ v1_volume_attachment_spec_t *v1_volume_attachment_spec_parseFromJSON(cJSON *v1_v
 
     return v1_volume_attachment_spec_local_var;
 end:
+    if (source_local_nonprim) {
+        v1_volume_attachment_source_free(source_local_nonprim);
+        source_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_volume_attachment_status.c
+++ b/kubernetes/model/v1_volume_attachment_status.c
@@ -178,6 +178,14 @@ v1_volume_attachment_status_t *v1_volume_attachment_status_parseFromJSON(cJSON *
 
     return v1_volume_attachment_status_local_var;
 end:
+    if (attach_error_local_nonprim) {
+        v1_volume_error_free(attach_error_local_nonprim);
+        attach_error_local_nonprim = NULL;
+    }
+    if (detach_error_local_nonprim) {
+        v1_volume_error_free(detach_error_local_nonprim);
+        detach_error_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_volume_node_affinity.c
+++ b/kubernetes/model/v1_volume_node_affinity.c
@@ -71,6 +71,10 @@ v1_volume_node_affinity_t *v1_volume_node_affinity_parseFromJSON(cJSON *v1_volum
 
     return v1_volume_node_affinity_local_var;
 end:
+    if (required_local_nonprim) {
+        v1_node_selector_free(required_local_nonprim);
+        required_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_volume_projection.c
+++ b/kubernetes/model/v1_volume_projection.c
@@ -152,6 +152,22 @@ v1_volume_projection_t *v1_volume_projection_parseFromJSON(cJSON *v1_volume_proj
 
     return v1_volume_projection_local_var;
 end:
+    if (config_map_local_nonprim) {
+        v1_config_map_projection_free(config_map_local_nonprim);
+        config_map_local_nonprim = NULL;
+    }
+    if (downward_api_local_nonprim) {
+        v1_downward_api_projection_free(downward_api_local_nonprim);
+        downward_api_local_nonprim = NULL;
+    }
+    if (secret_local_nonprim) {
+        v1_secret_projection_free(secret_local_nonprim);
+        secret_local_nonprim = NULL;
+    }
+    if (service_account_token_local_nonprim) {
+        v1_service_account_token_projection_free(service_account_token_local_nonprim);
+        service_account_token_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_webhook_conversion.c
+++ b/kubernetes/model/v1_webhook_conversion.c
@@ -123,6 +123,10 @@ v1_webhook_conversion_t *v1_webhook_conversion_parseFromJSON(cJSON *v1_webhook_c
 
     return v1_webhook_conversion_local_var;
 end:
+    if (client_config_local_nonprim) {
+        apiextensions_v1_webhook_client_config_free(client_config_local_nonprim);
+        client_config_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1_weighted_pod_affinity_term.c
+++ b/kubernetes/model/v1_weighted_pod_affinity_term.c
@@ -101,6 +101,10 @@ v1_weighted_pod_affinity_term_t *v1_weighted_pod_affinity_term_parseFromJSON(cJS
 
     return v1_weighted_pod_affinity_term_local_var;
 end:
+    if (pod_affinity_term_local_nonprim) {
+        v1_pod_affinity_term_free(pod_affinity_term_local_nonprim);
+        pod_affinity_term_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_audit_sink.c
+++ b/kubernetes/model/v1alpha1_audit_sink.c
@@ -146,6 +146,14 @@ v1alpha1_audit_sink_t *v1alpha1_audit_sink_parseFromJSON(cJSON *v1alpha1_audit_s
 
     return v1alpha1_audit_sink_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1alpha1_audit_sink_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_audit_sink_list.c
+++ b/kubernetes/model/v1alpha1_audit_sink_list.c
@@ -176,6 +176,10 @@ v1alpha1_audit_sink_list_t *v1alpha1_audit_sink_list_parseFromJSON(cJSON *v1alph
 
     return v1alpha1_audit_sink_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_audit_sink_spec.c
+++ b/kubernetes/model/v1alpha1_audit_sink_spec.c
@@ -108,6 +108,14 @@ v1alpha1_audit_sink_spec_t *v1alpha1_audit_sink_spec_parseFromJSON(cJSON *v1alph
 
     return v1alpha1_audit_sink_spec_local_var;
 end:
+    if (policy_local_nonprim) {
+        v1alpha1_policy_free(policy_local_nonprim);
+        policy_local_nonprim = NULL;
+    }
+    if (webhook_local_nonprim) {
+        v1alpha1_webhook_free(webhook_local_nonprim);
+        webhook_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_cluster_role.c
+++ b/kubernetes/model/v1alpha1_cluster_role.c
@@ -198,6 +198,14 @@ v1alpha1_cluster_role_t *v1alpha1_cluster_role_parseFromJSON(cJSON *v1alpha1_clu
 
     return v1alpha1_cluster_role_local_var;
 end:
+    if (aggregation_rule_local_nonprim) {
+        v1alpha1_aggregation_rule_free(aggregation_rule_local_nonprim);
+        aggregation_rule_local_nonprim = NULL;
+    }
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_cluster_role_binding.c
+++ b/kubernetes/model/v1alpha1_cluster_role_binding.c
@@ -203,6 +203,14 @@ v1alpha1_cluster_role_binding_t *v1alpha1_cluster_role_binding_parseFromJSON(cJS
 
     return v1alpha1_cluster_role_binding_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (role_ref_local_nonprim) {
+        v1alpha1_role_ref_free(role_ref_local_nonprim);
+        role_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_cluster_role_binding_list.c
+++ b/kubernetes/model/v1alpha1_cluster_role_binding_list.c
@@ -176,6 +176,10 @@ v1alpha1_cluster_role_binding_list_t *v1alpha1_cluster_role_binding_list_parseFr
 
     return v1alpha1_cluster_role_binding_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_cluster_role_list.c
+++ b/kubernetes/model/v1alpha1_cluster_role_list.c
@@ -176,6 +176,10 @@ v1alpha1_cluster_role_list_t *v1alpha1_cluster_role_list_parseFromJSON(cJSON *v1
 
     return v1alpha1_cluster_role_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_flow_schema.c
+++ b/kubernetes/model/v1alpha1_flow_schema.c
@@ -173,6 +173,18 @@ v1alpha1_flow_schema_t *v1alpha1_flow_schema_parseFromJSON(cJSON *v1alpha1_flow_
 
     return v1alpha1_flow_schema_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1alpha1_flow_schema_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1alpha1_flow_schema_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_flow_schema_list.c
+++ b/kubernetes/model/v1alpha1_flow_schema_list.c
@@ -176,6 +176,10 @@ v1alpha1_flow_schema_list_t *v1alpha1_flow_schema_list_parseFromJSON(cJSON *v1al
 
     return v1alpha1_flow_schema_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_flow_schema_spec.c
+++ b/kubernetes/model/v1alpha1_flow_schema_spec.c
@@ -175,6 +175,14 @@ v1alpha1_flow_schema_spec_t *v1alpha1_flow_schema_spec_parseFromJSON(cJSON *v1al
 
     return v1alpha1_flow_schema_spec_local_var;
 end:
+    if (distinguisher_method_local_nonprim) {
+        v1alpha1_flow_distinguisher_method_free(distinguisher_method_local_nonprim);
+        distinguisher_method_local_nonprim = NULL;
+    }
+    if (priority_level_configuration_local_nonprim) {
+        v1alpha1_priority_level_configuration_reference_free(priority_level_configuration_local_nonprim);
+        priority_level_configuration_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_limit_response.c
+++ b/kubernetes/model/v1alpha1_limit_response.c
@@ -100,6 +100,10 @@ v1alpha1_limit_response_t *v1alpha1_limit_response_parseFromJSON(cJSON *v1alpha1
 
     return v1alpha1_limit_response_local_var;
 end:
+    if (queuing_local_nonprim) {
+        v1alpha1_queuing_configuration_free(queuing_local_nonprim);
+        queuing_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_limited_priority_level_configuration.c
+++ b/kubernetes/model/v1alpha1_limited_priority_level_configuration.c
@@ -91,6 +91,10 @@ v1alpha1_limited_priority_level_configuration_t *v1alpha1_limited_priority_level
 
     return v1alpha1_limited_priority_level_configuration_local_var;
 end:
+    if (limit_response_local_nonprim) {
+        v1alpha1_limit_response_free(limit_response_local_nonprim);
+        limit_response_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_non_resource_policy_rule.c
+++ b/kubernetes/model/v1alpha1_non_resource_policy_rule.c
@@ -6,14 +6,14 @@
 
 
 v1alpha1_non_resource_policy_rule_t *v1alpha1_non_resource_policy_rule_create(
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *verbs
     ) {
     v1alpha1_non_resource_policy_rule_t *v1alpha1_non_resource_policy_rule_local_var = malloc(sizeof(v1alpha1_non_resource_policy_rule_t));
     if (!v1alpha1_non_resource_policy_rule_local_var) {
         return NULL;
     }
-    v1alpha1_non_resource_policy_rule_local_var->non_resource_ur_ls = non_resource_ur_ls;
+    v1alpha1_non_resource_policy_rule_local_var->non_resource_urls = non_resource_urls;
     v1alpha1_non_resource_policy_rule_local_var->verbs = verbs;
 
     return v1alpha1_non_resource_policy_rule_local_var;
@@ -25,12 +25,12 @@ void v1alpha1_non_resource_policy_rule_free(v1alpha1_non_resource_policy_rule_t 
         return ;
     }
     listEntry_t *listEntry;
-    if (v1alpha1_non_resource_policy_rule->non_resource_ur_ls) {
-        list_ForEach(listEntry, v1alpha1_non_resource_policy_rule->non_resource_ur_ls) {
+    if (v1alpha1_non_resource_policy_rule->non_resource_urls) {
+        list_ForEach(listEntry, v1alpha1_non_resource_policy_rule->non_resource_urls) {
             free(listEntry->data);
         }
-        list_free(v1alpha1_non_resource_policy_rule->non_resource_ur_ls);
-        v1alpha1_non_resource_policy_rule->non_resource_ur_ls = NULL;
+        list_free(v1alpha1_non_resource_policy_rule->non_resource_urls);
+        v1alpha1_non_resource_policy_rule->non_resource_urls = NULL;
     }
     if (v1alpha1_non_resource_policy_rule->verbs) {
         list_ForEach(listEntry, v1alpha1_non_resource_policy_rule->verbs) {
@@ -45,19 +45,19 @@ void v1alpha1_non_resource_policy_rule_free(v1alpha1_non_resource_policy_rule_t 
 cJSON *v1alpha1_non_resource_policy_rule_convertToJSON(v1alpha1_non_resource_policy_rule_t *v1alpha1_non_resource_policy_rule) {
     cJSON *item = cJSON_CreateObject();
 
-    // v1alpha1_non_resource_policy_rule->non_resource_ur_ls
-    if (!v1alpha1_non_resource_policy_rule->non_resource_ur_ls) {
+    // v1alpha1_non_resource_policy_rule->non_resource_urls
+    if (!v1alpha1_non_resource_policy_rule->non_resource_urls) {
         goto fail;
     }
     
-    cJSON *non_resource_ur_ls = cJSON_AddArrayToObject(item, "nonResourceURLs");
-    if(non_resource_ur_ls == NULL) {
+    cJSON *non_resource_urls = cJSON_AddArrayToObject(item, "nonResourceURLs");
+    if(non_resource_urls == NULL) {
         goto fail; //primitive container
     }
 
-    listEntry_t *non_resource_ur_lsListEntry;
-    list_ForEach(non_resource_ur_lsListEntry, v1alpha1_non_resource_policy_rule->non_resource_ur_ls) {
-    if(cJSON_AddStringToObject(non_resource_ur_ls, "", (char*)non_resource_ur_lsListEntry->data) == NULL)
+    listEntry_t *non_resource_urlsListEntry;
+    list_ForEach(non_resource_urlsListEntry, v1alpha1_non_resource_policy_rule->non_resource_urls) {
+    if(cJSON_AddStringToObject(non_resource_urls, "", (char*)non_resource_urlsListEntry->data) == NULL)
     {
         goto fail;
     }
@@ -94,27 +94,27 @@ v1alpha1_non_resource_policy_rule_t *v1alpha1_non_resource_policy_rule_parseFrom
 
     v1alpha1_non_resource_policy_rule_t *v1alpha1_non_resource_policy_rule_local_var = NULL;
 
-    // v1alpha1_non_resource_policy_rule->non_resource_ur_ls
-    cJSON *non_resource_ur_ls = cJSON_GetObjectItemCaseSensitive(v1alpha1_non_resource_policy_ruleJSON, "nonResourceURLs");
-    if (!non_resource_ur_ls) {
+    // v1alpha1_non_resource_policy_rule->non_resource_urls
+    cJSON *non_resource_urls = cJSON_GetObjectItemCaseSensitive(v1alpha1_non_resource_policy_ruleJSON, "nonResourceURLs");
+    if (!non_resource_urls) {
         goto end;
     }
 
-    list_t *non_resource_ur_lsList;
+    list_t *non_resource_urlsList;
     
-    cJSON *non_resource_ur_ls_local;
-    if(!cJSON_IsArray(non_resource_ur_ls)) {
+    cJSON *non_resource_urls_local;
+    if(!cJSON_IsArray(non_resource_urls)) {
         goto end;//primitive container
     }
-    non_resource_ur_lsList = list_create();
+    non_resource_urlsList = list_create();
 
-    cJSON_ArrayForEach(non_resource_ur_ls_local, non_resource_ur_ls)
+    cJSON_ArrayForEach(non_resource_urls_local, non_resource_urls)
     {
-        if(!cJSON_IsString(non_resource_ur_ls_local))
+        if(!cJSON_IsString(non_resource_urls_local))
         {
             goto end;
         }
-        list_addElement(non_resource_ur_lsList , strdup(non_resource_ur_ls_local->valuestring));
+        list_addElement(non_resource_urlsList , strdup(non_resource_urls_local->valuestring));
     }
 
     // v1alpha1_non_resource_policy_rule->verbs
@@ -142,7 +142,7 @@ v1alpha1_non_resource_policy_rule_t *v1alpha1_non_resource_policy_rule_parseFrom
 
 
     v1alpha1_non_resource_policy_rule_local_var = v1alpha1_non_resource_policy_rule_create (
-        non_resource_ur_lsList,
+        non_resource_urlsList,
         verbsList
         );
 

--- a/kubernetes/model/v1alpha1_non_resource_policy_rule.h
+++ b/kubernetes/model/v1alpha1_non_resource_policy_rule.h
@@ -19,13 +19,13 @@ typedef struct v1alpha1_non_resource_policy_rule_t v1alpha1_non_resource_policy_
 
 
 typedef struct v1alpha1_non_resource_policy_rule_t {
-    list_t *non_resource_ur_ls; //primitive container
+    list_t *non_resource_urls; //primitive container
     list_t *verbs; //primitive container
 
 } v1alpha1_non_resource_policy_rule_t;
 
 v1alpha1_non_resource_policy_rule_t *v1alpha1_non_resource_policy_rule_create(
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *verbs
 );
 

--- a/kubernetes/model/v1alpha1_pod_preset.c
+++ b/kubernetes/model/v1alpha1_pod_preset.c
@@ -146,6 +146,14 @@ v1alpha1_pod_preset_t *v1alpha1_pod_preset_parseFromJSON(cJSON *v1alpha1_pod_pre
 
     return v1alpha1_pod_preset_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1alpha1_pod_preset_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_pod_preset_list.c
+++ b/kubernetes/model/v1alpha1_pod_preset_list.c
@@ -176,6 +176,10 @@ v1alpha1_pod_preset_list_t *v1alpha1_pod_preset_list_parseFromJSON(cJSON *v1alph
 
     return v1alpha1_pod_preset_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_pod_preset_spec.c
+++ b/kubernetes/model/v1alpha1_pod_preset_spec.c
@@ -279,6 +279,10 @@ v1alpha1_pod_preset_spec_t *v1alpha1_pod_preset_spec_parseFromJSON(cJSON *v1alph
 
     return v1alpha1_pod_preset_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_policy_rule.c
+++ b/kubernetes/model/v1alpha1_policy_rule.c
@@ -7,7 +7,7 @@
 
 v1alpha1_policy_rule_t *v1alpha1_policy_rule_create(
     list_t *api_groups,
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *resource_names,
     list_t *resources,
     list_t *verbs
@@ -17,7 +17,7 @@ v1alpha1_policy_rule_t *v1alpha1_policy_rule_create(
         return NULL;
     }
     v1alpha1_policy_rule_local_var->api_groups = api_groups;
-    v1alpha1_policy_rule_local_var->non_resource_ur_ls = non_resource_ur_ls;
+    v1alpha1_policy_rule_local_var->non_resource_urls = non_resource_urls;
     v1alpha1_policy_rule_local_var->resource_names = resource_names;
     v1alpha1_policy_rule_local_var->resources = resources;
     v1alpha1_policy_rule_local_var->verbs = verbs;
@@ -38,12 +38,12 @@ void v1alpha1_policy_rule_free(v1alpha1_policy_rule_t *v1alpha1_policy_rule) {
         list_free(v1alpha1_policy_rule->api_groups);
         v1alpha1_policy_rule->api_groups = NULL;
     }
-    if (v1alpha1_policy_rule->non_resource_ur_ls) {
-        list_ForEach(listEntry, v1alpha1_policy_rule->non_resource_ur_ls) {
+    if (v1alpha1_policy_rule->non_resource_urls) {
+        list_ForEach(listEntry, v1alpha1_policy_rule->non_resource_urls) {
             free(listEntry->data);
         }
-        list_free(v1alpha1_policy_rule->non_resource_ur_ls);
-        v1alpha1_policy_rule->non_resource_ur_ls = NULL;
+        list_free(v1alpha1_policy_rule->non_resource_urls);
+        v1alpha1_policy_rule->non_resource_urls = NULL;
     }
     if (v1alpha1_policy_rule->resource_names) {
         list_ForEach(listEntry, v1alpha1_policy_rule->resource_names) {
@@ -89,16 +89,16 @@ cJSON *v1alpha1_policy_rule_convertToJSON(v1alpha1_policy_rule_t *v1alpha1_polic
      } 
 
 
-    // v1alpha1_policy_rule->non_resource_ur_ls
-    if(v1alpha1_policy_rule->non_resource_ur_ls) { 
-    cJSON *non_resource_ur_ls = cJSON_AddArrayToObject(item, "nonResourceURLs");
-    if(non_resource_ur_ls == NULL) {
+    // v1alpha1_policy_rule->non_resource_urls
+    if(v1alpha1_policy_rule->non_resource_urls) { 
+    cJSON *non_resource_urls = cJSON_AddArrayToObject(item, "nonResourceURLs");
+    if(non_resource_urls == NULL) {
         goto fail; //primitive container
     }
 
-    listEntry_t *non_resource_ur_lsListEntry;
-    list_ForEach(non_resource_ur_lsListEntry, v1alpha1_policy_rule->non_resource_ur_ls) {
-    if(cJSON_AddStringToObject(non_resource_ur_ls, "", (char*)non_resource_ur_lsListEntry->data) == NULL)
+    listEntry_t *non_resource_urlsListEntry;
+    list_ForEach(non_resource_urlsListEntry, v1alpha1_policy_rule->non_resource_urls) {
+    if(cJSON_AddStringToObject(non_resource_urls, "", (char*)non_resource_urlsListEntry->data) == NULL)
     {
         goto fail;
     }
@@ -190,23 +190,23 @@ v1alpha1_policy_rule_t *v1alpha1_policy_rule_parseFromJSON(cJSON *v1alpha1_polic
     }
     }
 
-    // v1alpha1_policy_rule->non_resource_ur_ls
-    cJSON *non_resource_ur_ls = cJSON_GetObjectItemCaseSensitive(v1alpha1_policy_ruleJSON, "nonResourceURLs");
-    list_t *non_resource_ur_lsList;
-    if (non_resource_ur_ls) { 
-    cJSON *non_resource_ur_ls_local;
-    if(!cJSON_IsArray(non_resource_ur_ls)) {
+    // v1alpha1_policy_rule->non_resource_urls
+    cJSON *non_resource_urls = cJSON_GetObjectItemCaseSensitive(v1alpha1_policy_ruleJSON, "nonResourceURLs");
+    list_t *non_resource_urlsList;
+    if (non_resource_urls) { 
+    cJSON *non_resource_urls_local;
+    if(!cJSON_IsArray(non_resource_urls)) {
         goto end;//primitive container
     }
-    non_resource_ur_lsList = list_create();
+    non_resource_urlsList = list_create();
 
-    cJSON_ArrayForEach(non_resource_ur_ls_local, non_resource_ur_ls)
+    cJSON_ArrayForEach(non_resource_urls_local, non_resource_urls)
     {
-        if(!cJSON_IsString(non_resource_ur_ls_local))
+        if(!cJSON_IsString(non_resource_urls_local))
         {
             goto end;
         }
-        list_addElement(non_resource_ur_lsList , strdup(non_resource_ur_ls_local->valuestring));
+        list_addElement(non_resource_urlsList , strdup(non_resource_urls_local->valuestring));
     }
     }
 
@@ -276,7 +276,7 @@ v1alpha1_policy_rule_t *v1alpha1_policy_rule_parseFromJSON(cJSON *v1alpha1_polic
 
     v1alpha1_policy_rule_local_var = v1alpha1_policy_rule_create (
         api_groups ? api_groupsList : NULL,
-        non_resource_ur_ls ? non_resource_ur_lsList : NULL,
+        non_resource_urls ? non_resource_urlsList : NULL,
         resource_names ? resource_namesList : NULL,
         resources ? resourcesList : NULL,
         verbsList

--- a/kubernetes/model/v1alpha1_policy_rule.h
+++ b/kubernetes/model/v1alpha1_policy_rule.h
@@ -20,7 +20,7 @@ typedef struct v1alpha1_policy_rule_t v1alpha1_policy_rule_t;
 
 typedef struct v1alpha1_policy_rule_t {
     list_t *api_groups; //primitive container
-    list_t *non_resource_ur_ls; //primitive container
+    list_t *non_resource_urls; //primitive container
     list_t *resource_names; //primitive container
     list_t *resources; //primitive container
     list_t *verbs; //primitive container
@@ -29,7 +29,7 @@ typedef struct v1alpha1_policy_rule_t {
 
 v1alpha1_policy_rule_t *v1alpha1_policy_rule_create(
     list_t *api_groups,
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *resource_names,
     list_t *resources,
     list_t *verbs

--- a/kubernetes/model/v1alpha1_priority_class.c
+++ b/kubernetes/model/v1alpha1_priority_class.c
@@ -212,6 +212,10 @@ v1alpha1_priority_class_t *v1alpha1_priority_class_parseFromJSON(cJSON *v1alpha1
 
     return v1alpha1_priority_class_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_priority_class_list.c
+++ b/kubernetes/model/v1alpha1_priority_class_list.c
@@ -176,6 +176,10 @@ v1alpha1_priority_class_list_t *v1alpha1_priority_class_list_parseFromJSON(cJSON
 
     return v1alpha1_priority_class_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_priority_level_configuration.c
+++ b/kubernetes/model/v1alpha1_priority_level_configuration.c
@@ -173,6 +173,18 @@ v1alpha1_priority_level_configuration_t *v1alpha1_priority_level_configuration_p
 
     return v1alpha1_priority_level_configuration_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1alpha1_priority_level_configuration_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1alpha1_priority_level_configuration_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_priority_level_configuration_list.c
+++ b/kubernetes/model/v1alpha1_priority_level_configuration_list.c
@@ -176,6 +176,10 @@ v1alpha1_priority_level_configuration_list_t *v1alpha1_priority_level_configurat
 
     return v1alpha1_priority_level_configuration_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_priority_level_configuration_spec.c
+++ b/kubernetes/model/v1alpha1_priority_level_configuration_spec.c
@@ -100,6 +100,10 @@ v1alpha1_priority_level_configuration_spec_t *v1alpha1_priority_level_configurat
 
     return v1alpha1_priority_level_configuration_spec_local_var;
 end:
+    if (limited_local_nonprim) {
+        v1alpha1_limited_priority_level_configuration_free(limited_local_nonprim);
+        limited_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_role.c
+++ b/kubernetes/model/v1alpha1_role.c
@@ -171,6 +171,10 @@ v1alpha1_role_t *v1alpha1_role_parseFromJSON(cJSON *v1alpha1_roleJSON){
 
     return v1alpha1_role_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_role_binding.c
+++ b/kubernetes/model/v1alpha1_role_binding.c
@@ -203,6 +203,14 @@ v1alpha1_role_binding_t *v1alpha1_role_binding_parseFromJSON(cJSON *v1alpha1_rol
 
     return v1alpha1_role_binding_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (role_ref_local_nonprim) {
+        v1alpha1_role_ref_free(role_ref_local_nonprim);
+        role_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_role_binding_list.c
+++ b/kubernetes/model/v1alpha1_role_binding_list.c
@@ -176,6 +176,10 @@ v1alpha1_role_binding_list_t *v1alpha1_role_binding_list_parseFromJSON(cJSON *v1
 
     return v1alpha1_role_binding_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_role_list.c
+++ b/kubernetes/model/v1alpha1_role_list.c
@@ -176,6 +176,10 @@ v1alpha1_role_list_t *v1alpha1_role_list_parseFromJSON(cJSON *v1alpha1_role_list
 
     return v1alpha1_role_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_runtime_class.c
+++ b/kubernetes/model/v1alpha1_runtime_class.c
@@ -151,6 +151,14 @@ v1alpha1_runtime_class_t *v1alpha1_runtime_class_parseFromJSON(cJSON *v1alpha1_r
 
     return v1alpha1_runtime_class_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1alpha1_runtime_class_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_runtime_class_list.c
+++ b/kubernetes/model/v1alpha1_runtime_class_list.c
@@ -176,6 +176,10 @@ v1alpha1_runtime_class_list_t *v1alpha1_runtime_class_list_parseFromJSON(cJSON *
 
     return v1alpha1_runtime_class_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_runtime_class_spec.c
+++ b/kubernetes/model/v1alpha1_runtime_class_spec.c
@@ -127,6 +127,14 @@ v1alpha1_runtime_class_spec_t *v1alpha1_runtime_class_spec_parseFromJSON(cJSON *
 
     return v1alpha1_runtime_class_spec_local_var;
 end:
+    if (overhead_local_nonprim) {
+        v1alpha1_overhead_free(overhead_local_nonprim);
+        overhead_local_nonprim = NULL;
+    }
+    if (scheduling_local_nonprim) {
+        v1alpha1_scheduling_free(scheduling_local_nonprim);
+        scheduling_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_volume_attachment.c
+++ b/kubernetes/model/v1alpha1_volume_attachment.c
@@ -178,6 +178,18 @@ v1alpha1_volume_attachment_t *v1alpha1_volume_attachment_parseFromJSON(cJSON *v1
 
     return v1alpha1_volume_attachment_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1alpha1_volume_attachment_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1alpha1_volume_attachment_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_volume_attachment_list.c
+++ b/kubernetes/model/v1alpha1_volume_attachment_list.c
@@ -176,6 +176,10 @@ v1alpha1_volume_attachment_list_t *v1alpha1_volume_attachment_list_parseFromJSON
 
     return v1alpha1_volume_attachment_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_volume_attachment_source.c
+++ b/kubernetes/model/v1alpha1_volume_attachment_source.c
@@ -95,6 +95,10 @@ v1alpha1_volume_attachment_source_t *v1alpha1_volume_attachment_source_parseFrom
 
     return v1alpha1_volume_attachment_source_local_var;
 end:
+    if (inline_volume_spec_local_nonprim) {
+        v1_persistent_volume_spec_free(inline_volume_spec_local_nonprim);
+        inline_volume_spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_volume_attachment_spec.c
+++ b/kubernetes/model/v1alpha1_volume_attachment_spec.c
@@ -134,6 +134,10 @@ v1alpha1_volume_attachment_spec_t *v1alpha1_volume_attachment_spec_parseFromJSON
 
     return v1alpha1_volume_attachment_spec_local_var;
 end:
+    if (source_local_nonprim) {
+        v1alpha1_volume_attachment_source_free(source_local_nonprim);
+        source_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_volume_attachment_status.c
+++ b/kubernetes/model/v1alpha1_volume_attachment_status.c
@@ -178,6 +178,14 @@ v1alpha1_volume_attachment_status_t *v1alpha1_volume_attachment_status_parseFrom
 
     return v1alpha1_volume_attachment_status_local_var;
 end:
+    if (attach_error_local_nonprim) {
+        v1alpha1_volume_error_free(attach_error_local_nonprim);
+        attach_error_local_nonprim = NULL;
+    }
+    if (detach_error_local_nonprim) {
+        v1alpha1_volume_error_free(detach_error_local_nonprim);
+        detach_error_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_webhook.c
+++ b/kubernetes/model/v1alpha1_webhook.c
@@ -103,6 +103,14 @@ v1alpha1_webhook_t *v1alpha1_webhook_parseFromJSON(cJSON *v1alpha1_webhookJSON){
 
     return v1alpha1_webhook_local_var;
 end:
+    if (client_config_local_nonprim) {
+        v1alpha1_webhook_client_config_free(client_config_local_nonprim);
+        client_config_local_nonprim = NULL;
+    }
+    if (throttle_local_nonprim) {
+        v1alpha1_webhook_throttle_config_free(throttle_local_nonprim);
+        throttle_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1alpha1_webhook_client_config.c
+++ b/kubernetes/model/v1alpha1_webhook_client_config.c
@@ -115,6 +115,10 @@ v1alpha1_webhook_client_config_t *v1alpha1_webhook_client_config_parseFromJSON(c
 
     return v1alpha1_webhook_client_config_local_var;
 end:
+    if (service_local_nonprim) {
+        v1alpha1_service_reference_free(service_local_nonprim);
+        service_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_api_service.c
+++ b/kubernetes/model/v1beta1_api_service.c
@@ -173,6 +173,18 @@ v1beta1_api_service_t *v1beta1_api_service_parseFromJSON(cJSON *v1beta1_api_serv
 
     return v1beta1_api_service_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_api_service_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_api_service_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_api_service_list.c
+++ b/kubernetes/model/v1beta1_api_service_list.c
@@ -176,6 +176,10 @@ v1beta1_api_service_list_t *v1beta1_api_service_list_parseFromJSON(cJSON *v1beta
 
     return v1beta1_api_service_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_api_service_spec.c
+++ b/kubernetes/model/v1beta1_api_service_spec.c
@@ -214,6 +214,10 @@ v1beta1_api_service_spec_t *v1beta1_api_service_spec_parseFromJSON(cJSON *v1beta
 
     return v1beta1_api_service_spec_local_var;
 end:
+    if (service_local_nonprim) {
+        apiregistration_v1beta1_service_reference_free(service_local_nonprim);
+        service_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_certificate_signing_request.c
+++ b/kubernetes/model/v1beta1_certificate_signing_request.c
@@ -173,6 +173,18 @@ v1beta1_certificate_signing_request_t *v1beta1_certificate_signing_request_parse
 
     return v1beta1_certificate_signing_request_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_certificate_signing_request_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_certificate_signing_request_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_certificate_signing_request_list.c
+++ b/kubernetes/model/v1beta1_certificate_signing_request_list.c
@@ -176,6 +176,10 @@ v1beta1_certificate_signing_request_list_t *v1beta1_certificate_signing_request_
 
     return v1beta1_certificate_signing_request_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_cluster_role.c
+++ b/kubernetes/model/v1beta1_cluster_role.c
@@ -198,6 +198,14 @@ v1beta1_cluster_role_t *v1beta1_cluster_role_parseFromJSON(cJSON *v1beta1_cluste
 
     return v1beta1_cluster_role_local_var;
 end:
+    if (aggregation_rule_local_nonprim) {
+        v1beta1_aggregation_rule_free(aggregation_rule_local_nonprim);
+        aggregation_rule_local_nonprim = NULL;
+    }
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_cluster_role_binding.c
+++ b/kubernetes/model/v1beta1_cluster_role_binding.c
@@ -203,6 +203,14 @@ v1beta1_cluster_role_binding_t *v1beta1_cluster_role_binding_parseFromJSON(cJSON
 
     return v1beta1_cluster_role_binding_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (role_ref_local_nonprim) {
+        v1beta1_role_ref_free(role_ref_local_nonprim);
+        role_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_cluster_role_binding_list.c
+++ b/kubernetes/model/v1beta1_cluster_role_binding_list.c
@@ -176,6 +176,10 @@ v1beta1_cluster_role_binding_list_t *v1beta1_cluster_role_binding_list_parseFrom
 
     return v1beta1_cluster_role_binding_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_cluster_role_list.c
+++ b/kubernetes/model/v1beta1_cluster_role_list.c
@@ -176,6 +176,10 @@ v1beta1_cluster_role_list_t *v1beta1_cluster_role_list_parseFromJSON(cJSON *v1be
 
     return v1beta1_cluster_role_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_controller_revision.c
+++ b/kubernetes/model/v1beta1_controller_revision.c
@@ -171,6 +171,10 @@ v1beta1_controller_revision_t *v1beta1_controller_revision_parseFromJSON(cJSON *
 
     return v1beta1_controller_revision_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_controller_revision_list.c
+++ b/kubernetes/model/v1beta1_controller_revision_list.c
@@ -176,6 +176,10 @@ v1beta1_controller_revision_list_t *v1beta1_controller_revision_list_parseFromJS
 
     return v1beta1_controller_revision_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_cron_job.c
+++ b/kubernetes/model/v1beta1_cron_job.c
@@ -173,6 +173,18 @@ v1beta1_cron_job_t *v1beta1_cron_job_parseFromJSON(cJSON *v1beta1_cron_jobJSON){
 
     return v1beta1_cron_job_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_cron_job_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_cron_job_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_cron_job_list.c
+++ b/kubernetes/model/v1beta1_cron_job_list.c
@@ -176,6 +176,10 @@ v1beta1_cron_job_list_t *v1beta1_cron_job_list_parseFromJSON(cJSON *v1beta1_cron
 
     return v1beta1_cron_job_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_cron_job_spec.c
+++ b/kubernetes/model/v1beta1_cron_job_spec.c
@@ -209,6 +209,10 @@ v1beta1_cron_job_spec_t *v1beta1_cron_job_spec_parseFromJSON(cJSON *v1beta1_cron
 
     return v1beta1_cron_job_spec_local_var;
 end:
+    if (job_template_local_nonprim) {
+        v1beta1_job_template_spec_free(job_template_local_nonprim);
+        job_template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_csi_driver.c
+++ b/kubernetes/model/v1beta1_csi_driver.c
@@ -151,6 +151,14 @@ v1beta1_csi_driver_t *v1beta1_csi_driver_parseFromJSON(cJSON *v1beta1_csi_driver
 
     return v1beta1_csi_driver_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_csi_driver_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_csi_driver_list.c
+++ b/kubernetes/model/v1beta1_csi_driver_list.c
@@ -176,6 +176,10 @@ v1beta1_csi_driver_list_t *v1beta1_csi_driver_list_parseFromJSON(cJSON *v1beta1_
 
     return v1beta1_csi_driver_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_csi_node.c
+++ b/kubernetes/model/v1beta1_csi_node.c
@@ -151,6 +151,14 @@ v1beta1_csi_node_t *v1beta1_csi_node_parseFromJSON(cJSON *v1beta1_csi_nodeJSON){
 
     return v1beta1_csi_node_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_csi_node_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_csi_node_driver.c
+++ b/kubernetes/model/v1beta1_csi_node_driver.c
@@ -176,6 +176,10 @@ v1beta1_csi_node_driver_t *v1beta1_csi_node_driver_parseFromJSON(cJSON *v1beta1_
 
     return v1beta1_csi_node_driver_local_var;
 end:
+    if (allocatable_local_nonprim) {
+        v1beta1_volume_node_resources_free(allocatable_local_nonprim);
+        allocatable_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_csi_node_list.c
+++ b/kubernetes/model/v1beta1_csi_node_list.c
@@ -176,6 +176,10 @@ v1beta1_csi_node_list_t *v1beta1_csi_node_list_parseFromJSON(cJSON *v1beta1_csi_
 
     return v1beta1_csi_node_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_custom_resource_conversion.c
+++ b/kubernetes/model/v1beta1_custom_resource_conversion.c
@@ -147,6 +147,10 @@ v1beta1_custom_resource_conversion_t *v1beta1_custom_resource_conversion_parseFr
 
     return v1beta1_custom_resource_conversion_local_var;
 end:
+    if (webhook_client_config_local_nonprim) {
+        apiextensions_v1beta1_webhook_client_config_free(webhook_client_config_local_nonprim);
+        webhook_client_config_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_custom_resource_definition.c
+++ b/kubernetes/model/v1beta1_custom_resource_definition.c
@@ -178,6 +178,18 @@ v1beta1_custom_resource_definition_t *v1beta1_custom_resource_definition_parseFr
 
     return v1beta1_custom_resource_definition_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_custom_resource_definition_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_custom_resource_definition_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_custom_resource_definition_list.c
+++ b/kubernetes/model/v1beta1_custom_resource_definition_list.c
@@ -176,6 +176,10 @@ v1beta1_custom_resource_definition_list_t *v1beta1_custom_resource_definition_li
 
     return v1beta1_custom_resource_definition_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_custom_resource_definition_spec.c
+++ b/kubernetes/model/v1beta1_custom_resource_definition_spec.c
@@ -363,6 +363,22 @@ v1beta1_custom_resource_definition_spec_t *v1beta1_custom_resource_definition_sp
 
     return v1beta1_custom_resource_definition_spec_local_var;
 end:
+    if (conversion_local_nonprim) {
+        v1beta1_custom_resource_conversion_free(conversion_local_nonprim);
+        conversion_local_nonprim = NULL;
+    }
+    if (names_local_nonprim) {
+        v1beta1_custom_resource_definition_names_free(names_local_nonprim);
+        names_local_nonprim = NULL;
+    }
+    if (subresources_local_nonprim) {
+        v1beta1_custom_resource_subresources_free(subresources_local_nonprim);
+        subresources_local_nonprim = NULL;
+    }
+    if (validation_local_nonprim) {
+        v1beta1_custom_resource_validation_free(validation_local_nonprim);
+        validation_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_custom_resource_definition_status.c
+++ b/kubernetes/model/v1beta1_custom_resource_definition_status.c
@@ -180,6 +180,10 @@ v1beta1_custom_resource_definition_status_t *v1beta1_custom_resource_definition_
 
     return v1beta1_custom_resource_definition_status_local_var;
 end:
+    if (accepted_names_local_nonprim) {
+        v1beta1_custom_resource_definition_names_free(accepted_names_local_nonprim);
+        accepted_names_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_custom_resource_definition_version.c
+++ b/kubernetes/model/v1beta1_custom_resource_definition_version.c
@@ -229,6 +229,14 @@ v1beta1_custom_resource_definition_version_t *v1beta1_custom_resource_definition
 
     return v1beta1_custom_resource_definition_version_local_var;
 end:
+    if (schema_local_nonprim) {
+        v1beta1_custom_resource_validation_free(schema_local_nonprim);
+        schema_local_nonprim = NULL;
+    }
+    if (subresources_local_nonprim) {
+        v1beta1_custom_resource_subresources_free(subresources_local_nonprim);
+        subresources_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_custom_resource_subresources.c
+++ b/kubernetes/model/v1beta1_custom_resource_subresources.c
@@ -98,6 +98,10 @@ v1beta1_custom_resource_subresources_t *v1beta1_custom_resource_subresources_par
 
     return v1beta1_custom_resource_subresources_local_var;
 end:
+    if (scale_local_nonprim) {
+        v1beta1_custom_resource_subresource_scale_free(scale_local_nonprim);
+        scale_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_custom_resource_validation.c
+++ b/kubernetes/model/v1beta1_custom_resource_validation.c
@@ -71,6 +71,10 @@ v1beta1_custom_resource_validation_t *v1beta1_custom_resource_validation_parseFr
 
     return v1beta1_custom_resource_validation_local_var;
 end:
+    if (open_apiv3_schema_local_nonprim) {
+        v1beta1_json_schema_props_free(open_apiv3_schema_local_nonprim);
+        open_apiv3_schema_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_daemon_set.c
+++ b/kubernetes/model/v1beta1_daemon_set.c
@@ -173,6 +173,18 @@ v1beta1_daemon_set_t *v1beta1_daemon_set_parseFromJSON(cJSON *v1beta1_daemon_set
 
     return v1beta1_daemon_set_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_daemon_set_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_daemon_set_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_daemon_set_list.c
+++ b/kubernetes/model/v1beta1_daemon_set_list.c
@@ -176,6 +176,10 @@ v1beta1_daemon_set_list_t *v1beta1_daemon_set_list_parseFromJSON(cJSON *v1beta1_
 
     return v1beta1_daemon_set_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_daemon_set_spec.c
+++ b/kubernetes/model/v1beta1_daemon_set_spec.c
@@ -190,6 +190,18 @@ v1beta1_daemon_set_spec_t *v1beta1_daemon_set_spec_parseFromJSON(cJSON *v1beta1_
 
     return v1beta1_daemon_set_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
+    if (update_strategy_local_nonprim) {
+        v1beta1_daemon_set_update_strategy_free(update_strategy_local_nonprim);
+        update_strategy_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_daemon_set_update_strategy.c
+++ b/kubernetes/model/v1beta1_daemon_set_update_strategy.c
@@ -95,6 +95,10 @@ v1beta1_daemon_set_update_strategy_t *v1beta1_daemon_set_update_strategy_parseFr
 
     return v1beta1_daemon_set_update_strategy_local_var;
 end:
+    if (rolling_update_local_nonprim) {
+        v1beta1_rolling_update_daemon_set_free(rolling_update_local_nonprim);
+        rolling_update_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_endpoint.c
+++ b/kubernetes/model/v1beta1_endpoint.c
@@ -229,6 +229,14 @@ v1beta1_endpoint_t *v1beta1_endpoint_parseFromJSON(cJSON *v1beta1_endpointJSON){
 
     return v1beta1_endpoint_local_var;
 end:
+    if (conditions_local_nonprim) {
+        v1beta1_endpoint_conditions_free(conditions_local_nonprim);
+        conditions_local_nonprim = NULL;
+    }
+    if (target_ref_local_nonprim) {
+        v1_object_reference_free(target_ref_local_nonprim);
+        target_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_endpoint_slice.c
+++ b/kubernetes/model/v1beta1_endpoint_slice.c
@@ -257,6 +257,10 @@ v1beta1_endpoint_slice_t *v1beta1_endpoint_slice_parseFromJSON(cJSON *v1beta1_en
 
     return v1beta1_endpoint_slice_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_endpoint_slice_list.c
+++ b/kubernetes/model/v1beta1_endpoint_slice_list.c
@@ -176,6 +176,10 @@ v1beta1_endpoint_slice_list_t *v1beta1_endpoint_slice_list_parseFromJSON(cJSON *
 
     return v1beta1_endpoint_slice_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_event.c
+++ b/kubernetes/model/v1beta1_event.c
@@ -468,6 +468,26 @@ v1beta1_event_t *v1beta1_event_parseFromJSON(cJSON *v1beta1_eventJSON){
 
     return v1beta1_event_local_var;
 end:
+    if (deprecated_source_local_nonprim) {
+        v1_event_source_free(deprecated_source_local_nonprim);
+        deprecated_source_local_nonprim = NULL;
+    }
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (regarding_local_nonprim) {
+        v1_object_reference_free(regarding_local_nonprim);
+        regarding_local_nonprim = NULL;
+    }
+    if (related_local_nonprim) {
+        v1_object_reference_free(related_local_nonprim);
+        related_local_nonprim = NULL;
+    }
+    if (series_local_nonprim) {
+        v1beta1_event_series_free(series_local_nonprim);
+        series_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_event_list.c
+++ b/kubernetes/model/v1beta1_event_list.c
@@ -176,6 +176,10 @@ v1beta1_event_list_t *v1beta1_event_list_parseFromJSON(cJSON *v1beta1_event_list
 
     return v1beta1_event_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_eviction.c
+++ b/kubernetes/model/v1beta1_eviction.c
@@ -146,6 +146,14 @@ v1beta1_eviction_t *v1beta1_eviction_parseFromJSON(cJSON *v1beta1_evictionJSON){
 
     return v1beta1_eviction_local_var;
 end:
+    if (delete_options_local_nonprim) {
+        v1_delete_options_free(delete_options_local_nonprim);
+        delete_options_local_nonprim = NULL;
+    }
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_job_template_spec.c
+++ b/kubernetes/model/v1beta1_job_template_spec.c
@@ -98,6 +98,14 @@ v1beta1_job_template_spec_t *v1beta1_job_template_spec_parseFromJSON(cJSON *v1be
 
     return v1beta1_job_template_spec_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_job_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_json_schema_props.c
+++ b/kubernetes/model/v1beta1_json_schema_props.c
@@ -1279,6 +1279,14 @@ v1beta1_json_schema_props_t *v1beta1_json_schema_props_parseFromJSON(cJSON *v1be
 
     return v1beta1_json_schema_props_local_var;
 end:
+    if (external_docs_local_nonprim) {
+        v1beta1_external_documentation_free(external_docs_local_nonprim);
+        external_docs_local_nonprim = NULL;
+    }
+    if (_not_local_nonprim) {
+        v1beta1_json_schema_props_free(_not_local_nonprim);
+        _not_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_lease.c
+++ b/kubernetes/model/v1beta1_lease.c
@@ -146,6 +146,14 @@ v1beta1_lease_t *v1beta1_lease_parseFromJSON(cJSON *v1beta1_leaseJSON){
 
     return v1beta1_lease_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_lease_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_lease_list.c
+++ b/kubernetes/model/v1beta1_lease_list.c
@@ -176,6 +176,10 @@ v1beta1_lease_list_t *v1beta1_lease_list_parseFromJSON(cJSON *v1beta1_lease_list
 
     return v1beta1_lease_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_local_subject_access_review.c
+++ b/kubernetes/model/v1beta1_local_subject_access_review.c
@@ -178,6 +178,18 @@ v1beta1_local_subject_access_review_t *v1beta1_local_subject_access_review_parse
 
     return v1beta1_local_subject_access_review_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_subject_access_review_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_subject_access_review_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_mutating_webhook.c
+++ b/kubernetes/model/v1beta1_mutating_webhook.c
@@ -374,6 +374,18 @@ v1beta1_mutating_webhook_t *v1beta1_mutating_webhook_parseFromJSON(cJSON *v1beta
 
     return v1beta1_mutating_webhook_local_var;
 end:
+    if (client_config_local_nonprim) {
+        admissionregistration_v1beta1_webhook_client_config_free(client_config_local_nonprim);
+        client_config_local_nonprim = NULL;
+    }
+    if (namespace_selector_local_nonprim) {
+        v1_label_selector_free(namespace_selector_local_nonprim);
+        namespace_selector_local_nonprim = NULL;
+    }
+    if (object_selector_local_nonprim) {
+        v1_label_selector_free(object_selector_local_nonprim);
+        object_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_mutating_webhook_configuration.c
+++ b/kubernetes/model/v1beta1_mutating_webhook_configuration.c
@@ -171,6 +171,10 @@ v1beta1_mutating_webhook_configuration_t *v1beta1_mutating_webhook_configuration
 
     return v1beta1_mutating_webhook_configuration_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_mutating_webhook_configuration_list.c
+++ b/kubernetes/model/v1beta1_mutating_webhook_configuration_list.c
@@ -176,6 +176,10 @@ v1beta1_mutating_webhook_configuration_list_t *v1beta1_mutating_webhook_configur
 
     return v1beta1_mutating_webhook_configuration_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_network_policy.c
+++ b/kubernetes/model/v1beta1_network_policy.c
@@ -146,6 +146,14 @@ v1beta1_network_policy_t *v1beta1_network_policy_parseFromJSON(cJSON *v1beta1_ne
 
     return v1beta1_network_policy_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_network_policy_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_network_policy_list.c
+++ b/kubernetes/model/v1beta1_network_policy_list.c
@@ -176,6 +176,10 @@ v1beta1_network_policy_list_t *v1beta1_network_policy_list_parseFromJSON(cJSON *
 
     return v1beta1_network_policy_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_network_policy_peer.c
+++ b/kubernetes/model/v1beta1_network_policy_peer.c
@@ -125,6 +125,18 @@ v1beta1_network_policy_peer_t *v1beta1_network_policy_peer_parseFromJSON(cJSON *
 
     return v1beta1_network_policy_peer_local_var;
 end:
+    if (ip_block_local_nonprim) {
+        v1beta1_ip_block_free(ip_block_local_nonprim);
+        ip_block_local_nonprim = NULL;
+    }
+    if (namespace_selector_local_nonprim) {
+        v1_label_selector_free(namespace_selector_local_nonprim);
+        namespace_selector_local_nonprim = NULL;
+    }
+    if (pod_selector_local_nonprim) {
+        v1_label_selector_free(pod_selector_local_nonprim);
+        pod_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_network_policy_spec.c
+++ b/kubernetes/model/v1beta1_network_policy_spec.c
@@ -227,6 +227,10 @@ v1beta1_network_policy_spec_t *v1beta1_network_policy_spec_parseFromJSON(cJSON *
 
     return v1beta1_network_policy_spec_local_var;
 end:
+    if (pod_selector_local_nonprim) {
+        v1_label_selector_free(pod_selector_local_nonprim);
+        pod_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_non_resource_rule.c
+++ b/kubernetes/model/v1beta1_non_resource_rule.c
@@ -6,14 +6,14 @@
 
 
 v1beta1_non_resource_rule_t *v1beta1_non_resource_rule_create(
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *verbs
     ) {
     v1beta1_non_resource_rule_t *v1beta1_non_resource_rule_local_var = malloc(sizeof(v1beta1_non_resource_rule_t));
     if (!v1beta1_non_resource_rule_local_var) {
         return NULL;
     }
-    v1beta1_non_resource_rule_local_var->non_resource_ur_ls = non_resource_ur_ls;
+    v1beta1_non_resource_rule_local_var->non_resource_urls = non_resource_urls;
     v1beta1_non_resource_rule_local_var->verbs = verbs;
 
     return v1beta1_non_resource_rule_local_var;
@@ -25,12 +25,12 @@ void v1beta1_non_resource_rule_free(v1beta1_non_resource_rule_t *v1beta1_non_res
         return ;
     }
     listEntry_t *listEntry;
-    if (v1beta1_non_resource_rule->non_resource_ur_ls) {
-        list_ForEach(listEntry, v1beta1_non_resource_rule->non_resource_ur_ls) {
+    if (v1beta1_non_resource_rule->non_resource_urls) {
+        list_ForEach(listEntry, v1beta1_non_resource_rule->non_resource_urls) {
             free(listEntry->data);
         }
-        list_free(v1beta1_non_resource_rule->non_resource_ur_ls);
-        v1beta1_non_resource_rule->non_resource_ur_ls = NULL;
+        list_free(v1beta1_non_resource_rule->non_resource_urls);
+        v1beta1_non_resource_rule->non_resource_urls = NULL;
     }
     if (v1beta1_non_resource_rule->verbs) {
         list_ForEach(listEntry, v1beta1_non_resource_rule->verbs) {
@@ -45,16 +45,16 @@ void v1beta1_non_resource_rule_free(v1beta1_non_resource_rule_t *v1beta1_non_res
 cJSON *v1beta1_non_resource_rule_convertToJSON(v1beta1_non_resource_rule_t *v1beta1_non_resource_rule) {
     cJSON *item = cJSON_CreateObject();
 
-    // v1beta1_non_resource_rule->non_resource_ur_ls
-    if(v1beta1_non_resource_rule->non_resource_ur_ls) { 
-    cJSON *non_resource_ur_ls = cJSON_AddArrayToObject(item, "nonResourceURLs");
-    if(non_resource_ur_ls == NULL) {
+    // v1beta1_non_resource_rule->non_resource_urls
+    if(v1beta1_non_resource_rule->non_resource_urls) { 
+    cJSON *non_resource_urls = cJSON_AddArrayToObject(item, "nonResourceURLs");
+    if(non_resource_urls == NULL) {
         goto fail; //primitive container
     }
 
-    listEntry_t *non_resource_ur_lsListEntry;
-    list_ForEach(non_resource_ur_lsListEntry, v1beta1_non_resource_rule->non_resource_ur_ls) {
-    if(cJSON_AddStringToObject(non_resource_ur_ls, "", (char*)non_resource_ur_lsListEntry->data) == NULL)
+    listEntry_t *non_resource_urlsListEntry;
+    list_ForEach(non_resource_urlsListEntry, v1beta1_non_resource_rule->non_resource_urls) {
+    if(cJSON_AddStringToObject(non_resource_urls, "", (char*)non_resource_urlsListEntry->data) == NULL)
     {
         goto fail;
     }
@@ -92,23 +92,23 @@ v1beta1_non_resource_rule_t *v1beta1_non_resource_rule_parseFromJSON(cJSON *v1be
 
     v1beta1_non_resource_rule_t *v1beta1_non_resource_rule_local_var = NULL;
 
-    // v1beta1_non_resource_rule->non_resource_ur_ls
-    cJSON *non_resource_ur_ls = cJSON_GetObjectItemCaseSensitive(v1beta1_non_resource_ruleJSON, "nonResourceURLs");
-    list_t *non_resource_ur_lsList;
-    if (non_resource_ur_ls) { 
-    cJSON *non_resource_ur_ls_local;
-    if(!cJSON_IsArray(non_resource_ur_ls)) {
+    // v1beta1_non_resource_rule->non_resource_urls
+    cJSON *non_resource_urls = cJSON_GetObjectItemCaseSensitive(v1beta1_non_resource_ruleJSON, "nonResourceURLs");
+    list_t *non_resource_urlsList;
+    if (non_resource_urls) { 
+    cJSON *non_resource_urls_local;
+    if(!cJSON_IsArray(non_resource_urls)) {
         goto end;//primitive container
     }
-    non_resource_ur_lsList = list_create();
+    non_resource_urlsList = list_create();
 
-    cJSON_ArrayForEach(non_resource_ur_ls_local, non_resource_ur_ls)
+    cJSON_ArrayForEach(non_resource_urls_local, non_resource_urls)
     {
-        if(!cJSON_IsString(non_resource_ur_ls_local))
+        if(!cJSON_IsString(non_resource_urls_local))
         {
             goto end;
         }
-        list_addElement(non_resource_ur_lsList , strdup(non_resource_ur_ls_local->valuestring));
+        list_addElement(non_resource_urlsList , strdup(non_resource_urls_local->valuestring));
     }
     }
 
@@ -137,7 +137,7 @@ v1beta1_non_resource_rule_t *v1beta1_non_resource_rule_parseFromJSON(cJSON *v1be
 
 
     v1beta1_non_resource_rule_local_var = v1beta1_non_resource_rule_create (
-        non_resource_ur_ls ? non_resource_ur_lsList : NULL,
+        non_resource_urls ? non_resource_urlsList : NULL,
         verbsList
         );
 

--- a/kubernetes/model/v1beta1_non_resource_rule.h
+++ b/kubernetes/model/v1beta1_non_resource_rule.h
@@ -19,13 +19,13 @@ typedef struct v1beta1_non_resource_rule_t v1beta1_non_resource_rule_t;
 
 
 typedef struct v1beta1_non_resource_rule_t {
-    list_t *non_resource_ur_ls; //primitive container
+    list_t *non_resource_urls; //primitive container
     list_t *verbs; //primitive container
 
 } v1beta1_non_resource_rule_t;
 
 v1beta1_non_resource_rule_t *v1beta1_non_resource_rule_create(
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *verbs
 );
 

--- a/kubernetes/model/v1beta1_pod_disruption_budget.c
+++ b/kubernetes/model/v1beta1_pod_disruption_budget.c
@@ -173,6 +173,18 @@ v1beta1_pod_disruption_budget_t *v1beta1_pod_disruption_budget_parseFromJSON(cJS
 
     return v1beta1_pod_disruption_budget_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_pod_disruption_budget_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_pod_disruption_budget_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_pod_disruption_budget_list.c
+++ b/kubernetes/model/v1beta1_pod_disruption_budget_list.c
@@ -176,6 +176,10 @@ v1beta1_pod_disruption_budget_list_t *v1beta1_pod_disruption_budget_list_parseFr
 
     return v1beta1_pod_disruption_budget_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_pod_disruption_budget_spec.c
+++ b/kubernetes/model/v1beta1_pod_disruption_budget_spec.c
@@ -125,6 +125,10 @@ v1beta1_pod_disruption_budget_spec_t *v1beta1_pod_disruption_budget_spec_parseFr
 
     return v1beta1_pod_disruption_budget_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_policy_rule.c
+++ b/kubernetes/model/v1beta1_policy_rule.c
@@ -7,7 +7,7 @@
 
 v1beta1_policy_rule_t *v1beta1_policy_rule_create(
     list_t *api_groups,
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *resource_names,
     list_t *resources,
     list_t *verbs
@@ -17,7 +17,7 @@ v1beta1_policy_rule_t *v1beta1_policy_rule_create(
         return NULL;
     }
     v1beta1_policy_rule_local_var->api_groups = api_groups;
-    v1beta1_policy_rule_local_var->non_resource_ur_ls = non_resource_ur_ls;
+    v1beta1_policy_rule_local_var->non_resource_urls = non_resource_urls;
     v1beta1_policy_rule_local_var->resource_names = resource_names;
     v1beta1_policy_rule_local_var->resources = resources;
     v1beta1_policy_rule_local_var->verbs = verbs;
@@ -38,12 +38,12 @@ void v1beta1_policy_rule_free(v1beta1_policy_rule_t *v1beta1_policy_rule) {
         list_free(v1beta1_policy_rule->api_groups);
         v1beta1_policy_rule->api_groups = NULL;
     }
-    if (v1beta1_policy_rule->non_resource_ur_ls) {
-        list_ForEach(listEntry, v1beta1_policy_rule->non_resource_ur_ls) {
+    if (v1beta1_policy_rule->non_resource_urls) {
+        list_ForEach(listEntry, v1beta1_policy_rule->non_resource_urls) {
             free(listEntry->data);
         }
-        list_free(v1beta1_policy_rule->non_resource_ur_ls);
-        v1beta1_policy_rule->non_resource_ur_ls = NULL;
+        list_free(v1beta1_policy_rule->non_resource_urls);
+        v1beta1_policy_rule->non_resource_urls = NULL;
     }
     if (v1beta1_policy_rule->resource_names) {
         list_ForEach(listEntry, v1beta1_policy_rule->resource_names) {
@@ -89,16 +89,16 @@ cJSON *v1beta1_policy_rule_convertToJSON(v1beta1_policy_rule_t *v1beta1_policy_r
      } 
 
 
-    // v1beta1_policy_rule->non_resource_ur_ls
-    if(v1beta1_policy_rule->non_resource_ur_ls) { 
-    cJSON *non_resource_ur_ls = cJSON_AddArrayToObject(item, "nonResourceURLs");
-    if(non_resource_ur_ls == NULL) {
+    // v1beta1_policy_rule->non_resource_urls
+    if(v1beta1_policy_rule->non_resource_urls) { 
+    cJSON *non_resource_urls = cJSON_AddArrayToObject(item, "nonResourceURLs");
+    if(non_resource_urls == NULL) {
         goto fail; //primitive container
     }
 
-    listEntry_t *non_resource_ur_lsListEntry;
-    list_ForEach(non_resource_ur_lsListEntry, v1beta1_policy_rule->non_resource_ur_ls) {
-    if(cJSON_AddStringToObject(non_resource_ur_ls, "", (char*)non_resource_ur_lsListEntry->data) == NULL)
+    listEntry_t *non_resource_urlsListEntry;
+    list_ForEach(non_resource_urlsListEntry, v1beta1_policy_rule->non_resource_urls) {
+    if(cJSON_AddStringToObject(non_resource_urls, "", (char*)non_resource_urlsListEntry->data) == NULL)
     {
         goto fail;
     }
@@ -190,23 +190,23 @@ v1beta1_policy_rule_t *v1beta1_policy_rule_parseFromJSON(cJSON *v1beta1_policy_r
     }
     }
 
-    // v1beta1_policy_rule->non_resource_ur_ls
-    cJSON *non_resource_ur_ls = cJSON_GetObjectItemCaseSensitive(v1beta1_policy_ruleJSON, "nonResourceURLs");
-    list_t *non_resource_ur_lsList;
-    if (non_resource_ur_ls) { 
-    cJSON *non_resource_ur_ls_local;
-    if(!cJSON_IsArray(non_resource_ur_ls)) {
+    // v1beta1_policy_rule->non_resource_urls
+    cJSON *non_resource_urls = cJSON_GetObjectItemCaseSensitive(v1beta1_policy_ruleJSON, "nonResourceURLs");
+    list_t *non_resource_urlsList;
+    if (non_resource_urls) { 
+    cJSON *non_resource_urls_local;
+    if(!cJSON_IsArray(non_resource_urls)) {
         goto end;//primitive container
     }
-    non_resource_ur_lsList = list_create();
+    non_resource_urlsList = list_create();
 
-    cJSON_ArrayForEach(non_resource_ur_ls_local, non_resource_ur_ls)
+    cJSON_ArrayForEach(non_resource_urls_local, non_resource_urls)
     {
-        if(!cJSON_IsString(non_resource_ur_ls_local))
+        if(!cJSON_IsString(non_resource_urls_local))
         {
             goto end;
         }
-        list_addElement(non_resource_ur_lsList , strdup(non_resource_ur_ls_local->valuestring));
+        list_addElement(non_resource_urlsList , strdup(non_resource_urls_local->valuestring));
     }
     }
 
@@ -276,7 +276,7 @@ v1beta1_policy_rule_t *v1beta1_policy_rule_parseFromJSON(cJSON *v1beta1_policy_r
 
     v1beta1_policy_rule_local_var = v1beta1_policy_rule_create (
         api_groups ? api_groupsList : NULL,
-        non_resource_ur_ls ? non_resource_ur_lsList : NULL,
+        non_resource_urls ? non_resource_urlsList : NULL,
         resource_names ? resource_namesList : NULL,
         resources ? resourcesList : NULL,
         verbsList

--- a/kubernetes/model/v1beta1_policy_rule.h
+++ b/kubernetes/model/v1beta1_policy_rule.h
@@ -20,7 +20,7 @@ typedef struct v1beta1_policy_rule_t v1beta1_policy_rule_t;
 
 typedef struct v1beta1_policy_rule_t {
     list_t *api_groups; //primitive container
-    list_t *non_resource_ur_ls; //primitive container
+    list_t *non_resource_urls; //primitive container
     list_t *resource_names; //primitive container
     list_t *resources; //primitive container
     list_t *verbs; //primitive container
@@ -29,7 +29,7 @@ typedef struct v1beta1_policy_rule_t {
 
 v1beta1_policy_rule_t *v1beta1_policy_rule_create(
     list_t *api_groups,
-    list_t *non_resource_ur_ls,
+    list_t *non_resource_urls,
     list_t *resource_names,
     list_t *resources,
     list_t *verbs

--- a/kubernetes/model/v1beta1_priority_class.c
+++ b/kubernetes/model/v1beta1_priority_class.c
@@ -212,6 +212,10 @@ v1beta1_priority_class_t *v1beta1_priority_class_parseFromJSON(cJSON *v1beta1_pr
 
     return v1beta1_priority_class_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_priority_class_list.c
+++ b/kubernetes/model/v1beta1_priority_class_list.c
@@ -176,6 +176,10 @@ v1beta1_priority_class_list_t *v1beta1_priority_class_list_parseFromJSON(cJSON *
 
     return v1beta1_priority_class_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_replica_set.c
+++ b/kubernetes/model/v1beta1_replica_set.c
@@ -173,6 +173,18 @@ v1beta1_replica_set_t *v1beta1_replica_set_parseFromJSON(cJSON *v1beta1_replica_
 
     return v1beta1_replica_set_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_replica_set_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_replica_set_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_replica_set_list.c
+++ b/kubernetes/model/v1beta1_replica_set_list.c
@@ -176,6 +176,10 @@ v1beta1_replica_set_list_t *v1beta1_replica_set_list_parseFromJSON(cJSON *v1beta
 
     return v1beta1_replica_set_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_replica_set_spec.c
+++ b/kubernetes/model/v1beta1_replica_set_spec.c
@@ -138,6 +138,14 @@ v1beta1_replica_set_spec_t *v1beta1_replica_set_spec_parseFromJSON(cJSON *v1beta
 
     return v1beta1_replica_set_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_role.c
+++ b/kubernetes/model/v1beta1_role.c
@@ -171,6 +171,10 @@ v1beta1_role_t *v1beta1_role_parseFromJSON(cJSON *v1beta1_roleJSON){
 
     return v1beta1_role_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_role_binding.c
+++ b/kubernetes/model/v1beta1_role_binding.c
@@ -203,6 +203,14 @@ v1beta1_role_binding_t *v1beta1_role_binding_parseFromJSON(cJSON *v1beta1_role_b
 
     return v1beta1_role_binding_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (role_ref_local_nonprim) {
+        v1beta1_role_ref_free(role_ref_local_nonprim);
+        role_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_role_binding_list.c
+++ b/kubernetes/model/v1beta1_role_binding_list.c
@@ -176,6 +176,10 @@ v1beta1_role_binding_list_t *v1beta1_role_binding_list_parseFromJSON(cJSON *v1be
 
     return v1beta1_role_binding_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_role_list.c
+++ b/kubernetes/model/v1beta1_role_list.c
@@ -176,6 +176,10 @@ v1beta1_role_list_t *v1beta1_role_list_parseFromJSON(cJSON *v1beta1_role_listJSO
 
     return v1beta1_role_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_runtime_class.c
+++ b/kubernetes/model/v1beta1_runtime_class.c
@@ -202,6 +202,18 @@ v1beta1_runtime_class_t *v1beta1_runtime_class_parseFromJSON(cJSON *v1beta1_runt
 
     return v1beta1_runtime_class_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (overhead_local_nonprim) {
+        v1beta1_overhead_free(overhead_local_nonprim);
+        overhead_local_nonprim = NULL;
+    }
+    if (scheduling_local_nonprim) {
+        v1beta1_scheduling_free(scheduling_local_nonprim);
+        scheduling_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_runtime_class_list.c
+++ b/kubernetes/model/v1beta1_runtime_class_list.c
@@ -176,6 +176,10 @@ v1beta1_runtime_class_list_t *v1beta1_runtime_class_list_parseFromJSON(cJSON *v1
 
     return v1beta1_runtime_class_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_self_subject_access_review.c
+++ b/kubernetes/model/v1beta1_self_subject_access_review.c
@@ -178,6 +178,18 @@ v1beta1_self_subject_access_review_t *v1beta1_self_subject_access_review_parseFr
 
     return v1beta1_self_subject_access_review_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_self_subject_access_review_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_subject_access_review_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_self_subject_access_review_spec.c
+++ b/kubernetes/model/v1beta1_self_subject_access_review_spec.c
@@ -98,6 +98,14 @@ v1beta1_self_subject_access_review_spec_t *v1beta1_self_subject_access_review_sp
 
     return v1beta1_self_subject_access_review_spec_local_var;
 end:
+    if (non_resource_attributes_local_nonprim) {
+        v1beta1_non_resource_attributes_free(non_resource_attributes_local_nonprim);
+        non_resource_attributes_local_nonprim = NULL;
+    }
+    if (resource_attributes_local_nonprim) {
+        v1beta1_resource_attributes_free(resource_attributes_local_nonprim);
+        resource_attributes_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_self_subject_rules_review.c
+++ b/kubernetes/model/v1beta1_self_subject_rules_review.c
@@ -178,6 +178,18 @@ v1beta1_self_subject_rules_review_t *v1beta1_self_subject_rules_review_parseFrom
 
     return v1beta1_self_subject_rules_review_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_self_subject_rules_review_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_subject_rules_review_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_stateful_set.c
+++ b/kubernetes/model/v1beta1_stateful_set.c
@@ -173,6 +173,18 @@ v1beta1_stateful_set_t *v1beta1_stateful_set_parseFromJSON(cJSON *v1beta1_statef
 
     return v1beta1_stateful_set_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_stateful_set_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_stateful_set_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_stateful_set_list.c
+++ b/kubernetes/model/v1beta1_stateful_set_list.c
@@ -176,6 +176,10 @@ v1beta1_stateful_set_list_t *v1beta1_stateful_set_list_parseFromJSON(cJSON *v1be
 
     return v1beta1_stateful_set_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_stateful_set_spec.c
+++ b/kubernetes/model/v1beta1_stateful_set_spec.c
@@ -275,6 +275,18 @@ v1beta1_stateful_set_spec_t *v1beta1_stateful_set_spec_parseFromJSON(cJSON *v1be
 
     return v1beta1_stateful_set_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
+    if (update_strategy_local_nonprim) {
+        v1beta1_stateful_set_update_strategy_free(update_strategy_local_nonprim);
+        update_strategy_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_stateful_set_update_strategy.c
+++ b/kubernetes/model/v1beta1_stateful_set_update_strategy.c
@@ -95,6 +95,10 @@ v1beta1_stateful_set_update_strategy_t *v1beta1_stateful_set_update_strategy_par
 
     return v1beta1_stateful_set_update_strategy_local_var;
 end:
+    if (rolling_update_local_nonprim) {
+        v1beta1_rolling_update_stateful_set_strategy_free(rolling_update_local_nonprim);
+        rolling_update_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_storage_class.c
+++ b/kubernetes/model/v1beta1_storage_class.c
@@ -370,6 +370,10 @@ v1beta1_storage_class_t *v1beta1_storage_class_parseFromJSON(cJSON *v1beta1_stor
 
     return v1beta1_storage_class_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_storage_class_list.c
+++ b/kubernetes/model/v1beta1_storage_class_list.c
@@ -176,6 +176,10 @@ v1beta1_storage_class_list_t *v1beta1_storage_class_list_parseFromJSON(cJSON *v1
 
     return v1beta1_storage_class_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_subject_access_review.c
+++ b/kubernetes/model/v1beta1_subject_access_review.c
@@ -178,6 +178,18 @@ v1beta1_subject_access_review_t *v1beta1_subject_access_review_parseFromJSON(cJS
 
     return v1beta1_subject_access_review_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_subject_access_review_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_subject_access_review_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_subject_access_review_spec.c
+++ b/kubernetes/model/v1beta1_subject_access_review_spec.c
@@ -239,6 +239,14 @@ v1beta1_subject_access_review_spec_t *v1beta1_subject_access_review_spec_parseFr
 
     return v1beta1_subject_access_review_spec_local_var;
 end:
+    if (non_resource_attributes_local_nonprim) {
+        v1beta1_non_resource_attributes_free(non_resource_attributes_local_nonprim);
+        non_resource_attributes_local_nonprim = NULL;
+    }
+    if (resource_attributes_local_nonprim) {
+        v1beta1_resource_attributes_free(resource_attributes_local_nonprim);
+        resource_attributes_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_token_review.c
+++ b/kubernetes/model/v1beta1_token_review.c
@@ -178,6 +178,18 @@ v1beta1_token_review_t *v1beta1_token_review_parseFromJSON(cJSON *v1beta1_token_
 
     return v1beta1_token_review_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_token_review_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_token_review_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_token_review_status.c
+++ b/kubernetes/model/v1beta1_token_review_status.c
@@ -162,6 +162,10 @@ v1beta1_token_review_status_t *v1beta1_token_review_status_parseFromJSON(cJSON *
 
     return v1beta1_token_review_status_local_var;
 end:
+    if (user_local_nonprim) {
+        v1beta1_user_info_free(user_local_nonprim);
+        user_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_validating_webhook.c
+++ b/kubernetes/model/v1beta1_validating_webhook.c
@@ -350,6 +350,18 @@ v1beta1_validating_webhook_t *v1beta1_validating_webhook_parseFromJSON(cJSON *v1
 
     return v1beta1_validating_webhook_local_var;
 end:
+    if (client_config_local_nonprim) {
+        admissionregistration_v1beta1_webhook_client_config_free(client_config_local_nonprim);
+        client_config_local_nonprim = NULL;
+    }
+    if (namespace_selector_local_nonprim) {
+        v1_label_selector_free(namespace_selector_local_nonprim);
+        namespace_selector_local_nonprim = NULL;
+    }
+    if (object_selector_local_nonprim) {
+        v1_label_selector_free(object_selector_local_nonprim);
+        object_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_validating_webhook_configuration.c
+++ b/kubernetes/model/v1beta1_validating_webhook_configuration.c
@@ -171,6 +171,10 @@ v1beta1_validating_webhook_configuration_t *v1beta1_validating_webhook_configura
 
     return v1beta1_validating_webhook_configuration_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_validating_webhook_configuration_list.c
+++ b/kubernetes/model/v1beta1_validating_webhook_configuration_list.c
@@ -176,6 +176,10 @@ v1beta1_validating_webhook_configuration_list_t *v1beta1_validating_webhook_conf
 
     return v1beta1_validating_webhook_configuration_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_volume_attachment.c
+++ b/kubernetes/model/v1beta1_volume_attachment.c
@@ -178,6 +178,18 @@ v1beta1_volume_attachment_t *v1beta1_volume_attachment_parseFromJSON(cJSON *v1be
 
     return v1beta1_volume_attachment_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta1_volume_attachment_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta1_volume_attachment_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_volume_attachment_list.c
+++ b/kubernetes/model/v1beta1_volume_attachment_list.c
@@ -176,6 +176,10 @@ v1beta1_volume_attachment_list_t *v1beta1_volume_attachment_list_parseFromJSON(c
 
     return v1beta1_volume_attachment_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_volume_attachment_source.c
+++ b/kubernetes/model/v1beta1_volume_attachment_source.c
@@ -95,6 +95,10 @@ v1beta1_volume_attachment_source_t *v1beta1_volume_attachment_source_parseFromJS
 
     return v1beta1_volume_attachment_source_local_var;
 end:
+    if (inline_volume_spec_local_nonprim) {
+        v1_persistent_volume_spec_free(inline_volume_spec_local_nonprim);
+        inline_volume_spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_volume_attachment_spec.c
+++ b/kubernetes/model/v1beta1_volume_attachment_spec.c
@@ -134,6 +134,10 @@ v1beta1_volume_attachment_spec_t *v1beta1_volume_attachment_spec_parseFromJSON(c
 
     return v1beta1_volume_attachment_spec_local_var;
 end:
+    if (source_local_nonprim) {
+        v1beta1_volume_attachment_source_free(source_local_nonprim);
+        source_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta1_volume_attachment_status.c
+++ b/kubernetes/model/v1beta1_volume_attachment_status.c
@@ -178,6 +178,14 @@ v1beta1_volume_attachment_status_t *v1beta1_volume_attachment_status_parseFromJS
 
     return v1beta1_volume_attachment_status_local_var;
 end:
+    if (attach_error_local_nonprim) {
+        v1beta1_volume_error_free(attach_error_local_nonprim);
+        attach_error_local_nonprim = NULL;
+    }
+    if (detach_error_local_nonprim) {
+        v1beta1_volume_error_free(detach_error_local_nonprim);
+        detach_error_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_controller_revision.c
+++ b/kubernetes/model/v1beta2_controller_revision.c
@@ -171,6 +171,10 @@ v1beta2_controller_revision_t *v1beta2_controller_revision_parseFromJSON(cJSON *
 
     return v1beta2_controller_revision_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_controller_revision_list.c
+++ b/kubernetes/model/v1beta2_controller_revision_list.c
@@ -176,6 +176,10 @@ v1beta2_controller_revision_list_t *v1beta2_controller_revision_list_parseFromJS
 
     return v1beta2_controller_revision_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_daemon_set.c
+++ b/kubernetes/model/v1beta2_daemon_set.c
@@ -173,6 +173,18 @@ v1beta2_daemon_set_t *v1beta2_daemon_set_parseFromJSON(cJSON *v1beta2_daemon_set
 
     return v1beta2_daemon_set_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta2_daemon_set_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta2_daemon_set_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_daemon_set_list.c
+++ b/kubernetes/model/v1beta2_daemon_set_list.c
@@ -176,6 +176,10 @@ v1beta2_daemon_set_list_t *v1beta2_daemon_set_list_parseFromJSON(cJSON *v1beta2_
 
     return v1beta2_daemon_set_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_daemon_set_spec.c
+++ b/kubernetes/model/v1beta2_daemon_set_spec.c
@@ -175,6 +175,18 @@ v1beta2_daemon_set_spec_t *v1beta2_daemon_set_spec_parseFromJSON(cJSON *v1beta2_
 
     return v1beta2_daemon_set_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
+    if (update_strategy_local_nonprim) {
+        v1beta2_daemon_set_update_strategy_free(update_strategy_local_nonprim);
+        update_strategy_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_daemon_set_update_strategy.c
+++ b/kubernetes/model/v1beta2_daemon_set_update_strategy.c
@@ -95,6 +95,10 @@ v1beta2_daemon_set_update_strategy_t *v1beta2_daemon_set_update_strategy_parseFr
 
     return v1beta2_daemon_set_update_strategy_local_var;
 end:
+    if (rolling_update_local_nonprim) {
+        v1beta2_rolling_update_daemon_set_free(rolling_update_local_nonprim);
+        rolling_update_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_deployment.c
+++ b/kubernetes/model/v1beta2_deployment.c
@@ -173,6 +173,18 @@ v1beta2_deployment_t *v1beta2_deployment_parseFromJSON(cJSON *v1beta2_deployment
 
     return v1beta2_deployment_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta2_deployment_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta2_deployment_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_deployment_list.c
+++ b/kubernetes/model/v1beta2_deployment_list.c
@@ -176,6 +176,10 @@ v1beta2_deployment_list_t *v1beta2_deployment_list_parseFromJSON(cJSON *v1beta2_
 
     return v1beta2_deployment_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_deployment_spec.c
+++ b/kubernetes/model/v1beta2_deployment_spec.c
@@ -235,6 +235,18 @@ v1beta2_deployment_spec_t *v1beta2_deployment_spec_parseFromJSON(cJSON *v1beta2_
 
     return v1beta2_deployment_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (strategy_local_nonprim) {
+        v1beta2_deployment_strategy_free(strategy_local_nonprim);
+        strategy_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_deployment_strategy.c
+++ b/kubernetes/model/v1beta2_deployment_strategy.c
@@ -95,6 +95,10 @@ v1beta2_deployment_strategy_t *v1beta2_deployment_strategy_parseFromJSON(cJSON *
 
     return v1beta2_deployment_strategy_local_var;
 end:
+    if (rolling_update_local_nonprim) {
+        v1beta2_rolling_update_deployment_free(rolling_update_local_nonprim);
+        rolling_update_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_replica_set.c
+++ b/kubernetes/model/v1beta2_replica_set.c
@@ -173,6 +173,18 @@ v1beta2_replica_set_t *v1beta2_replica_set_parseFromJSON(cJSON *v1beta2_replica_
 
     return v1beta2_replica_set_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta2_replica_set_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta2_replica_set_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_replica_set_list.c
+++ b/kubernetes/model/v1beta2_replica_set_list.c
@@ -176,6 +176,10 @@ v1beta2_replica_set_list_t *v1beta2_replica_set_list_parseFromJSON(cJSON *v1beta
 
     return v1beta2_replica_set_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_replica_set_spec.c
+++ b/kubernetes/model/v1beta2_replica_set_spec.c
@@ -143,6 +143,14 @@ v1beta2_replica_set_spec_t *v1beta2_replica_set_spec_parseFromJSON(cJSON *v1beta
 
     return v1beta2_replica_set_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_scale.c
+++ b/kubernetes/model/v1beta2_scale.c
@@ -173,6 +173,18 @@ v1beta2_scale_t *v1beta2_scale_parseFromJSON(cJSON *v1beta2_scaleJSON){
 
     return v1beta2_scale_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta2_scale_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta2_scale_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_stateful_set.c
+++ b/kubernetes/model/v1beta2_stateful_set.c
@@ -173,6 +173,18 @@ v1beta2_stateful_set_t *v1beta2_stateful_set_parseFromJSON(cJSON *v1beta2_statef
 
     return v1beta2_stateful_set_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1beta2_stateful_set_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v1beta2_stateful_set_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_stateful_set_list.c
+++ b/kubernetes/model/v1beta2_stateful_set_list.c
@@ -176,6 +176,10 @@ v1beta2_stateful_set_list_t *v1beta2_stateful_set_list_parseFromJSON(cJSON *v1be
 
     return v1beta2_stateful_set_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_stateful_set_spec.c
+++ b/kubernetes/model/v1beta2_stateful_set_spec.c
@@ -280,6 +280,18 @@ v1beta2_stateful_set_spec_t *v1beta2_stateful_set_spec_parseFromJSON(cJSON *v1be
 
     return v1beta2_stateful_set_spec_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (_template_local_nonprim) {
+        v1_pod_template_spec_free(_template_local_nonprim);
+        _template_local_nonprim = NULL;
+    }
+    if (update_strategy_local_nonprim) {
+        v1beta2_stateful_set_update_strategy_free(update_strategy_local_nonprim);
+        update_strategy_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v1beta2_stateful_set_update_strategy.c
+++ b/kubernetes/model/v1beta2_stateful_set_update_strategy.c
@@ -95,6 +95,10 @@ v1beta2_stateful_set_update_strategy_t *v1beta2_stateful_set_update_strategy_par
 
     return v1beta2_stateful_set_update_strategy_local_var;
 end:
+    if (rolling_update_local_nonprim) {
+        v1beta2_rolling_update_stateful_set_strategy_free(rolling_update_local_nonprim);
+        rolling_update_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2alpha1_cron_job.c
+++ b/kubernetes/model/v2alpha1_cron_job.c
@@ -173,6 +173,18 @@ v2alpha1_cron_job_t *v2alpha1_cron_job_parseFromJSON(cJSON *v2alpha1_cron_jobJSO
 
     return v2alpha1_cron_job_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v2alpha1_cron_job_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v2alpha1_cron_job_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2alpha1_cron_job_list.c
+++ b/kubernetes/model/v2alpha1_cron_job_list.c
@@ -176,6 +176,10 @@ v2alpha1_cron_job_list_t *v2alpha1_cron_job_list_parseFromJSON(cJSON *v2alpha1_c
 
     return v2alpha1_cron_job_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2alpha1_cron_job_spec.c
+++ b/kubernetes/model/v2alpha1_cron_job_spec.c
@@ -209,6 +209,10 @@ v2alpha1_cron_job_spec_t *v2alpha1_cron_job_spec_parseFromJSON(cJSON *v2alpha1_c
 
     return v2alpha1_cron_job_spec_local_var;
 end:
+    if (job_template_local_nonprim) {
+        v2alpha1_job_template_spec_free(job_template_local_nonprim);
+        job_template_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2alpha1_job_template_spec.c
+++ b/kubernetes/model/v2alpha1_job_template_spec.c
@@ -98,6 +98,14 @@ v2alpha1_job_template_spec_t *v2alpha1_job_template_spec_parseFromJSON(cJSON *v2
 
     return v2alpha1_job_template_spec_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v1_job_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_external_metric_source.c
+++ b/kubernetes/model/v2beta1_external_metric_source.c
@@ -148,6 +148,10 @@ v2beta1_external_metric_source_t *v2beta1_external_metric_source_parseFromJSON(c
 
     return v2beta1_external_metric_source_local_var;
 end:
+    if (metric_selector_local_nonprim) {
+        v1_label_selector_free(metric_selector_local_nonprim);
+        metric_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_external_metric_status.c
+++ b/kubernetes/model/v2beta1_external_metric_status.c
@@ -153,6 +153,10 @@ v2beta1_external_metric_status_t *v2beta1_external_metric_status_parseFromJSON(c
 
     return v2beta1_external_metric_status_local_var;
 end:
+    if (metric_selector_local_nonprim) {
+        v1_label_selector_free(metric_selector_local_nonprim);
+        metric_selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_horizontal_pod_autoscaler.c
+++ b/kubernetes/model/v2beta1_horizontal_pod_autoscaler.c
@@ -173,6 +173,18 @@ v2beta1_horizontal_pod_autoscaler_t *v2beta1_horizontal_pod_autoscaler_parseFrom
 
     return v2beta1_horizontal_pod_autoscaler_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v2beta1_horizontal_pod_autoscaler_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v2beta1_horizontal_pod_autoscaler_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_horizontal_pod_autoscaler_list.c
+++ b/kubernetes/model/v2beta1_horizontal_pod_autoscaler_list.c
@@ -176,6 +176,10 @@ v2beta1_horizontal_pod_autoscaler_list_t *v2beta1_horizontal_pod_autoscaler_list
 
     return v2beta1_horizontal_pod_autoscaler_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_horizontal_pod_autoscaler_spec.c
+++ b/kubernetes/model/v2beta1_horizontal_pod_autoscaler_spec.c
@@ -173,6 +173,10 @@ v2beta1_horizontal_pod_autoscaler_spec_t *v2beta1_horizontal_pod_autoscaler_spec
 
     return v2beta1_horizontal_pod_autoscaler_spec_local_var;
 end:
+    if (scale_target_ref_local_nonprim) {
+        v2beta1_cross_version_object_reference_free(scale_target_ref_local_nonprim);
+        scale_target_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_metric_spec.c
+++ b/kubernetes/model/v2beta1_metric_spec.c
@@ -181,6 +181,22 @@ v2beta1_metric_spec_t *v2beta1_metric_spec_parseFromJSON(cJSON *v2beta1_metric_s
 
     return v2beta1_metric_spec_local_var;
 end:
+    if (external_local_nonprim) {
+        v2beta1_external_metric_source_free(external_local_nonprim);
+        external_local_nonprim = NULL;
+    }
+    if (object_local_nonprim) {
+        v2beta1_object_metric_source_free(object_local_nonprim);
+        object_local_nonprim = NULL;
+    }
+    if (pods_local_nonprim) {
+        v2beta1_pods_metric_source_free(pods_local_nonprim);
+        pods_local_nonprim = NULL;
+    }
+    if (resource_local_nonprim) {
+        v2beta1_resource_metric_source_free(resource_local_nonprim);
+        resource_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_metric_status.c
+++ b/kubernetes/model/v2beta1_metric_status.c
@@ -181,6 +181,22 @@ v2beta1_metric_status_t *v2beta1_metric_status_parseFromJSON(cJSON *v2beta1_metr
 
     return v2beta1_metric_status_local_var;
 end:
+    if (external_local_nonprim) {
+        v2beta1_external_metric_status_free(external_local_nonprim);
+        external_local_nonprim = NULL;
+    }
+    if (object_local_nonprim) {
+        v2beta1_object_metric_status_free(object_local_nonprim);
+        object_local_nonprim = NULL;
+    }
+    if (pods_local_nonprim) {
+        v2beta1_pods_metric_status_free(pods_local_nonprim);
+        pods_local_nonprim = NULL;
+    }
+    if (resource_local_nonprim) {
+        v2beta1_resource_metric_status_free(resource_local_nonprim);
+        resource_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_object_metric_source.c
+++ b/kubernetes/model/v2beta1_object_metric_source.c
@@ -185,6 +185,14 @@ v2beta1_object_metric_source_t *v2beta1_object_metric_source_parseFromJSON(cJSON
 
     return v2beta1_object_metric_source_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (target_local_nonprim) {
+        v2beta1_cross_version_object_reference_free(target_local_nonprim);
+        target_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_object_metric_status.c
+++ b/kubernetes/model/v2beta1_object_metric_status.c
@@ -185,6 +185,14 @@ v2beta1_object_metric_status_t *v2beta1_object_metric_status_parseFromJSON(cJSON
 
     return v2beta1_object_metric_status_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
+    if (target_local_nonprim) {
+        v2beta1_cross_version_object_reference_free(target_local_nonprim);
+        target_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_pods_metric_source.c
+++ b/kubernetes/model/v2beta1_pods_metric_source.c
@@ -129,6 +129,10 @@ v2beta1_pods_metric_source_t *v2beta1_pods_metric_source_parseFromJSON(cJSON *v2
 
     return v2beta1_pods_metric_source_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta1_pods_metric_status.c
+++ b/kubernetes/model/v2beta1_pods_metric_status.c
@@ -129,6 +129,10 @@ v2beta1_pods_metric_status_t *v2beta1_pods_metric_status_parseFromJSON(cJSON *v2
 
     return v2beta1_pods_metric_status_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_external_metric_source.c
+++ b/kubernetes/model/v2beta2_external_metric_source.c
@@ -108,6 +108,14 @@ v2beta2_external_metric_source_t *v2beta2_external_metric_source_parseFromJSON(c
 
     return v2beta2_external_metric_source_local_var;
 end:
+    if (metric_local_nonprim) {
+        v2beta2_metric_identifier_free(metric_local_nonprim);
+        metric_local_nonprim = NULL;
+    }
+    if (target_local_nonprim) {
+        v2beta2_metric_target_free(target_local_nonprim);
+        target_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_external_metric_status.c
+++ b/kubernetes/model/v2beta2_external_metric_status.c
@@ -108,6 +108,14 @@ v2beta2_external_metric_status_t *v2beta2_external_metric_status_parseFromJSON(c
 
     return v2beta2_external_metric_status_local_var;
 end:
+    if (current_local_nonprim) {
+        v2beta2_metric_value_status_free(current_local_nonprim);
+        current_local_nonprim = NULL;
+    }
+    if (metric_local_nonprim) {
+        v2beta2_metric_identifier_free(metric_local_nonprim);
+        metric_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_horizontal_pod_autoscaler.c
+++ b/kubernetes/model/v2beta2_horizontal_pod_autoscaler.c
@@ -173,6 +173,18 @@ v2beta2_horizontal_pod_autoscaler_t *v2beta2_horizontal_pod_autoscaler_parseFrom
 
     return v2beta2_horizontal_pod_autoscaler_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_object_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
+    if (spec_local_nonprim) {
+        v2beta2_horizontal_pod_autoscaler_spec_free(spec_local_nonprim);
+        spec_local_nonprim = NULL;
+    }
+    if (status_local_nonprim) {
+        v2beta2_horizontal_pod_autoscaler_status_free(status_local_nonprim);
+        status_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_horizontal_pod_autoscaler_list.c
+++ b/kubernetes/model/v2beta2_horizontal_pod_autoscaler_list.c
@@ -176,6 +176,10 @@ v2beta2_horizontal_pod_autoscaler_list_t *v2beta2_horizontal_pod_autoscaler_list
 
     return v2beta2_horizontal_pod_autoscaler_list_local_var;
 end:
+    if (metadata_local_nonprim) {
+        v1_list_meta_free(metadata_local_nonprim);
+        metadata_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_horizontal_pod_autoscaler_spec.c
+++ b/kubernetes/model/v2beta2_horizontal_pod_autoscaler_spec.c
@@ -173,6 +173,10 @@ v2beta2_horizontal_pod_autoscaler_spec_t *v2beta2_horizontal_pod_autoscaler_spec
 
     return v2beta2_horizontal_pod_autoscaler_spec_local_var;
 end:
+    if (scale_target_ref_local_nonprim) {
+        v2beta2_cross_version_object_reference_free(scale_target_ref_local_nonprim);
+        scale_target_ref_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_metric_identifier.c
+++ b/kubernetes/model/v2beta2_metric_identifier.c
@@ -100,6 +100,10 @@ v2beta2_metric_identifier_t *v2beta2_metric_identifier_parseFromJSON(cJSON *v2be
 
     return v2beta2_metric_identifier_local_var;
 end:
+    if (selector_local_nonprim) {
+        v1_label_selector_free(selector_local_nonprim);
+        selector_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_metric_spec.c
+++ b/kubernetes/model/v2beta2_metric_spec.c
@@ -181,6 +181,22 @@ v2beta2_metric_spec_t *v2beta2_metric_spec_parseFromJSON(cJSON *v2beta2_metric_s
 
     return v2beta2_metric_spec_local_var;
 end:
+    if (external_local_nonprim) {
+        v2beta2_external_metric_source_free(external_local_nonprim);
+        external_local_nonprim = NULL;
+    }
+    if (object_local_nonprim) {
+        v2beta2_object_metric_source_free(object_local_nonprim);
+        object_local_nonprim = NULL;
+    }
+    if (pods_local_nonprim) {
+        v2beta2_pods_metric_source_free(pods_local_nonprim);
+        pods_local_nonprim = NULL;
+    }
+    if (resource_local_nonprim) {
+        v2beta2_resource_metric_source_free(resource_local_nonprim);
+        resource_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_metric_status.c
+++ b/kubernetes/model/v2beta2_metric_status.c
@@ -181,6 +181,22 @@ v2beta2_metric_status_t *v2beta2_metric_status_parseFromJSON(cJSON *v2beta2_metr
 
     return v2beta2_metric_status_local_var;
 end:
+    if (external_local_nonprim) {
+        v2beta2_external_metric_status_free(external_local_nonprim);
+        external_local_nonprim = NULL;
+    }
+    if (object_local_nonprim) {
+        v2beta2_object_metric_status_free(object_local_nonprim);
+        object_local_nonprim = NULL;
+    }
+    if (pods_local_nonprim) {
+        v2beta2_pods_metric_status_free(pods_local_nonprim);
+        pods_local_nonprim = NULL;
+    }
+    if (resource_local_nonprim) {
+        v2beta2_resource_metric_status_free(resource_local_nonprim);
+        resource_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_object_metric_source.c
+++ b/kubernetes/model/v2beta2_object_metric_source.c
@@ -140,6 +140,18 @@ v2beta2_object_metric_source_t *v2beta2_object_metric_source_parseFromJSON(cJSON
 
     return v2beta2_object_metric_source_local_var;
 end:
+    if (described_object_local_nonprim) {
+        v2beta2_cross_version_object_reference_free(described_object_local_nonprim);
+        described_object_local_nonprim = NULL;
+    }
+    if (metric_local_nonprim) {
+        v2beta2_metric_identifier_free(metric_local_nonprim);
+        metric_local_nonprim = NULL;
+    }
+    if (target_local_nonprim) {
+        v2beta2_metric_target_free(target_local_nonprim);
+        target_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_object_metric_status.c
+++ b/kubernetes/model/v2beta2_object_metric_status.c
@@ -140,6 +140,18 @@ v2beta2_object_metric_status_t *v2beta2_object_metric_status_parseFromJSON(cJSON
 
     return v2beta2_object_metric_status_local_var;
 end:
+    if (current_local_nonprim) {
+        v2beta2_metric_value_status_free(current_local_nonprim);
+        current_local_nonprim = NULL;
+    }
+    if (described_object_local_nonprim) {
+        v2beta2_cross_version_object_reference_free(described_object_local_nonprim);
+        described_object_local_nonprim = NULL;
+    }
+    if (metric_local_nonprim) {
+        v2beta2_metric_identifier_free(metric_local_nonprim);
+        metric_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_pods_metric_source.c
+++ b/kubernetes/model/v2beta2_pods_metric_source.c
@@ -108,6 +108,14 @@ v2beta2_pods_metric_source_t *v2beta2_pods_metric_source_parseFromJSON(cJSON *v2
 
     return v2beta2_pods_metric_source_local_var;
 end:
+    if (metric_local_nonprim) {
+        v2beta2_metric_identifier_free(metric_local_nonprim);
+        metric_local_nonprim = NULL;
+    }
+    if (target_local_nonprim) {
+        v2beta2_metric_target_free(target_local_nonprim);
+        target_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_pods_metric_status.c
+++ b/kubernetes/model/v2beta2_pods_metric_status.c
@@ -108,6 +108,14 @@ v2beta2_pods_metric_status_t *v2beta2_pods_metric_status_parseFromJSON(cJSON *v2
 
     return v2beta2_pods_metric_status_local_var;
 end:
+    if (current_local_nonprim) {
+        v2beta2_metric_value_status_free(current_local_nonprim);
+        current_local_nonprim = NULL;
+    }
+    if (metric_local_nonprim) {
+        v2beta2_metric_identifier_free(metric_local_nonprim);
+        metric_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_resource_metric_source.c
+++ b/kubernetes/model/v2beta2_resource_metric_source.c
@@ -105,6 +105,10 @@ v2beta2_resource_metric_source_t *v2beta2_resource_metric_source_parseFromJSON(c
 
     return v2beta2_resource_metric_source_local_var;
 end:
+    if (target_local_nonprim) {
+        v2beta2_metric_target_free(target_local_nonprim);
+        target_local_nonprim = NULL;
+    }
     return NULL;
 
 }

--- a/kubernetes/model/v2beta2_resource_metric_status.c
+++ b/kubernetes/model/v2beta2_resource_metric_status.c
@@ -105,6 +105,10 @@ v2beta2_resource_metric_status_t *v2beta2_resource_metric_status_parseFromJSON(c
 
     return v2beta2_resource_metric_status_local_var;
 end:
+    if (current_local_nonprim) {
+        v2beta2_metric_value_status_free(current_local_nonprim);
+        current_local_nonprim = NULL;
+    }
     return NULL;
 
 }


### PR DESCRIPTION
The valgrind test reports a memory leak for the example [delete_pod](https://github.com/kubernetes-client/c/tree/master/examples/delete_pod)

```shell
valgrind --tool=memcheck --leak-check=full ./delete_pod_bin
==32029== Memcheck, a memory error detector
==32029== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==32029== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==32029== Command: ./delete_pod_bin
==32029==
OK
The return code of HTTP request=200
The pod is deleted successfully.
==32029==
==32029== HEAP SUMMARY:
==32029==     in use at exit: 82 bytes in 3 blocks
==32029==   total heap usage: 8,728 allocs, 8,725 frees, 1,057,554 bytes allocated
==32029==
==32029== 82 (32 direct, 50 indirect) bytes in 1 blocks are definitely lost in loss record 3 of 3
==32029==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==32029==    by 0x4EEBFA1: v1_list_meta_create (v1_list_meta.c:14)
==32029==    by 0x4EEC2F2: v1_list_meta_parseFromJSON (v1_list_meta.c:130)
==32029==    by 0x4F1D1B2: v1_status_parseFromJSON (v1_status.c:206)
==32029==    by 0x5044D9C: CoreV1API_deleteNamespacedPod (CoreV1API.c:14789)
==32029==    by 0x108B45: delete_a_pod (main.c:10)
==32029==    by 0x108C94: main (main.c:53)
==32029==
==32029== LEAK SUMMARY:
==32029==    definitely lost: 32 bytes in 1 blocks
==32029==    indirectly lost: 50 bytes in 2 blocks
==32029==      possibly lost: 0 bytes in 0 blocks
==32029==    still reachable: 0 bytes in 0 blocks
==32029==         suppressed: 0 bytes in 0 blocks
==32029==
==32029== For counts of detected and suppressed errors, rerun with: -v
==32029== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

The reason is:
Deleting a pod successfully will return a ```v1_pod_t```  other than a ```v1_status_t``` from Kubernetes API server, but the generated client code still wants to parse the JSON string to create a ```v1_status_t``` in the function ```v1_status_parseFromJSON```, the detail can refer to  https://github.com/kubernetes-client/c/issues/31#issuecomment-704321954

 ```v1_status_t *v1_status_parseFromJSON(cJSON *v1_statusJSON)``` will return NULL because the parameter ```v1_statusJSON``` is not a valid ```v1_status_t``` JSON, but ```metadata_local_nonprim``` (member of v1_status_t) is created and its memory is not released before the function returns, this will cause memory leak.

I fixed the issue by this [PR](https://github.com/OpenAPITools/openapi-generator/pull/8390) in the openapi-generator repo, now re-generate the C client to merge the fix.

After this fix, valgrind does not reports memory leak:
```
==28375== All heap blocks were freed -- no leaks are possible
```