### PR TITLE
Change some parameters of the functions from "char *" to "const char *" to eliminate compilation warnings

### DIFF
--- a/kubernetes/api/AppsV1API.c
+++ b/kubernetes/api/AppsV1API.c
@@ -5893,7 +5893,7 @@ end:
 // list or watch objects of kind StatefulSet
 //
 v1_stateful_set_list_t*
-AppsV1API_listNamespacedStatefulSet(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
+AppsV1API_listNamespacedStatefulSet(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -10388,7 +10388,7 @@ end:
 // read the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export )
+AppsV1API_readNamespacedStatefulSet(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AppsV1API.h
+++ b/kubernetes/api/AppsV1API.h
@@ -162,7 +162,7 @@ AppsV1API_listNamespacedReplicaSet(apiClient_t *apiClient, char * _namespace , c
 // list or watch objects of kind StatefulSet
 //
 v1_stateful_set_list_t*
-AppsV1API_listNamespacedStatefulSet(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
+AppsV1API_listNamespacedStatefulSet(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ReplicaSet
@@ -306,7 +306,7 @@ AppsV1API_readNamespacedReplicaSetStatus(apiClient_t *apiClient, char * name , c
 // read the specified StatefulSet
 //
 v1_stateful_set_t*
-AppsV1API_readNamespacedStatefulSet(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export );
+AppsV1API_readNamespacedStatefulSet(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export );
 
 
 // read scale of the specified StatefulSet

--- a/kubernetes/api/AutoscalingV1API.c
+++ b/kubernetes/api/AutoscalingV1API.c
@@ -1119,7 +1119,7 @@ end:
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_list_t*
-AutoscalingV1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
+AutoscalingV1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1821,7 +1821,7 @@ end:
 // read the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export )
+AutoscalingV1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -1982,7 +1982,7 @@ end:
 // read status of the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * _namespace , char * pretty )
+AutoscalingV1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/AutoscalingV1API.h
+++ b/kubernetes/api/AutoscalingV1API.h
@@ -45,7 +45,7 @@ AutoscalingV1API_listHorizontalPodAutoscalerForAllNamespaces(apiClient_t *apiCli
 // list or watch objects of kind HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_list_t*
-AutoscalingV1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
+AutoscalingV1API_listNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // partially update the specified HorizontalPodAutoscaler
@@ -63,13 +63,13 @@ AutoscalingV1API_patchNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiCl
 // read the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export );
+AutoscalingV1API_readNamespacedHorizontalPodAutoscaler(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export );
 
 
 // read status of the specified HorizontalPodAutoscaler
 //
 v1_horizontal_pod_autoscaler_t*
-AutoscalingV1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, char * name , char * _namespace , char * pretty );
+AutoscalingV1API_readNamespacedHorizontalPodAutoscalerStatus(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty );
 
 
 // replace the specified HorizontalPodAutoscaler

--- a/kubernetes/api/CoreV1API.c
+++ b/kubernetes/api/CoreV1API.c
@@ -14655,7 +14655,7 @@ end:
 // delete a Pod
 //
 v1_status_t*
-CoreV1API_deleteNamespacedPod(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body )
+CoreV1API_deleteNamespacedPod(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , const char * dryRun , int gracePeriodSeconds , int orphanDependents , const char * propagationPolicy , v1_delete_options_t * body )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -18167,7 +18167,7 @@ end:
 // list or watch objects of kind Namespace
 //
 v1_namespace_list_t*
-CoreV1API_listNamespace(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
+CoreV1API_listNamespace(apiClient_t *apiClient, const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -18454,7 +18454,7 @@ end:
 // list or watch objects of kind ConfigMap
 //
 v1_config_map_list_t*
-CoreV1API_listNamespacedConfigMap(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
+CoreV1API_listNamespacedConfigMap(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -19646,7 +19646,7 @@ end:
 // list or watch objects of kind PersistentVolumeClaim
 //
 v1_persistent_volume_claim_list_t*
-CoreV1API_listNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
+CoreV1API_listNamespacedPersistentVolumeClaim(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -19944,7 +19944,7 @@ end:
 // list or watch objects of kind Pod
 //
 v1_pod_list_t*
-CoreV1API_listNamespacedPod(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
+CoreV1API_listNamespacedPod(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -21434,7 +21434,7 @@ end:
 // list or watch objects of kind Service
 //
 v1_service_list_t*
-CoreV1API_listNamespacedService(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch )
+CoreV1API_listNamespacedService(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -29782,7 +29782,7 @@ end:
 // read the specified Namespace
 //
 v1_namespace_t*
-CoreV1API_readNamespace(apiClient_t *apiClient, char * name , char * pretty , int exact , int _export )
+CoreV1API_readNamespace(apiClient_t *apiClient, const char * name , char * pretty , int exact , int _export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30032,7 +30032,7 @@ end:
 // read the specified ConfigMap
 //
 v1_config_map_t*
-CoreV1API_readNamespacedConfigMap(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export )
+CoreV1API_readNamespacedConfigMap(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30676,7 +30676,7 @@ end:
 // read the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_readNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export )
+CoreV1API_readNamespacedPersistentVolumeClaim(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -30948,7 +30948,7 @@ end:
 // read the specified Pod
 //
 v1_pod_t*
-CoreV1API_readNamespacedPod(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export )
+CoreV1API_readNamespacedPod(apiClient_t *apiClient, const char * name , const char * _namespace , char * pretty , int exact , int _export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -32502,7 +32502,7 @@ end:
 // read the specified Service
 //
 v1_service_t*
-CoreV1API_readNamespacedService(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export )
+CoreV1API_readNamespacedService(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;
@@ -32935,7 +32935,7 @@ end:
 // read the specified Node
 //
 v1_node_t*
-CoreV1API_readNode(apiClient_t *apiClient, char * name , char * pretty , int exact , int _export )
+CoreV1API_readNode(apiClient_t *apiClient, const char * name , const char * pretty , int exact , int _export )
 {
     list_t    *localVarQueryParameters = list_create();
     list_t    *localVarHeaderParameters = NULL;

--- a/kubernetes/api/CoreV1API.h
+++ b/kubernetes/api/CoreV1API.h
@@ -565,7 +565,7 @@ CoreV1API_deleteNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * n
 // delete a Pod
 //
 v1_status_t*
-CoreV1API_deleteNamespacedPod(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
+CoreV1API_deleteNamespacedPod(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , const char * dryRun , int gracePeriodSeconds , int orphanDependents , char * propagationPolicy , v1_delete_options_t * body );
 
 
 // delete a PodTemplate
@@ -655,13 +655,13 @@ CoreV1API_listLimitRangeForAllNamespaces(apiClient_t *apiClient, int allowWatchB
 // list or watch objects of kind Namespace
 //
 v1_namespace_list_t*
-CoreV1API_listNamespace(apiClient_t *apiClient, char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
+CoreV1API_listNamespace(apiClient_t *apiClient, const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ConfigMap
 //
 v1_config_map_list_t*
-CoreV1API_listNamespacedConfigMap(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
+CoreV1API_listNamespacedConfigMap(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Endpoints
@@ -685,13 +685,13 @@ CoreV1API_listNamespacedLimitRange(apiClient_t *apiClient, char * _namespace , c
 // list or watch objects of kind PersistentVolumeClaim
 //
 v1_persistent_volume_claim_list_t*
-CoreV1API_listNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
+CoreV1API_listNamespacedPersistentVolumeClaim(apiClient_t *apiClient, const char * _namespace , char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind Pod
 //
 v1_pod_list_t*
-CoreV1API_listNamespacedPod(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
+CoreV1API_listNamespacedPod(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind PodTemplate
@@ -721,7 +721,7 @@ CoreV1API_listNamespacedSecret(apiClient_t *apiClient, char * _namespace , char 
 // list or watch objects of kind Service
 //
 v1_service_list_t*
-CoreV1API_listNamespacedService(apiClient_t *apiClient, char * _namespace , char * pretty , int allowWatchBookmarks , char * _continue , char * fieldSelector , char * labelSelector , int limit , char * resourceVersion , int timeoutSeconds , int watch );
+CoreV1API_listNamespacedService(apiClient_t *apiClient, const char * _namespace , const char * pretty , int allowWatchBookmarks , const char * _continue , const char * fieldSelector , const char * labelSelector , int limit , const char * resourceVersion , int timeoutSeconds , int watch );
 
 
 // list or watch objects of kind ServiceAccount
@@ -955,7 +955,7 @@ CoreV1API_readNamespaceStatus(apiClient_t *apiClient, char * name , char * prett
 // read the specified ConfigMap
 //
 v1_config_map_t*
-CoreV1API_readNamespacedConfigMap(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export );
+CoreV1API_readNamespacedConfigMap(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export );
 
 
 // read the specified Endpoints
@@ -979,7 +979,7 @@ CoreV1API_readNamespacedLimitRange(apiClient_t *apiClient, char * name , char * 
 // read the specified PersistentVolumeClaim
 //
 v1_persistent_volume_claim_t*
-CoreV1API_readNamespacedPersistentVolumeClaim(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export );
+CoreV1API_readNamespacedPersistentVolumeClaim(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export );
 
 
 // read status of the specified PersistentVolumeClaim
@@ -991,7 +991,7 @@ CoreV1API_readNamespacedPersistentVolumeClaimStatus(apiClient_t *apiClient, char
 // read the specified Pod
 //
 v1_pod_t*
-CoreV1API_readNamespacedPod(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export );
+CoreV1API_readNamespacedPod(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export );
 
 
 // read log of the specified Pod
@@ -1051,7 +1051,7 @@ CoreV1API_readNamespacedSecret(apiClient_t *apiClient, char * name , char * _nam
 // read the specified Service
 //
 v1_service_t*
-CoreV1API_readNamespacedService(apiClient_t *apiClient, char * name , char * _namespace , char * pretty , int exact , int _export );
+CoreV1API_readNamespacedService(apiClient_t *apiClient, const char * name , const char * _namespace , const char * pretty , int exact , int _export );
 
 
 // read the specified ServiceAccount
@@ -1069,7 +1069,7 @@ CoreV1API_readNamespacedServiceStatus(apiClient_t *apiClient, char * name , char
 // read the specified Node
 //
 v1_node_t*
-CoreV1API_readNode(apiClient_t *apiClient, char * name , char * pretty , int exact , int _export );
+CoreV1API_readNode(apiClient_t *apiClient, const char * name , const char * pretty , int exact , int _export );
 
 
 // read status of the specified Node


### PR DESCRIPTION
To fix the issue described in #61 

Change some parameters of the functions from "char *" to "const char *" to eliminate compilation warnings