### PR TITLE
[Multi-Thread] Remove cJSON_GetErrorPtr in examples and authentication plugin code

### DIFF
--- a/examples/multi_thread/watch_pod.c
+++ b/examples/multi_thread/watch_pod.c
@@ -12,9 +12,13 @@ static void on_pod_event_comes(const char *event_string)
         return;
     }
 
-    cJSON *event_json_obj = cJSON_Parse(event_string);
+    char *type = NULL;
+    v1_pod_t *pod = NULL;
+
+    const char *parse_end = NULL;
+    cJSON *event_json_obj = cJSON_ParseWithOpts(event_string, &parse_end, 1);
     if (!event_json_obj) {
-        fprintf(stderr, "%s: Cannot create JSON from string.[%s].\n", fname, cJSON_GetErrorPtr());
+        fprintf(stderr, "%s: Cannot create JSON from string: [%s].\n", fname, parse_end);
         goto end;
     }
 
@@ -23,7 +27,7 @@ static void on_pod_event_comes(const char *event_string)
         fprintf(stderr, "%s: Cannot get type in watch event.\n", fname);
         goto end;
     }
-    char *type = strdup(json_value_type->valuestring);
+    type = strdup(json_value_type->valuestring);
     printf("type: %s\n", type);
 
     cJSON *json_value_object = cJSON_GetObjectItem(event_json_obj, WATCH_EVENT_KEY_OBJECT);
@@ -31,7 +35,7 @@ static void on_pod_event_comes(const char *event_string)
         fprintf(stderr, "%s: Cannot get object in watch event.\n", fname);
         goto end;
     }
-    v1_pod_t *pod = v1_pod_parseFromJSON(json_value_object);
+    pod = v1_pod_parseFromJSON(json_value_object);
     if (!pod) {
         fprintf(stderr, "%s: Cannot get pod from watch event object.\n", fname);
         goto end;

--- a/examples/watch_list_pod/main.c
+++ b/examples/watch_list_pod/main.c
@@ -18,9 +18,13 @@ void on_pod_event_comes(const char *event_string)
     }
     printf("\nwatch event raw string:\n%s\n\n", event_string);
 
-    cJSON *event_json_obj = cJSON_Parse(event_string);
+    char *type = NULL;
+    v1_pod_t *pod = NULL;
+
+    const char *parse_end = NULL;
+    cJSON *event_json_obj = cJSON_ParseWithOpts(event_string, &parse_end, 1);
     if (!event_json_obj) {
-        fprintf(stderr, "%s: Cannot create JSON from string.[%s].\n", fname, cJSON_GetErrorPtr());
+        fprintf(stderr, "%s: Cannot create JSON from string: [%s].\n", fname, parse_end);
         goto end;
     }
 
@@ -29,7 +33,7 @@ void on_pod_event_comes(const char *event_string)
         fprintf(stderr, "%s: Cannot get type in watch event.\n", fname);
         goto end;
     }
-    char *type = strdup(json_value_type->valuestring);
+    type = strdup(json_value_type->valuestring);
     printf("type: %s\n", type);
 
     cJSON *json_value_object = cJSON_GetObjectItem(event_json_obj, WATCH_EVENT_KEY_OBJECT);
@@ -37,7 +41,7 @@ void on_pod_event_comes(const char *event_string)
         fprintf(stderr, "%s: Cannot get object in watch event.\n", fname);
         goto end;
     }
-    v1_pod_t *pod = v1_pod_parseFromJSON(json_value_object);
+    pod = v1_pod_parseFromJSON(json_value_object);
     if (!pod) {
         fprintf(stderr, "%s: Cannot get pod from watch event object.\n", fname);
         goto end;

--- a/kubernetes/config/authn_plugin/authn_plugin_util.c
+++ b/kubernetes/config/authn_plugin/authn_plugin_util.c
@@ -15,13 +15,13 @@ int shc_request(char **p_http_response, int *p_http_response_length, char *type,
     int rc = http_client->response_code;
     switch (rc) {
     case HTTP_RC_OK:
-        *p_http_response = strndup((char *)http_client->dataReceived, http_client->dataReceivedLen);
+        *p_http_response = strndup((char *) http_client->dataReceived, http_client->dataReceivedLen);
         *p_http_response_length = http_client->dataReceivedLen;
         break;
     default:
         printf("%s: response_code=%ld\n", fname, http_client->response_code);
         if (http_client->dataReceived) {
-            printf("%s: %s\n", fname, (char *)http_client->dataReceived);
+            printf("%s: %s\n", fname, (char *) http_client->dataReceived);
         }
         break;
     }
@@ -50,9 +50,10 @@ char *shc_get_string_from_json(const char *json_string, const char *key)
         return NULL;
     }
 
-    cJSON *json = cJSON_Parse(json_string);
+    const char *parse_end = NULL;
+    cJSON *json = cJSON_ParseWithOpts(json_string, &parse_end, 1);
     if (!json) {
-        fprintf(stderr, "%s: Cannot create JSON from string.[%s].\n", fname, cJSON_GetErrorPtr());
+        fprintf(stderr, "%s: Cannot create JSON from string: [%s].\n", fname, parse_end);
         return NULL;
     }
     cJSON *value = cJSON_GetObjectItem(json, key);

--- a/kubernetes/config/authn_plugin/plugins/oidc/libkubernetes_oidc.c
+++ b/kubernetes/config/authn_plugin/plugins/oidc/libkubernetes_oidc.c
@@ -70,9 +70,10 @@ static time_t get_token_expiration_time(const char *token_string)
         goto end;
     }
 
-    cJSON *payload_JSON = cJSON_Parse(b64decode);
+    const char *parse_end = NULL;
+    cJSON *payload_JSON = cJSON_ParseWithOpts(b64decode, &parse_end, 1);
     if (!payload_JSON) {
-        fprintf(stderr, "%s: Cannot create JSON from string.[%s].\n", fname, cJSON_GetErrorPtr());
+        fprintf(stderr, "%s: Cannot create JSON from string.[%s].\n", fname, parse_end);
         goto end;
     }
     cJSON *json_value = cJSON_GetObjectItem(payload_JSON, OIDC_ID_TOKEN_EXP);


### PR DESCRIPTION
To fix the issue described in #54

Remove `cJSON_GetErrorPtr()` in examples and authentication plugin code to ensure thread safety