### PR TITLE
Define and initialize non-primitive variables at the beginning of function

### DIFF
--- a/kubernetes/model/admissionregistration_v1_webhook_client_config.c
+++ b/kubernetes/model/admissionregistration_v1_webhook_client_config.c
@@ -85,6 +85,9 @@ admissionregistration_v1_webhook_client_config_t *admissionregistration_v1_webho
 
     admissionregistration_v1_webhook_client_config_t *admissionregistration_v1_webhook_client_config_local_var = NULL;
 
+    // define the local variable for admissionregistration_v1_webhook_client_config->service
+    admissionregistration_v1_service_reference_t *service_local_nonprim = NULL;
+
     // admissionregistration_v1_webhook_client_config->ca_bundle
     cJSON *ca_bundle = cJSON_GetObjectItemCaseSensitive(admissionregistration_v1_webhook_client_configJSON, "caBundle");
     if (ca_bundle) { 
@@ -96,7 +99,6 @@ admissionregistration_v1_webhook_client_config_t *admissionregistration_v1_webho
 
     // admissionregistration_v1_webhook_client_config->service
     cJSON *service = cJSON_GetObjectItemCaseSensitive(admissionregistration_v1_webhook_client_configJSON, "service");
-    admissionregistration_v1_service_reference_t *service_local_nonprim = NULL;
     if (service) { 
     service_local_nonprim = admissionregistration_v1_service_reference_parseFromJSON(service); //nonprimitive
     }

--- a/kubernetes/model/apiextensions_v1_webhook_client_config.c
+++ b/kubernetes/model/apiextensions_v1_webhook_client_config.c
@@ -85,6 +85,9 @@ apiextensions_v1_webhook_client_config_t *apiextensions_v1_webhook_client_config
 
     apiextensions_v1_webhook_client_config_t *apiextensions_v1_webhook_client_config_local_var = NULL;
 
+    // define the local variable for apiextensions_v1_webhook_client_config->service
+    apiextensions_v1_service_reference_t *service_local_nonprim = NULL;
+
     // apiextensions_v1_webhook_client_config->ca_bundle
     cJSON *ca_bundle = cJSON_GetObjectItemCaseSensitive(apiextensions_v1_webhook_client_configJSON, "caBundle");
     if (ca_bundle) { 
@@ -96,7 +99,6 @@ apiextensions_v1_webhook_client_config_t *apiextensions_v1_webhook_client_config
 
     // apiextensions_v1_webhook_client_config->service
     cJSON *service = cJSON_GetObjectItemCaseSensitive(apiextensions_v1_webhook_client_configJSON, "service");
-    apiextensions_v1_service_reference_t *service_local_nonprim = NULL;
     if (service) { 
     service_local_nonprim = apiextensions_v1_service_reference_parseFromJSON(service); //nonprimitive
     }

--- a/kubernetes/model/authentication_v1_token_request.c
+++ b/kubernetes/model/authentication_v1_token_request.c
@@ -125,6 +125,15 @@ authentication_v1_token_request_t *authentication_v1_token_request_parseFromJSON
 
     authentication_v1_token_request_t *authentication_v1_token_request_local_var = NULL;
 
+    // define the local variable for authentication_v1_token_request->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for authentication_v1_token_request->spec
+    v1_token_request_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for authentication_v1_token_request->status
+    v1_token_request_status_t *status_local_nonprim = NULL;
+
     // authentication_v1_token_request->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(authentication_v1_token_requestJSON, "apiVersion");
     if (api_version) { 
@@ -145,7 +154,6 @@ authentication_v1_token_request_t *authentication_v1_token_request_parseFromJSON
 
     // authentication_v1_token_request->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(authentication_v1_token_requestJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -156,13 +164,11 @@ authentication_v1_token_request_t *authentication_v1_token_request_parseFromJSON
         goto end;
     }
 
-    v1_token_request_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_token_request_spec_parseFromJSON(spec); //nonprimitive
 
     // authentication_v1_token_request->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(authentication_v1_token_requestJSON, "status");
-    v1_token_request_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_token_request_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/core_v1_event.c
+++ b/kubernetes/model/core_v1_event.c
@@ -301,6 +301,21 @@ core_v1_event_t *core_v1_event_parseFromJSON(cJSON *core_v1_eventJSON){
 
     core_v1_event_t *core_v1_event_local_var = NULL;
 
+    // define the local variable for core_v1_event->involved_object
+    v1_object_reference_t *involved_object_local_nonprim = NULL;
+
+    // define the local variable for core_v1_event->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for core_v1_event->related
+    v1_object_reference_t *related_local_nonprim = NULL;
+
+    // define the local variable for core_v1_event->series
+    core_v1_event_series_t *series_local_nonprim = NULL;
+
+    // define the local variable for core_v1_event->source
+    v1_event_source_t *source_local_nonprim = NULL;
+
     // core_v1_event->action
     cJSON *action = cJSON_GetObjectItemCaseSensitive(core_v1_eventJSON, "action");
     if (action) { 
@@ -352,7 +367,6 @@ core_v1_event_t *core_v1_event_parseFromJSON(cJSON *core_v1_eventJSON){
         goto end;
     }
 
-    v1_object_reference_t *involved_object_local_nonprim = NULL;
     
     involved_object_local_nonprim = v1_object_reference_parseFromJSON(involved_object); //nonprimitive
 
@@ -389,7 +403,6 @@ core_v1_event_t *core_v1_event_parseFromJSON(cJSON *core_v1_eventJSON){
         goto end;
     }
 
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
 
@@ -404,7 +417,6 @@ core_v1_event_t *core_v1_event_parseFromJSON(cJSON *core_v1_eventJSON){
 
     // core_v1_event->related
     cJSON *related = cJSON_GetObjectItemCaseSensitive(core_v1_eventJSON, "related");
-    v1_object_reference_t *related_local_nonprim = NULL;
     if (related) { 
     related_local_nonprim = v1_object_reference_parseFromJSON(related); //nonprimitive
     }
@@ -429,14 +441,12 @@ core_v1_event_t *core_v1_event_parseFromJSON(cJSON *core_v1_eventJSON){
 
     // core_v1_event->series
     cJSON *series = cJSON_GetObjectItemCaseSensitive(core_v1_eventJSON, "series");
-    core_v1_event_series_t *series_local_nonprim = NULL;
     if (series) { 
     series_local_nonprim = core_v1_event_series_parseFromJSON(series); //nonprimitive
     }
 
     // core_v1_event->source
     cJSON *source = cJSON_GetObjectItemCaseSensitive(core_v1_eventJSON, "source");
-    v1_event_source_t *source_local_nonprim = NULL;
     if (source) { 
     source_local_nonprim = v1_event_source_parseFromJSON(source); //nonprimitive
     }

--- a/kubernetes/model/core_v1_event_list.c
+++ b/kubernetes/model/core_v1_event_list.c
@@ -116,6 +116,9 @@ core_v1_event_list_t *core_v1_event_list_parseFromJSON(cJSON *core_v1_event_list
 
     core_v1_event_list_t *core_v1_event_list_local_var = NULL;
 
+    // define the local variable for core_v1_event_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // core_v1_event_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(core_v1_event_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ core_v1_event_list_t *core_v1_event_list_parseFromJSON(cJSON *core_v1_event_list
 
     // core_v1_event_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(core_v1_event_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/events_v1_event.c
+++ b/kubernetes/model/events_v1_event.c
@@ -299,6 +299,21 @@ events_v1_event_t *events_v1_event_parseFromJSON(cJSON *events_v1_eventJSON){
 
     events_v1_event_t *events_v1_event_local_var = NULL;
 
+    // define the local variable for events_v1_event->deprecated_source
+    v1_event_source_t *deprecated_source_local_nonprim = NULL;
+
+    // define the local variable for events_v1_event->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for events_v1_event->regarding
+    v1_object_reference_t *regarding_local_nonprim = NULL;
+
+    // define the local variable for events_v1_event->related
+    v1_object_reference_t *related_local_nonprim = NULL;
+
+    // define the local variable for events_v1_event->series
+    events_v1_event_series_t *series_local_nonprim = NULL;
+
     // events_v1_event->action
     cJSON *action = cJSON_GetObjectItemCaseSensitive(events_v1_eventJSON, "action");
     if (action) { 
@@ -346,7 +361,6 @@ events_v1_event_t *events_v1_event_parseFromJSON(cJSON *events_v1_eventJSON){
 
     // events_v1_event->deprecated_source
     cJSON *deprecated_source = cJSON_GetObjectItemCaseSensitive(events_v1_eventJSON, "deprecatedSource");
-    v1_event_source_t *deprecated_source_local_nonprim = NULL;
     if (deprecated_source) { 
     deprecated_source_local_nonprim = v1_event_source_parseFromJSON(deprecated_source); //nonprimitive
     }
@@ -374,7 +388,6 @@ events_v1_event_t *events_v1_event_parseFromJSON(cJSON *events_v1_eventJSON){
 
     // events_v1_event->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(events_v1_eventJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -399,14 +412,12 @@ events_v1_event_t *events_v1_event_parseFromJSON(cJSON *events_v1_eventJSON){
 
     // events_v1_event->regarding
     cJSON *regarding = cJSON_GetObjectItemCaseSensitive(events_v1_eventJSON, "regarding");
-    v1_object_reference_t *regarding_local_nonprim = NULL;
     if (regarding) { 
     regarding_local_nonprim = v1_object_reference_parseFromJSON(regarding); //nonprimitive
     }
 
     // events_v1_event->related
     cJSON *related = cJSON_GetObjectItemCaseSensitive(events_v1_eventJSON, "related");
-    v1_object_reference_t *related_local_nonprim = NULL;
     if (related) { 
     related_local_nonprim = v1_object_reference_parseFromJSON(related); //nonprimitive
     }
@@ -431,7 +442,6 @@ events_v1_event_t *events_v1_event_parseFromJSON(cJSON *events_v1_eventJSON){
 
     // events_v1_event->series
     cJSON *series = cJSON_GetObjectItemCaseSensitive(events_v1_eventJSON, "series");
-    events_v1_event_series_t *series_local_nonprim = NULL;
     if (series) { 
     series_local_nonprim = events_v1_event_series_parseFromJSON(series); //nonprimitive
     }

--- a/kubernetes/model/events_v1_event_list.c
+++ b/kubernetes/model/events_v1_event_list.c
@@ -116,6 +116,9 @@ events_v1_event_list_t *events_v1_event_list_parseFromJSON(cJSON *events_v1_even
 
     events_v1_event_list_t *events_v1_event_list_local_var = NULL;
 
+    // define the local variable for events_v1_event_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // events_v1_event_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(events_v1_event_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ events_v1_event_list_t *events_v1_event_list_parseFromJSON(cJSON *events_v1_even
 
     // events_v1_event_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(events_v1_event_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_affinity.c
+++ b/kubernetes/model/v1_affinity.c
@@ -95,23 +95,29 @@ v1_affinity_t *v1_affinity_parseFromJSON(cJSON *v1_affinityJSON){
 
     v1_affinity_t *v1_affinity_local_var = NULL;
 
+    // define the local variable for v1_affinity->node_affinity
+    v1_node_affinity_t *node_affinity_local_nonprim = NULL;
+
+    // define the local variable for v1_affinity->pod_affinity
+    v1_pod_affinity_t *pod_affinity_local_nonprim = NULL;
+
+    // define the local variable for v1_affinity->pod_anti_affinity
+    v1_pod_anti_affinity_t *pod_anti_affinity_local_nonprim = NULL;
+
     // v1_affinity->node_affinity
     cJSON *node_affinity = cJSON_GetObjectItemCaseSensitive(v1_affinityJSON, "nodeAffinity");
-    v1_node_affinity_t *node_affinity_local_nonprim = NULL;
     if (node_affinity) { 
     node_affinity_local_nonprim = v1_node_affinity_parseFromJSON(node_affinity); //nonprimitive
     }
 
     // v1_affinity->pod_affinity
     cJSON *pod_affinity = cJSON_GetObjectItemCaseSensitive(v1_affinityJSON, "podAffinity");
-    v1_pod_affinity_t *pod_affinity_local_nonprim = NULL;
     if (pod_affinity) { 
     pod_affinity_local_nonprim = v1_pod_affinity_parseFromJSON(pod_affinity); //nonprimitive
     }
 
     // v1_affinity->pod_anti_affinity
     cJSON *pod_anti_affinity = cJSON_GetObjectItemCaseSensitive(v1_affinityJSON, "podAntiAffinity");
-    v1_pod_anti_affinity_t *pod_anti_affinity_local_nonprim = NULL;
     if (pod_anti_affinity) { 
     pod_anti_affinity_local_nonprim = v1_pod_anti_affinity_parseFromJSON(pod_anti_affinity); //nonprimitive
     }

--- a/kubernetes/model/v1_api_group.c
+++ b/kubernetes/model/v1_api_group.c
@@ -161,6 +161,9 @@ v1_api_group_t *v1_api_group_parseFromJSON(cJSON *v1_api_groupJSON){
 
     v1_api_group_t *v1_api_group_local_var = NULL;
 
+    // define the local variable for v1_api_group->preferred_version
+    v1_group_version_for_discovery_t *preferred_version_local_nonprim = NULL;
+
     // v1_api_group->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_api_groupJSON, "apiVersion");
     if (api_version) { 
@@ -193,7 +196,6 @@ v1_api_group_t *v1_api_group_parseFromJSON(cJSON *v1_api_groupJSON){
 
     // v1_api_group->preferred_version
     cJSON *preferred_version = cJSON_GetObjectItemCaseSensitive(v1_api_groupJSON, "preferredVersion");
-    v1_group_version_for_discovery_t *preferred_version_local_nonprim = NULL;
     if (preferred_version) { 
     preferred_version_local_nonprim = v1_group_version_for_discovery_parseFromJSON(preferred_version); //nonprimitive
     }

--- a/kubernetes/model/v1_api_service.c
+++ b/kubernetes/model/v1_api_service.c
@@ -123,6 +123,15 @@ v1_api_service_t *v1_api_service_parseFromJSON(cJSON *v1_api_serviceJSON){
 
     v1_api_service_t *v1_api_service_local_var = NULL;
 
+    // define the local variable for v1_api_service->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_api_service->spec
+    v1_api_service_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_api_service->status
+    v1_api_service_status_t *status_local_nonprim = NULL;
+
     // v1_api_service->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_api_serviceJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_api_service_t *v1_api_service_parseFromJSON(cJSON *v1_api_serviceJSON){
 
     // v1_api_service->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_api_serviceJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_api_service->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_api_serviceJSON, "spec");
-    v1_api_service_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_api_service_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_api_service->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_api_serviceJSON, "status");
-    v1_api_service_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_api_service_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_api_service_list.c
+++ b/kubernetes/model/v1_api_service_list.c
@@ -116,6 +116,9 @@ v1_api_service_list_t *v1_api_service_list_parseFromJSON(cJSON *v1_api_service_l
 
     v1_api_service_list_t *v1_api_service_list_local_var = NULL;
 
+    // define the local variable for v1_api_service_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_api_service_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_api_service_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_api_service_list_t *v1_api_service_list_parseFromJSON(cJSON *v1_api_service_l
 
     // v1_api_service_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_api_service_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_api_service_spec.c
+++ b/kubernetes/model/v1_api_service_spec.c
@@ -133,6 +133,9 @@ v1_api_service_spec_t *v1_api_service_spec_parseFromJSON(cJSON *v1_api_service_s
 
     v1_api_service_spec_t *v1_api_service_spec_local_var = NULL;
 
+    // define the local variable for v1_api_service_spec->service
+    apiregistration_v1_service_reference_t *service_local_nonprim = NULL;
+
     // v1_api_service_spec->ca_bundle
     cJSON *ca_bundle = cJSON_GetObjectItemCaseSensitive(v1_api_service_specJSON, "caBundle");
     if (ca_bundle) { 
@@ -174,7 +177,6 @@ v1_api_service_spec_t *v1_api_service_spec_parseFromJSON(cJSON *v1_api_service_s
 
     // v1_api_service_spec->service
     cJSON *service = cJSON_GetObjectItemCaseSensitive(v1_api_service_specJSON, "service");
-    apiregistration_v1_service_reference_t *service_local_nonprim = NULL;
     if (service) { 
     service_local_nonprim = apiregistration_v1_service_reference_parseFromJSON(service); //nonprimitive
     }

--- a/kubernetes/model/v1_binding.c
+++ b/kubernetes/model/v1_binding.c
@@ -106,6 +106,12 @@ v1_binding_t *v1_binding_parseFromJSON(cJSON *v1_bindingJSON){
 
     v1_binding_t *v1_binding_local_var = NULL;
 
+    // define the local variable for v1_binding->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_binding->target
+    v1_object_reference_t *target_local_nonprim = NULL;
+
     // v1_binding->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_bindingJSON, "apiVersion");
     if (api_version) { 
@@ -126,7 +132,6 @@ v1_binding_t *v1_binding_parseFromJSON(cJSON *v1_bindingJSON){
 
     // v1_binding->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_bindingJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -137,7 +142,6 @@ v1_binding_t *v1_binding_parseFromJSON(cJSON *v1_bindingJSON){
         goto end;
     }
 
-    v1_object_reference_t *target_local_nonprim = NULL;
     
     target_local_nonprim = v1_object_reference_parseFromJSON(target); //nonprimitive
 

--- a/kubernetes/model/v1_ceph_fs_persistent_volume_source.c
+++ b/kubernetes/model/v1_ceph_fs_persistent_volume_source.c
@@ -137,6 +137,9 @@ v1_ceph_fs_persistent_volume_source_t *v1_ceph_fs_persistent_volume_source_parse
 
     v1_ceph_fs_persistent_volume_source_t *v1_ceph_fs_persistent_volume_source_local_var = NULL;
 
+    // define the local variable for v1_ceph_fs_persistent_volume_source->secret_ref
+    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_ceph_fs_persistent_volume_source->monitors
     cJSON *monitors = cJSON_GetObjectItemCaseSensitive(v1_ceph_fs_persistent_volume_sourceJSON, "monitors");
     if (!monitors) {
@@ -189,7 +192,6 @@ v1_ceph_fs_persistent_volume_source_t *v1_ceph_fs_persistent_volume_source_parse
 
     // v1_ceph_fs_persistent_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_ceph_fs_persistent_volume_sourceJSON, "secretRef");
-    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_secret_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_ceph_fs_volume_source.c
+++ b/kubernetes/model/v1_ceph_fs_volume_source.c
@@ -137,6 +137,9 @@ v1_ceph_fs_volume_source_t *v1_ceph_fs_volume_source_parseFromJSON(cJSON *v1_cep
 
     v1_ceph_fs_volume_source_t *v1_ceph_fs_volume_source_local_var = NULL;
 
+    // define the local variable for v1_ceph_fs_volume_source->secret_ref
+    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_ceph_fs_volume_source->monitors
     cJSON *monitors = cJSON_GetObjectItemCaseSensitive(v1_ceph_fs_volume_sourceJSON, "monitors");
     if (!monitors) {
@@ -189,7 +192,6 @@ v1_ceph_fs_volume_source_t *v1_ceph_fs_volume_source_parseFromJSON(cJSON *v1_cep
 
     // v1_ceph_fs_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_ceph_fs_volume_sourceJSON, "secretRef");
-    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_local_object_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_certificate_signing_request.c
+++ b/kubernetes/model/v1_certificate_signing_request.c
@@ -125,6 +125,15 @@ v1_certificate_signing_request_t *v1_certificate_signing_request_parseFromJSON(c
 
     v1_certificate_signing_request_t *v1_certificate_signing_request_local_var = NULL;
 
+    // define the local variable for v1_certificate_signing_request->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_certificate_signing_request->spec
+    v1_certificate_signing_request_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_certificate_signing_request->status
+    v1_certificate_signing_request_status_t *status_local_nonprim = NULL;
+
     // v1_certificate_signing_request->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_certificate_signing_requestJSON, "apiVersion");
     if (api_version) { 
@@ -145,7 +154,6 @@ v1_certificate_signing_request_t *v1_certificate_signing_request_parseFromJSON(c
 
     // v1_certificate_signing_request->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_certificate_signing_requestJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -156,13 +164,11 @@ v1_certificate_signing_request_t *v1_certificate_signing_request_parseFromJSON(c
         goto end;
     }
 
-    v1_certificate_signing_request_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_certificate_signing_request_spec_parseFromJSON(spec); //nonprimitive
 
     // v1_certificate_signing_request->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_certificate_signing_requestJSON, "status");
-    v1_certificate_signing_request_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_certificate_signing_request_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_certificate_signing_request_list.c
+++ b/kubernetes/model/v1_certificate_signing_request_list.c
@@ -116,6 +116,9 @@ v1_certificate_signing_request_list_t *v1_certificate_signing_request_list_parse
 
     v1_certificate_signing_request_list_t *v1_certificate_signing_request_list_local_var = NULL;
 
+    // define the local variable for v1_certificate_signing_request_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_certificate_signing_request_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_certificate_signing_request_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_certificate_signing_request_list_t *v1_certificate_signing_request_list_parse
 
     // v1_certificate_signing_request_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_certificate_signing_request_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_cinder_persistent_volume_source.c
+++ b/kubernetes/model/v1_cinder_persistent_volume_source.c
@@ -97,6 +97,9 @@ v1_cinder_persistent_volume_source_t *v1_cinder_persistent_volume_source_parseFr
 
     v1_cinder_persistent_volume_source_t *v1_cinder_persistent_volume_source_local_var = NULL;
 
+    // define the local variable for v1_cinder_persistent_volume_source->secret_ref
+    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_cinder_persistent_volume_source->fs_type
     cJSON *fs_type = cJSON_GetObjectItemCaseSensitive(v1_cinder_persistent_volume_sourceJSON, "fsType");
     if (fs_type) { 
@@ -117,7 +120,6 @@ v1_cinder_persistent_volume_source_t *v1_cinder_persistent_volume_source_parseFr
 
     // v1_cinder_persistent_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_cinder_persistent_volume_sourceJSON, "secretRef");
-    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_secret_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_cinder_volume_source.c
+++ b/kubernetes/model/v1_cinder_volume_source.c
@@ -97,6 +97,9 @@ v1_cinder_volume_source_t *v1_cinder_volume_source_parseFromJSON(cJSON *v1_cinde
 
     v1_cinder_volume_source_t *v1_cinder_volume_source_local_var = NULL;
 
+    // define the local variable for v1_cinder_volume_source->secret_ref
+    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_cinder_volume_source->fs_type
     cJSON *fs_type = cJSON_GetObjectItemCaseSensitive(v1_cinder_volume_sourceJSON, "fsType");
     if (fs_type) { 
@@ -117,7 +120,6 @@ v1_cinder_volume_source_t *v1_cinder_volume_source_parseFromJSON(cJSON *v1_cinde
 
     // v1_cinder_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_cinder_volume_sourceJSON, "secretRef");
-    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_local_object_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_cluster_role.c
+++ b/kubernetes/model/v1_cluster_role.c
@@ -133,9 +133,14 @@ v1_cluster_role_t *v1_cluster_role_parseFromJSON(cJSON *v1_cluster_roleJSON){
 
     v1_cluster_role_t *v1_cluster_role_local_var = NULL;
 
+    // define the local variable for v1_cluster_role->aggregation_rule
+    v1_aggregation_rule_t *aggregation_rule_local_nonprim = NULL;
+
+    // define the local variable for v1_cluster_role->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_cluster_role->aggregation_rule
     cJSON *aggregation_rule = cJSON_GetObjectItemCaseSensitive(v1_cluster_roleJSON, "aggregationRule");
-    v1_aggregation_rule_t *aggregation_rule_local_nonprim = NULL;
     if (aggregation_rule) { 
     aggregation_rule_local_nonprim = v1_aggregation_rule_parseFromJSON(aggregation_rule); //nonprimitive
     }
@@ -160,7 +165,6 @@ v1_cluster_role_t *v1_cluster_role_parseFromJSON(cJSON *v1_cluster_roleJSON){
 
     // v1_cluster_role->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_cluster_roleJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_cluster_role_binding.c
+++ b/kubernetes/model/v1_cluster_role_binding.c
@@ -135,6 +135,12 @@ v1_cluster_role_binding_t *v1_cluster_role_binding_parseFromJSON(cJSON *v1_clust
 
     v1_cluster_role_binding_t *v1_cluster_role_binding_local_var = NULL;
 
+    // define the local variable for v1_cluster_role_binding->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_cluster_role_binding->role_ref
+    v1_role_ref_t *role_ref_local_nonprim = NULL;
+
     // v1_cluster_role_binding->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_cluster_role_bindingJSON, "apiVersion");
     if (api_version) { 
@@ -155,7 +161,6 @@ v1_cluster_role_binding_t *v1_cluster_role_binding_parseFromJSON(cJSON *v1_clust
 
     // v1_cluster_role_binding->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_cluster_role_bindingJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -166,7 +171,6 @@ v1_cluster_role_binding_t *v1_cluster_role_binding_parseFromJSON(cJSON *v1_clust
         goto end;
     }
 
-    v1_role_ref_t *role_ref_local_nonprim = NULL;
     
     role_ref_local_nonprim = v1_role_ref_parseFromJSON(role_ref); //nonprimitive
 

--- a/kubernetes/model/v1_cluster_role_binding_list.c
+++ b/kubernetes/model/v1_cluster_role_binding_list.c
@@ -116,6 +116,9 @@ v1_cluster_role_binding_list_t *v1_cluster_role_binding_list_parseFromJSON(cJSON
 
     v1_cluster_role_binding_list_t *v1_cluster_role_binding_list_local_var = NULL;
 
+    // define the local variable for v1_cluster_role_binding_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_cluster_role_binding_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_cluster_role_binding_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_cluster_role_binding_list_t *v1_cluster_role_binding_list_parseFromJSON(cJSON
 
     // v1_cluster_role_binding_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_cluster_role_binding_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_cluster_role_list.c
+++ b/kubernetes/model/v1_cluster_role_list.c
@@ -116,6 +116,9 @@ v1_cluster_role_list_t *v1_cluster_role_list_parseFromJSON(cJSON *v1_cluster_rol
 
     v1_cluster_role_list_t *v1_cluster_role_list_local_var = NULL;
 
+    // define the local variable for v1_cluster_role_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_cluster_role_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_cluster_role_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_cluster_role_list_t *v1_cluster_role_list_parseFromJSON(cJSON *v1_cluster_rol
 
     // v1_cluster_role_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_cluster_role_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_component_status.c
+++ b/kubernetes/model/v1_component_status.c
@@ -114,6 +114,9 @@ v1_component_status_t *v1_component_status_parseFromJSON(cJSON *v1_component_sta
 
     v1_component_status_t *v1_component_status_local_var = NULL;
 
+    // define the local variable for v1_component_status->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_component_status->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_component_statusJSON, "apiVersion");
     if (api_version) { 
@@ -156,7 +159,6 @@ v1_component_status_t *v1_component_status_parseFromJSON(cJSON *v1_component_sta
 
     // v1_component_status->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_component_statusJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_component_status_list.c
+++ b/kubernetes/model/v1_component_status_list.c
@@ -116,6 +116,9 @@ v1_component_status_list_t *v1_component_status_list_parseFromJSON(cJSON *v1_com
 
     v1_component_status_list_t *v1_component_status_list_local_var = NULL;
 
+    // define the local variable for v1_component_status_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_component_status_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_component_status_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_component_status_list_t *v1_component_status_list_parseFromJSON(cJSON *v1_com
 
     // v1_component_status_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_component_status_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_config_map.c
+++ b/kubernetes/model/v1_config_map.c
@@ -159,6 +159,9 @@ v1_config_map_t *v1_config_map_parseFromJSON(cJSON *v1_config_mapJSON){
 
     v1_config_map_t *v1_config_map_local_var = NULL;
 
+    // define the local variable for v1_config_map->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_config_map->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_config_mapJSON, "apiVersion");
     if (api_version) { 
@@ -232,7 +235,6 @@ v1_config_map_t *v1_config_map_parseFromJSON(cJSON *v1_config_mapJSON){
 
     // v1_config_map->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_config_mapJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_config_map_list.c
+++ b/kubernetes/model/v1_config_map_list.c
@@ -116,6 +116,9 @@ v1_config_map_list_t *v1_config_map_list_parseFromJSON(cJSON *v1_config_map_list
 
     v1_config_map_list_t *v1_config_map_list_local_var = NULL;
 
+    // define the local variable for v1_config_map_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_config_map_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_config_map_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_config_map_list_t *v1_config_map_list_parseFromJSON(cJSON *v1_config_map_list
 
     // v1_config_map_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_config_map_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_container.c
+++ b/kubernetes/model/v1_container.c
@@ -465,6 +465,24 @@ v1_container_t *v1_container_parseFromJSON(cJSON *v1_containerJSON){
 
     v1_container_t *v1_container_local_var = NULL;
 
+    // define the local variable for v1_container->lifecycle
+    v1_lifecycle_t *lifecycle_local_nonprim = NULL;
+
+    // define the local variable for v1_container->liveness_probe
+    v1_probe_t *liveness_probe_local_nonprim = NULL;
+
+    // define the local variable for v1_container->readiness_probe
+    v1_probe_t *readiness_probe_local_nonprim = NULL;
+
+    // define the local variable for v1_container->resources
+    v1_resource_requirements_t *resources_local_nonprim = NULL;
+
+    // define the local variable for v1_container->security_context
+    v1_security_context_t *security_context_local_nonprim = NULL;
+
+    // define the local variable for v1_container->startup_probe
+    v1_probe_t *startup_probe_local_nonprim = NULL;
+
     // v1_container->args
     cJSON *args = cJSON_GetObjectItemCaseSensitive(v1_containerJSON, "args");
     list_t *argsList;
@@ -569,14 +587,12 @@ v1_container_t *v1_container_parseFromJSON(cJSON *v1_containerJSON){
 
     // v1_container->lifecycle
     cJSON *lifecycle = cJSON_GetObjectItemCaseSensitive(v1_containerJSON, "lifecycle");
-    v1_lifecycle_t *lifecycle_local_nonprim = NULL;
     if (lifecycle) { 
     lifecycle_local_nonprim = v1_lifecycle_parseFromJSON(lifecycle); //nonprimitive
     }
 
     // v1_container->liveness_probe
     cJSON *liveness_probe = cJSON_GetObjectItemCaseSensitive(v1_containerJSON, "livenessProbe");
-    v1_probe_t *liveness_probe_local_nonprim = NULL;
     if (liveness_probe) { 
     liveness_probe_local_nonprim = v1_probe_parseFromJSON(liveness_probe); //nonprimitive
     }
@@ -617,28 +633,24 @@ v1_container_t *v1_container_parseFromJSON(cJSON *v1_containerJSON){
 
     // v1_container->readiness_probe
     cJSON *readiness_probe = cJSON_GetObjectItemCaseSensitive(v1_containerJSON, "readinessProbe");
-    v1_probe_t *readiness_probe_local_nonprim = NULL;
     if (readiness_probe) { 
     readiness_probe_local_nonprim = v1_probe_parseFromJSON(readiness_probe); //nonprimitive
     }
 
     // v1_container->resources
     cJSON *resources = cJSON_GetObjectItemCaseSensitive(v1_containerJSON, "resources");
-    v1_resource_requirements_t *resources_local_nonprim = NULL;
     if (resources) { 
     resources_local_nonprim = v1_resource_requirements_parseFromJSON(resources); //nonprimitive
     }
 
     // v1_container->security_context
     cJSON *security_context = cJSON_GetObjectItemCaseSensitive(v1_containerJSON, "securityContext");
-    v1_security_context_t *security_context_local_nonprim = NULL;
     if (security_context) { 
     security_context_local_nonprim = v1_security_context_parseFromJSON(security_context); //nonprimitive
     }
 
     // v1_container->startup_probe
     cJSON *startup_probe = cJSON_GetObjectItemCaseSensitive(v1_containerJSON, "startupProbe");
-    v1_probe_t *startup_probe_local_nonprim = NULL;
     if (startup_probe) { 
     startup_probe_local_nonprim = v1_probe_parseFromJSON(startup_probe); //nonprimitive
     }

--- a/kubernetes/model/v1_container_state.c
+++ b/kubernetes/model/v1_container_state.c
@@ -95,23 +95,29 @@ v1_container_state_t *v1_container_state_parseFromJSON(cJSON *v1_container_state
 
     v1_container_state_t *v1_container_state_local_var = NULL;
 
+    // define the local variable for v1_container_state->running
+    v1_container_state_running_t *running_local_nonprim = NULL;
+
+    // define the local variable for v1_container_state->terminated
+    v1_container_state_terminated_t *terminated_local_nonprim = NULL;
+
+    // define the local variable for v1_container_state->waiting
+    v1_container_state_waiting_t *waiting_local_nonprim = NULL;
+
     // v1_container_state->running
     cJSON *running = cJSON_GetObjectItemCaseSensitive(v1_container_stateJSON, "running");
-    v1_container_state_running_t *running_local_nonprim = NULL;
     if (running) { 
     running_local_nonprim = v1_container_state_running_parseFromJSON(running); //nonprimitive
     }
 
     // v1_container_state->terminated
     cJSON *terminated = cJSON_GetObjectItemCaseSensitive(v1_container_stateJSON, "terminated");
-    v1_container_state_terminated_t *terminated_local_nonprim = NULL;
     if (terminated) { 
     terminated_local_nonprim = v1_container_state_terminated_parseFromJSON(terminated); //nonprimitive
     }
 
     // v1_container_state->waiting
     cJSON *waiting = cJSON_GetObjectItemCaseSensitive(v1_container_stateJSON, "waiting");
-    v1_container_state_waiting_t *waiting_local_nonprim = NULL;
     if (waiting) { 
     waiting_local_nonprim = v1_container_state_waiting_parseFromJSON(waiting); //nonprimitive
     }

--- a/kubernetes/model/v1_container_status.c
+++ b/kubernetes/model/v1_container_status.c
@@ -172,6 +172,12 @@ v1_container_status_t *v1_container_status_parseFromJSON(cJSON *v1_container_sta
 
     v1_container_status_t *v1_container_status_local_var = NULL;
 
+    // define the local variable for v1_container_status->last_state
+    v1_container_state_t *last_state_local_nonprim = NULL;
+
+    // define the local variable for v1_container_status->state
+    v1_container_state_t *state_local_nonprim = NULL;
+
     // v1_container_status->container_id
     cJSON *container_id = cJSON_GetObjectItemCaseSensitive(v1_container_statusJSON, "containerID");
     if (container_id) { 
@@ -207,7 +213,6 @@ v1_container_status_t *v1_container_status_parseFromJSON(cJSON *v1_container_sta
 
     // v1_container_status->last_state
     cJSON *last_state = cJSON_GetObjectItemCaseSensitive(v1_container_statusJSON, "lastState");
-    v1_container_state_t *last_state_local_nonprim = NULL;
     if (last_state) { 
     last_state_local_nonprim = v1_container_state_parseFromJSON(last_state); //nonprimitive
     }
@@ -259,7 +264,6 @@ v1_container_status_t *v1_container_status_parseFromJSON(cJSON *v1_container_sta
 
     // v1_container_status->state
     cJSON *state = cJSON_GetObjectItemCaseSensitive(v1_container_statusJSON, "state");
-    v1_container_state_t *state_local_nonprim = NULL;
     if (state) { 
     state_local_nonprim = v1_container_state_parseFromJSON(state); //nonprimitive
     }

--- a/kubernetes/model/v1_controller_revision.c
+++ b/kubernetes/model/v1_controller_revision.c
@@ -116,6 +116,9 @@ v1_controller_revision_t *v1_controller_revision_parseFromJSON(cJSON *v1_control
 
     v1_controller_revision_t *v1_controller_revision_local_var = NULL;
 
+    // define the local variable for v1_controller_revision->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_controller_revision->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_controller_revisionJSON, "apiVersion");
     if (api_version) { 
@@ -143,7 +146,6 @@ v1_controller_revision_t *v1_controller_revision_parseFromJSON(cJSON *v1_control
 
     // v1_controller_revision->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_controller_revisionJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_controller_revision_list.c
+++ b/kubernetes/model/v1_controller_revision_list.c
@@ -116,6 +116,9 @@ v1_controller_revision_list_t *v1_controller_revision_list_parseFromJSON(cJSON *
 
     v1_controller_revision_list_t *v1_controller_revision_list_local_var = NULL;
 
+    // define the local variable for v1_controller_revision_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_controller_revision_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_controller_revision_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_controller_revision_list_t *v1_controller_revision_list_parseFromJSON(cJSON *
 
     // v1_controller_revision_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_controller_revision_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_cron_job.c
+++ b/kubernetes/model/v1_cron_job.c
@@ -123,6 +123,15 @@ v1_cron_job_t *v1_cron_job_parseFromJSON(cJSON *v1_cron_jobJSON){
 
     v1_cron_job_t *v1_cron_job_local_var = NULL;
 
+    // define the local variable for v1_cron_job->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_cron_job->spec
+    v1_cron_job_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_cron_job->status
+    v1_cron_job_status_t *status_local_nonprim = NULL;
+
     // v1_cron_job->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_cron_jobJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_cron_job_t *v1_cron_job_parseFromJSON(cJSON *v1_cron_jobJSON){
 
     // v1_cron_job->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_cron_jobJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_cron_job->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_cron_jobJSON, "spec");
-    v1_cron_job_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_cron_job_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_cron_job->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_cron_jobJSON, "status");
-    v1_cron_job_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_cron_job_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_cron_job_list.c
+++ b/kubernetes/model/v1_cron_job_list.c
@@ -116,6 +116,9 @@ v1_cron_job_list_t *v1_cron_job_list_parseFromJSON(cJSON *v1_cron_job_listJSON){
 
     v1_cron_job_list_t *v1_cron_job_list_local_var = NULL;
 
+    // define the local variable for v1_cron_job_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_cron_job_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_cron_job_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_cron_job_list_t *v1_cron_job_list_parseFromJSON(cJSON *v1_cron_job_listJSON){
 
     // v1_cron_job_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_cron_job_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_cron_job_spec.c
+++ b/kubernetes/model/v1_cron_job_spec.c
@@ -129,6 +129,9 @@ v1_cron_job_spec_t *v1_cron_job_spec_parseFromJSON(cJSON *v1_cron_job_specJSON){
 
     v1_cron_job_spec_t *v1_cron_job_spec_local_var = NULL;
 
+    // define the local variable for v1_cron_job_spec->job_template
+    v1_job_template_spec_t *job_template_local_nonprim = NULL;
+
     // v1_cron_job_spec->concurrency_policy
     cJSON *concurrency_policy = cJSON_GetObjectItemCaseSensitive(v1_cron_job_specJSON, "concurrencyPolicy");
     if (concurrency_policy) { 
@@ -153,7 +156,6 @@ v1_cron_job_spec_t *v1_cron_job_spec_parseFromJSON(cJSON *v1_cron_job_specJSON){
         goto end;
     }
 
-    v1_job_template_spec_t *job_template_local_nonprim = NULL;
     
     job_template_local_nonprim = v1_job_template_spec_parseFromJSON(job_template); //nonprimitive
 

--- a/kubernetes/model/v1_csi_driver.c
+++ b/kubernetes/model/v1_csi_driver.c
@@ -106,6 +106,12 @@ v1_csi_driver_t *v1_csi_driver_parseFromJSON(cJSON *v1_csi_driverJSON){
 
     v1_csi_driver_t *v1_csi_driver_local_var = NULL;
 
+    // define the local variable for v1_csi_driver->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_csi_driver->spec
+    v1_csi_driver_spec_t *spec_local_nonprim = NULL;
+
     // v1_csi_driver->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_csi_driverJSON, "apiVersion");
     if (api_version) { 
@@ -126,7 +132,6 @@ v1_csi_driver_t *v1_csi_driver_parseFromJSON(cJSON *v1_csi_driverJSON){
 
     // v1_csi_driver->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_csi_driverJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -137,7 +142,6 @@ v1_csi_driver_t *v1_csi_driver_parseFromJSON(cJSON *v1_csi_driverJSON){
         goto end;
     }
 
-    v1_csi_driver_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_csi_driver_spec_parseFromJSON(spec); //nonprimitive
 

--- a/kubernetes/model/v1_csi_driver_list.c
+++ b/kubernetes/model/v1_csi_driver_list.c
@@ -116,6 +116,9 @@ v1_csi_driver_list_t *v1_csi_driver_list_parseFromJSON(cJSON *v1_csi_driver_list
 
     v1_csi_driver_list_t *v1_csi_driver_list_local_var = NULL;
 
+    // define the local variable for v1_csi_driver_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_csi_driver_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_csi_driver_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_csi_driver_list_t *v1_csi_driver_list_parseFromJSON(cJSON *v1_csi_driver_list
 
     // v1_csi_driver_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_csi_driver_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_csi_node.c
+++ b/kubernetes/model/v1_csi_node.c
@@ -106,6 +106,12 @@ v1_csi_node_t *v1_csi_node_parseFromJSON(cJSON *v1_csi_nodeJSON){
 
     v1_csi_node_t *v1_csi_node_local_var = NULL;
 
+    // define the local variable for v1_csi_node->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_csi_node->spec
+    v1_csi_node_spec_t *spec_local_nonprim = NULL;
+
     // v1_csi_node->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_csi_nodeJSON, "apiVersion");
     if (api_version) { 
@@ -126,7 +132,6 @@ v1_csi_node_t *v1_csi_node_parseFromJSON(cJSON *v1_csi_nodeJSON){
 
     // v1_csi_node->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_csi_nodeJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -137,7 +142,6 @@ v1_csi_node_t *v1_csi_node_parseFromJSON(cJSON *v1_csi_nodeJSON){
         goto end;
     }
 
-    v1_csi_node_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_csi_node_spec_parseFromJSON(spec); //nonprimitive
 

--- a/kubernetes/model/v1_csi_node_driver.c
+++ b/kubernetes/model/v1_csi_node_driver.c
@@ -115,9 +115,11 @@ v1_csi_node_driver_t *v1_csi_node_driver_parseFromJSON(cJSON *v1_csi_node_driver
 
     v1_csi_node_driver_t *v1_csi_node_driver_local_var = NULL;
 
+    // define the local variable for v1_csi_node_driver->allocatable
+    v1_volume_node_resources_t *allocatable_local_nonprim = NULL;
+
     // v1_csi_node_driver->allocatable
     cJSON *allocatable = cJSON_GetObjectItemCaseSensitive(v1_csi_node_driverJSON, "allocatable");
-    v1_volume_node_resources_t *allocatable_local_nonprim = NULL;
     if (allocatable) { 
     allocatable_local_nonprim = v1_volume_node_resources_parseFromJSON(allocatable); //nonprimitive
     }

--- a/kubernetes/model/v1_csi_node_list.c
+++ b/kubernetes/model/v1_csi_node_list.c
@@ -116,6 +116,9 @@ v1_csi_node_list_t *v1_csi_node_list_parseFromJSON(cJSON *v1_csi_node_listJSON){
 
     v1_csi_node_list_t *v1_csi_node_list_local_var = NULL;
 
+    // define the local variable for v1_csi_node_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_csi_node_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_csi_node_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_csi_node_list_t *v1_csi_node_list_parseFromJSON(cJSON *v1_csi_node_listJSON){
 
     // v1_csi_node_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_csi_node_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_csi_persistent_volume_source.c
+++ b/kubernetes/model/v1_csi_persistent_volume_source.c
@@ -202,16 +202,26 @@ v1_csi_persistent_volume_source_t *v1_csi_persistent_volume_source_parseFromJSON
 
     v1_csi_persistent_volume_source_t *v1_csi_persistent_volume_source_local_var = NULL;
 
+    // define the local variable for v1_csi_persistent_volume_source->controller_expand_secret_ref
+    v1_secret_reference_t *controller_expand_secret_ref_local_nonprim = NULL;
+
+    // define the local variable for v1_csi_persistent_volume_source->controller_publish_secret_ref
+    v1_secret_reference_t *controller_publish_secret_ref_local_nonprim = NULL;
+
+    // define the local variable for v1_csi_persistent_volume_source->node_publish_secret_ref
+    v1_secret_reference_t *node_publish_secret_ref_local_nonprim = NULL;
+
+    // define the local variable for v1_csi_persistent_volume_source->node_stage_secret_ref
+    v1_secret_reference_t *node_stage_secret_ref_local_nonprim = NULL;
+
     // v1_csi_persistent_volume_source->controller_expand_secret_ref
     cJSON *controller_expand_secret_ref = cJSON_GetObjectItemCaseSensitive(v1_csi_persistent_volume_sourceJSON, "controllerExpandSecretRef");
-    v1_secret_reference_t *controller_expand_secret_ref_local_nonprim = NULL;
     if (controller_expand_secret_ref) { 
     controller_expand_secret_ref_local_nonprim = v1_secret_reference_parseFromJSON(controller_expand_secret_ref); //nonprimitive
     }
 
     // v1_csi_persistent_volume_source->controller_publish_secret_ref
     cJSON *controller_publish_secret_ref = cJSON_GetObjectItemCaseSensitive(v1_csi_persistent_volume_sourceJSON, "controllerPublishSecretRef");
-    v1_secret_reference_t *controller_publish_secret_ref_local_nonprim = NULL;
     if (controller_publish_secret_ref) { 
     controller_publish_secret_ref_local_nonprim = v1_secret_reference_parseFromJSON(controller_publish_secret_ref); //nonprimitive
     }
@@ -239,14 +249,12 @@ v1_csi_persistent_volume_source_t *v1_csi_persistent_volume_source_parseFromJSON
 
     // v1_csi_persistent_volume_source->node_publish_secret_ref
     cJSON *node_publish_secret_ref = cJSON_GetObjectItemCaseSensitive(v1_csi_persistent_volume_sourceJSON, "nodePublishSecretRef");
-    v1_secret_reference_t *node_publish_secret_ref_local_nonprim = NULL;
     if (node_publish_secret_ref) { 
     node_publish_secret_ref_local_nonprim = v1_secret_reference_parseFromJSON(node_publish_secret_ref); //nonprimitive
     }
 
     // v1_csi_persistent_volume_source->node_stage_secret_ref
     cJSON *node_stage_secret_ref = cJSON_GetObjectItemCaseSensitive(v1_csi_persistent_volume_sourceJSON, "nodeStageSecretRef");
-    v1_secret_reference_t *node_stage_secret_ref_local_nonprim = NULL;
     if (node_stage_secret_ref) { 
     node_stage_secret_ref_local_nonprim = v1_secret_reference_parseFromJSON(node_stage_secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_csi_volume_source.c
+++ b/kubernetes/model/v1_csi_volume_source.c
@@ -129,6 +129,9 @@ v1_csi_volume_source_t *v1_csi_volume_source_parseFromJSON(cJSON *v1_csi_volume_
 
     v1_csi_volume_source_t *v1_csi_volume_source_local_var = NULL;
 
+    // define the local variable for v1_csi_volume_source->node_publish_secret_ref
+    v1_local_object_reference_t *node_publish_secret_ref_local_nonprim = NULL;
+
     // v1_csi_volume_source->driver
     cJSON *driver = cJSON_GetObjectItemCaseSensitive(v1_csi_volume_sourceJSON, "driver");
     if (!driver) {
@@ -152,7 +155,6 @@ v1_csi_volume_source_t *v1_csi_volume_source_parseFromJSON(cJSON *v1_csi_volume_
 
     // v1_csi_volume_source->node_publish_secret_ref
     cJSON *node_publish_secret_ref = cJSON_GetObjectItemCaseSensitive(v1_csi_volume_sourceJSON, "nodePublishSecretRef");
-    v1_local_object_reference_t *node_publish_secret_ref_local_nonprim = NULL;
     if (node_publish_secret_ref) { 
     node_publish_secret_ref_local_nonprim = v1_local_object_reference_parseFromJSON(node_publish_secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_custom_resource_conversion.c
+++ b/kubernetes/model/v1_custom_resource_conversion.c
@@ -73,6 +73,9 @@ v1_custom_resource_conversion_t *v1_custom_resource_conversion_parseFromJSON(cJS
 
     v1_custom_resource_conversion_t *v1_custom_resource_conversion_local_var = NULL;
 
+    // define the local variable for v1_custom_resource_conversion->webhook
+    v1_webhook_conversion_t *webhook_local_nonprim = NULL;
+
     // v1_custom_resource_conversion->strategy
     cJSON *strategy = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_conversionJSON, "strategy");
     if (!strategy) {
@@ -87,7 +90,6 @@ v1_custom_resource_conversion_t *v1_custom_resource_conversion_parseFromJSON(cJS
 
     // v1_custom_resource_conversion->webhook
     cJSON *webhook = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_conversionJSON, "webhook");
-    v1_webhook_conversion_t *webhook_local_nonprim = NULL;
     if (webhook) { 
     webhook_local_nonprim = v1_webhook_conversion_parseFromJSON(webhook); //nonprimitive
     }

--- a/kubernetes/model/v1_custom_resource_definition.c
+++ b/kubernetes/model/v1_custom_resource_definition.c
@@ -125,6 +125,15 @@ v1_custom_resource_definition_t *v1_custom_resource_definition_parseFromJSON(cJS
 
     v1_custom_resource_definition_t *v1_custom_resource_definition_local_var = NULL;
 
+    // define the local variable for v1_custom_resource_definition->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_custom_resource_definition->spec
+    v1_custom_resource_definition_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_custom_resource_definition->status
+    v1_custom_resource_definition_status_t *status_local_nonprim = NULL;
+
     // v1_custom_resource_definition->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_definitionJSON, "apiVersion");
     if (api_version) { 
@@ -145,7 +154,6 @@ v1_custom_resource_definition_t *v1_custom_resource_definition_parseFromJSON(cJS
 
     // v1_custom_resource_definition->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_definitionJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -156,13 +164,11 @@ v1_custom_resource_definition_t *v1_custom_resource_definition_parseFromJSON(cJS
         goto end;
     }
 
-    v1_custom_resource_definition_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_custom_resource_definition_spec_parseFromJSON(spec); //nonprimitive
 
     // v1_custom_resource_definition->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_definitionJSON, "status");
-    v1_custom_resource_definition_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_custom_resource_definition_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_custom_resource_definition_list.c
+++ b/kubernetes/model/v1_custom_resource_definition_list.c
@@ -116,6 +116,9 @@ v1_custom_resource_definition_list_t *v1_custom_resource_definition_list_parseFr
 
     v1_custom_resource_definition_list_t *v1_custom_resource_definition_list_local_var = NULL;
 
+    // define the local variable for v1_custom_resource_definition_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_custom_resource_definition_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_definition_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_custom_resource_definition_list_t *v1_custom_resource_definition_list_parseFr
 
     // v1_custom_resource_definition_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_definition_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_custom_resource_definition_spec.c
+++ b/kubernetes/model/v1_custom_resource_definition_spec.c
@@ -151,9 +151,14 @@ v1_custom_resource_definition_spec_t *v1_custom_resource_definition_spec_parseFr
 
     v1_custom_resource_definition_spec_t *v1_custom_resource_definition_spec_local_var = NULL;
 
+    // define the local variable for v1_custom_resource_definition_spec->conversion
+    v1_custom_resource_conversion_t *conversion_local_nonprim = NULL;
+
+    // define the local variable for v1_custom_resource_definition_spec->names
+    v1_custom_resource_definition_names_t *names_local_nonprim = NULL;
+
     // v1_custom_resource_definition_spec->conversion
     cJSON *conversion = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_definition_specJSON, "conversion");
-    v1_custom_resource_conversion_t *conversion_local_nonprim = NULL;
     if (conversion) { 
     conversion_local_nonprim = v1_custom_resource_conversion_parseFromJSON(conversion); //nonprimitive
     }
@@ -176,7 +181,6 @@ v1_custom_resource_definition_spec_t *v1_custom_resource_definition_spec_parseFr
         goto end;
     }
 
-    v1_custom_resource_definition_names_t *names_local_nonprim = NULL;
     
     names_local_nonprim = v1_custom_resource_definition_names_parseFromJSON(names); //nonprimitive
 

--- a/kubernetes/model/v1_custom_resource_definition_status.c
+++ b/kubernetes/model/v1_custom_resource_definition_status.c
@@ -112,9 +112,11 @@ v1_custom_resource_definition_status_t *v1_custom_resource_definition_status_par
 
     v1_custom_resource_definition_status_t *v1_custom_resource_definition_status_local_var = NULL;
 
+    // define the local variable for v1_custom_resource_definition_status->accepted_names
+    v1_custom_resource_definition_names_t *accepted_names_local_nonprim = NULL;
+
     // v1_custom_resource_definition_status->accepted_names
     cJSON *accepted_names = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_definition_statusJSON, "acceptedNames");
-    v1_custom_resource_definition_names_t *accepted_names_local_nonprim = NULL;
     if (accepted_names) { 
     accepted_names_local_nonprim = v1_custom_resource_definition_names_parseFromJSON(accepted_names); //nonprimitive
     }

--- a/kubernetes/model/v1_custom_resource_definition_version.c
+++ b/kubernetes/model/v1_custom_resource_definition_version.c
@@ -169,6 +169,12 @@ v1_custom_resource_definition_version_t *v1_custom_resource_definition_version_p
 
     v1_custom_resource_definition_version_t *v1_custom_resource_definition_version_local_var = NULL;
 
+    // define the local variable for v1_custom_resource_definition_version->schema
+    v1_custom_resource_validation_t *schema_local_nonprim = NULL;
+
+    // define the local variable for v1_custom_resource_definition_version->subresources
+    v1_custom_resource_subresources_t *subresources_local_nonprim = NULL;
+
     // v1_custom_resource_definition_version->additional_printer_columns
     cJSON *additional_printer_columns = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_definition_versionJSON, "additionalPrinterColumns");
     list_t *additional_printer_columnsList;
@@ -223,7 +229,6 @@ v1_custom_resource_definition_version_t *v1_custom_resource_definition_version_p
 
     // v1_custom_resource_definition_version->schema
     cJSON *schema = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_definition_versionJSON, "schema");
-    v1_custom_resource_validation_t *schema_local_nonprim = NULL;
     if (schema) { 
     schema_local_nonprim = v1_custom_resource_validation_parseFromJSON(schema); //nonprimitive
     }
@@ -254,7 +259,6 @@ v1_custom_resource_definition_version_t *v1_custom_resource_definition_version_p
 
     // v1_custom_resource_definition_version->subresources
     cJSON *subresources = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_definition_versionJSON, "subresources");
-    v1_custom_resource_subresources_t *subresources_local_nonprim = NULL;
     if (subresources) { 
     subresources_local_nonprim = v1_custom_resource_subresources_parseFromJSON(subresources); //nonprimitive
     }

--- a/kubernetes/model/v1_custom_resource_subresources.c
+++ b/kubernetes/model/v1_custom_resource_subresources.c
@@ -76,9 +76,11 @@ v1_custom_resource_subresources_t *v1_custom_resource_subresources_parseFromJSON
 
     v1_custom_resource_subresources_t *v1_custom_resource_subresources_local_var = NULL;
 
+    // define the local variable for v1_custom_resource_subresources->scale
+    v1_custom_resource_subresource_scale_t *scale_local_nonprim = NULL;
+
     // v1_custom_resource_subresources->scale
     cJSON *scale = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_subresourcesJSON, "scale");
-    v1_custom_resource_subresource_scale_t *scale_local_nonprim = NULL;
     if (scale) { 
     scale_local_nonprim = v1_custom_resource_subresource_scale_parseFromJSON(scale); //nonprimitive
     }

--- a/kubernetes/model/v1_custom_resource_validation.c
+++ b/kubernetes/model/v1_custom_resource_validation.c
@@ -57,9 +57,11 @@ v1_custom_resource_validation_t *v1_custom_resource_validation_parseFromJSON(cJS
 
     v1_custom_resource_validation_t *v1_custom_resource_validation_local_var = NULL;
 
+    // define the local variable for v1_custom_resource_validation->open_apiv3_schema
+    v1_json_schema_props_t *open_apiv3_schema_local_nonprim = NULL;
+
     // v1_custom_resource_validation->open_apiv3_schema
     cJSON *open_apiv3_schema = cJSON_GetObjectItemCaseSensitive(v1_custom_resource_validationJSON, "openAPIV3Schema");
-    v1_json_schema_props_t *open_apiv3_schema_local_nonprim = NULL;
     if (open_apiv3_schema) { 
     open_apiv3_schema_local_nonprim = v1_json_schema_props_parseFromJSON(open_apiv3_schema); //nonprimitive
     }

--- a/kubernetes/model/v1_daemon_set.c
+++ b/kubernetes/model/v1_daemon_set.c
@@ -123,6 +123,15 @@ v1_daemon_set_t *v1_daemon_set_parseFromJSON(cJSON *v1_daemon_setJSON){
 
     v1_daemon_set_t *v1_daemon_set_local_var = NULL;
 
+    // define the local variable for v1_daemon_set->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_daemon_set->spec
+    v1_daemon_set_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_daemon_set->status
+    v1_daemon_set_status_t *status_local_nonprim = NULL;
+
     // v1_daemon_set->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_daemon_setJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_daemon_set_t *v1_daemon_set_parseFromJSON(cJSON *v1_daemon_setJSON){
 
     // v1_daemon_set->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_daemon_setJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_daemon_set->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_daemon_setJSON, "spec");
-    v1_daemon_set_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_daemon_set_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_daemon_set->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_daemon_setJSON, "status");
-    v1_daemon_set_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_daemon_set_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_daemon_set_list.c
+++ b/kubernetes/model/v1_daemon_set_list.c
@@ -116,6 +116,9 @@ v1_daemon_set_list_t *v1_daemon_set_list_parseFromJSON(cJSON *v1_daemon_set_list
 
     v1_daemon_set_list_t *v1_daemon_set_list_local_var = NULL;
 
+    // define the local variable for v1_daemon_set_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_daemon_set_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_daemon_set_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_daemon_set_list_t *v1_daemon_set_list_parseFromJSON(cJSON *v1_daemon_set_list
 
     // v1_daemon_set_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_daemon_set_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_daemon_set_spec.c
+++ b/kubernetes/model/v1_daemon_set_spec.c
@@ -119,6 +119,15 @@ v1_daemon_set_spec_t *v1_daemon_set_spec_parseFromJSON(cJSON *v1_daemon_set_spec
 
     v1_daemon_set_spec_t *v1_daemon_set_spec_local_var = NULL;
 
+    // define the local variable for v1_daemon_set_spec->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
+    // define the local variable for v1_daemon_set_spec->_template
+    v1_pod_template_spec_t *_template_local_nonprim = NULL;
+
+    // define the local variable for v1_daemon_set_spec->update_strategy
+    v1_daemon_set_update_strategy_t *update_strategy_local_nonprim = NULL;
+
     // v1_daemon_set_spec->min_ready_seconds
     cJSON *min_ready_seconds = cJSON_GetObjectItemCaseSensitive(v1_daemon_set_specJSON, "minReadySeconds");
     if (min_ready_seconds) { 
@@ -143,7 +152,6 @@ v1_daemon_set_spec_t *v1_daemon_set_spec_parseFromJSON(cJSON *v1_daemon_set_spec
         goto end;
     }
 
-    v1_label_selector_t *selector_local_nonprim = NULL;
     
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
 
@@ -153,13 +161,11 @@ v1_daemon_set_spec_t *v1_daemon_set_spec_parseFromJSON(cJSON *v1_daemon_set_spec
         goto end;
     }
 
-    v1_pod_template_spec_t *_template_local_nonprim = NULL;
     
     _template_local_nonprim = v1_pod_template_spec_parseFromJSON(_template); //nonprimitive
 
     // v1_daemon_set_spec->update_strategy
     cJSON *update_strategy = cJSON_GetObjectItemCaseSensitive(v1_daemon_set_specJSON, "updateStrategy");
-    v1_daemon_set_update_strategy_t *update_strategy_local_nonprim = NULL;
     if (update_strategy) { 
     update_strategy_local_nonprim = v1_daemon_set_update_strategy_parseFromJSON(update_strategy); //nonprimitive
     }

--- a/kubernetes/model/v1_daemon_set_update_strategy.c
+++ b/kubernetes/model/v1_daemon_set_update_strategy.c
@@ -71,9 +71,11 @@ v1_daemon_set_update_strategy_t *v1_daemon_set_update_strategy_parseFromJSON(cJS
 
     v1_daemon_set_update_strategy_t *v1_daemon_set_update_strategy_local_var = NULL;
 
+    // define the local variable for v1_daemon_set_update_strategy->rolling_update
+    v1_rolling_update_daemon_set_t *rolling_update_local_nonprim = NULL;
+
     // v1_daemon_set_update_strategy->rolling_update
     cJSON *rolling_update = cJSON_GetObjectItemCaseSensitive(v1_daemon_set_update_strategyJSON, "rollingUpdate");
-    v1_rolling_update_daemon_set_t *rolling_update_local_nonprim = NULL;
     if (rolling_update) { 
     rolling_update_local_nonprim = v1_rolling_update_daemon_set_parseFromJSON(rolling_update); //nonprimitive
     }

--- a/kubernetes/model/v1_delete_options.c
+++ b/kubernetes/model/v1_delete_options.c
@@ -145,6 +145,9 @@ v1_delete_options_t *v1_delete_options_parseFromJSON(cJSON *v1_delete_optionsJSO
 
     v1_delete_options_t *v1_delete_options_local_var = NULL;
 
+    // define the local variable for v1_delete_options->preconditions
+    v1_preconditions_t *preconditions_local_nonprim = NULL;
+
     // v1_delete_options->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_delete_optionsJSON, "apiVersion");
     if (api_version) { 
@@ -203,7 +206,6 @@ v1_delete_options_t *v1_delete_options_parseFromJSON(cJSON *v1_delete_optionsJSO
 
     // v1_delete_options->preconditions
     cJSON *preconditions = cJSON_GetObjectItemCaseSensitive(v1_delete_optionsJSON, "preconditions");
-    v1_preconditions_t *preconditions_local_nonprim = NULL;
     if (preconditions) { 
     preconditions_local_nonprim = v1_preconditions_parseFromJSON(preconditions); //nonprimitive
     }

--- a/kubernetes/model/v1_deployment.c
+++ b/kubernetes/model/v1_deployment.c
@@ -123,6 +123,15 @@ v1_deployment_t *v1_deployment_parseFromJSON(cJSON *v1_deploymentJSON){
 
     v1_deployment_t *v1_deployment_local_var = NULL;
 
+    // define the local variable for v1_deployment->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_deployment->spec
+    v1_deployment_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_deployment->status
+    v1_deployment_status_t *status_local_nonprim = NULL;
+
     // v1_deployment->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_deploymentJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_deployment_t *v1_deployment_parseFromJSON(cJSON *v1_deploymentJSON){
 
     // v1_deployment->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_deploymentJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_deployment->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_deploymentJSON, "spec");
-    v1_deployment_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_deployment_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_deployment->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_deploymentJSON, "status");
-    v1_deployment_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_deployment_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_deployment_list.c
+++ b/kubernetes/model/v1_deployment_list.c
@@ -116,6 +116,9 @@ v1_deployment_list_t *v1_deployment_list_parseFromJSON(cJSON *v1_deployment_list
 
     v1_deployment_list_t *v1_deployment_list_local_var = NULL;
 
+    // define the local variable for v1_deployment_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_deployment_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_deployment_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_deployment_list_t *v1_deployment_list_parseFromJSON(cJSON *v1_deployment_list
 
     // v1_deployment_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_deployment_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_deployment_spec.c
+++ b/kubernetes/model/v1_deployment_spec.c
@@ -149,6 +149,15 @@ v1_deployment_spec_t *v1_deployment_spec_parseFromJSON(cJSON *v1_deployment_spec
 
     v1_deployment_spec_t *v1_deployment_spec_local_var = NULL;
 
+    // define the local variable for v1_deployment_spec->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
+    // define the local variable for v1_deployment_spec->strategy
+    v1_deployment_strategy_t *strategy_local_nonprim = NULL;
+
+    // define the local variable for v1_deployment_spec->_template
+    v1_pod_template_spec_t *_template_local_nonprim = NULL;
+
     // v1_deployment_spec->min_ready_seconds
     cJSON *min_ready_seconds = cJSON_GetObjectItemCaseSensitive(v1_deployment_specJSON, "minReadySeconds");
     if (min_ready_seconds) { 
@@ -200,13 +209,11 @@ v1_deployment_spec_t *v1_deployment_spec_parseFromJSON(cJSON *v1_deployment_spec
         goto end;
     }
 
-    v1_label_selector_t *selector_local_nonprim = NULL;
     
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
 
     // v1_deployment_spec->strategy
     cJSON *strategy = cJSON_GetObjectItemCaseSensitive(v1_deployment_specJSON, "strategy");
-    v1_deployment_strategy_t *strategy_local_nonprim = NULL;
     if (strategy) { 
     strategy_local_nonprim = v1_deployment_strategy_parseFromJSON(strategy); //nonprimitive
     }
@@ -217,7 +224,6 @@ v1_deployment_spec_t *v1_deployment_spec_parseFromJSON(cJSON *v1_deployment_spec
         goto end;
     }
 
-    v1_pod_template_spec_t *_template_local_nonprim = NULL;
     
     _template_local_nonprim = v1_pod_template_spec_parseFromJSON(_template); //nonprimitive
 

--- a/kubernetes/model/v1_deployment_strategy.c
+++ b/kubernetes/model/v1_deployment_strategy.c
@@ -71,9 +71,11 @@ v1_deployment_strategy_t *v1_deployment_strategy_parseFromJSON(cJSON *v1_deploym
 
     v1_deployment_strategy_t *v1_deployment_strategy_local_var = NULL;
 
+    // define the local variable for v1_deployment_strategy->rolling_update
+    v1_rolling_update_deployment_t *rolling_update_local_nonprim = NULL;
+
     // v1_deployment_strategy->rolling_update
     cJSON *rolling_update = cJSON_GetObjectItemCaseSensitive(v1_deployment_strategyJSON, "rollingUpdate");
-    v1_rolling_update_deployment_t *rolling_update_local_nonprim = NULL;
     if (rolling_update) { 
     rolling_update_local_nonprim = v1_rolling_update_deployment_parseFromJSON(rolling_update); //nonprimitive
     }

--- a/kubernetes/model/v1_downward_api_volume_file.c
+++ b/kubernetes/model/v1_downward_api_volume_file.c
@@ -102,9 +102,14 @@ v1_downward_api_volume_file_t *v1_downward_api_volume_file_parseFromJSON(cJSON *
 
     v1_downward_api_volume_file_t *v1_downward_api_volume_file_local_var = NULL;
 
+    // define the local variable for v1_downward_api_volume_file->field_ref
+    v1_object_field_selector_t *field_ref_local_nonprim = NULL;
+
+    // define the local variable for v1_downward_api_volume_file->resource_field_ref
+    v1_resource_field_selector_t *resource_field_ref_local_nonprim = NULL;
+
     // v1_downward_api_volume_file->field_ref
     cJSON *field_ref = cJSON_GetObjectItemCaseSensitive(v1_downward_api_volume_fileJSON, "fieldRef");
-    v1_object_field_selector_t *field_ref_local_nonprim = NULL;
     if (field_ref) { 
     field_ref_local_nonprim = v1_object_field_selector_parseFromJSON(field_ref); //nonprimitive
     }
@@ -132,7 +137,6 @@ v1_downward_api_volume_file_t *v1_downward_api_volume_file_parseFromJSON(cJSON *
 
     // v1_downward_api_volume_file->resource_field_ref
     cJSON *resource_field_ref = cJSON_GetObjectItemCaseSensitive(v1_downward_api_volume_fileJSON, "resourceFieldRef");
-    v1_resource_field_selector_t *resource_field_ref_local_nonprim = NULL;
     if (resource_field_ref) { 
     resource_field_ref_local_nonprim = v1_resource_field_selector_parseFromJSON(resource_field_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_endpoint.c
+++ b/kubernetes/model/v1_endpoint.c
@@ -197,6 +197,15 @@ v1_endpoint_t *v1_endpoint_parseFromJSON(cJSON *v1_endpointJSON){
 
     v1_endpoint_t *v1_endpoint_local_var = NULL;
 
+    // define the local variable for v1_endpoint->conditions
+    v1_endpoint_conditions_t *conditions_local_nonprim = NULL;
+
+    // define the local variable for v1_endpoint->hints
+    v1_endpoint_hints_t *hints_local_nonprim = NULL;
+
+    // define the local variable for v1_endpoint->target_ref
+    v1_object_reference_t *target_ref_local_nonprim = NULL;
+
     // v1_endpoint->addresses
     cJSON *addresses = cJSON_GetObjectItemCaseSensitive(v1_endpointJSON, "addresses");
     if (!addresses) {
@@ -222,7 +231,6 @@ v1_endpoint_t *v1_endpoint_parseFromJSON(cJSON *v1_endpointJSON){
 
     // v1_endpoint->conditions
     cJSON *conditions = cJSON_GetObjectItemCaseSensitive(v1_endpointJSON, "conditions");
-    v1_endpoint_conditions_t *conditions_local_nonprim = NULL;
     if (conditions) { 
     conditions_local_nonprim = v1_endpoint_conditions_parseFromJSON(conditions); //nonprimitive
     }
@@ -251,7 +259,6 @@ v1_endpoint_t *v1_endpoint_parseFromJSON(cJSON *v1_endpointJSON){
 
     // v1_endpoint->hints
     cJSON *hints = cJSON_GetObjectItemCaseSensitive(v1_endpointJSON, "hints");
-    v1_endpoint_hints_t *hints_local_nonprim = NULL;
     if (hints) { 
     hints_local_nonprim = v1_endpoint_hints_parseFromJSON(hints); //nonprimitive
     }
@@ -276,7 +283,6 @@ v1_endpoint_t *v1_endpoint_parseFromJSON(cJSON *v1_endpointJSON){
 
     // v1_endpoint->target_ref
     cJSON *target_ref = cJSON_GetObjectItemCaseSensitive(v1_endpointJSON, "targetRef");
-    v1_object_reference_t *target_ref_local_nonprim = NULL;
     if (target_ref) { 
     target_ref_local_nonprim = v1_object_reference_parseFromJSON(target_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_endpoint_address.c
+++ b/kubernetes/model/v1_endpoint_address.c
@@ -101,6 +101,9 @@ v1_endpoint_address_t *v1_endpoint_address_parseFromJSON(cJSON *v1_endpoint_addr
 
     v1_endpoint_address_t *v1_endpoint_address_local_var = NULL;
 
+    // define the local variable for v1_endpoint_address->target_ref
+    v1_object_reference_t *target_ref_local_nonprim = NULL;
+
     // v1_endpoint_address->hostname
     cJSON *hostname = cJSON_GetObjectItemCaseSensitive(v1_endpoint_addressJSON, "hostname");
     if (hostname) { 
@@ -133,7 +136,6 @@ v1_endpoint_address_t *v1_endpoint_address_parseFromJSON(cJSON *v1_endpoint_addr
 
     // v1_endpoint_address->target_ref
     cJSON *target_ref = cJSON_GetObjectItemCaseSensitive(v1_endpoint_addressJSON, "targetRef");
-    v1_object_reference_t *target_ref_local_nonprim = NULL;
     if (target_ref) { 
     target_ref_local_nonprim = v1_object_reference_parseFromJSON(target_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_endpoint_slice.c
+++ b/kubernetes/model/v1_endpoint_slice.c
@@ -161,6 +161,9 @@ v1_endpoint_slice_t *v1_endpoint_slice_parseFromJSON(cJSON *v1_endpoint_sliceJSO
 
     v1_endpoint_slice_t *v1_endpoint_slice_local_var = NULL;
 
+    // define the local variable for v1_endpoint_slice->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_endpoint_slice->address_type
     cJSON *address_type = cJSON_GetObjectItemCaseSensitive(v1_endpoint_sliceJSON, "addressType");
     if (!address_type) {
@@ -218,7 +221,6 @@ v1_endpoint_slice_t *v1_endpoint_slice_parseFromJSON(cJSON *v1_endpoint_sliceJSO
 
     // v1_endpoint_slice->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_endpoint_sliceJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_endpoint_slice_list.c
+++ b/kubernetes/model/v1_endpoint_slice_list.c
@@ -116,6 +116,9 @@ v1_endpoint_slice_list_t *v1_endpoint_slice_list_parseFromJSON(cJSON *v1_endpoin
 
     v1_endpoint_slice_list_t *v1_endpoint_slice_list_local_var = NULL;
 
+    // define the local variable for v1_endpoint_slice_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_endpoint_slice_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_endpoint_slice_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_endpoint_slice_list_t *v1_endpoint_slice_list_parseFromJSON(cJSON *v1_endpoin
 
     // v1_endpoint_slice_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_endpoint_slice_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_endpoints.c
+++ b/kubernetes/model/v1_endpoints.c
@@ -114,6 +114,9 @@ v1_endpoints_t *v1_endpoints_parseFromJSON(cJSON *v1_endpointsJSON){
 
     v1_endpoints_t *v1_endpoints_local_var = NULL;
 
+    // define the local variable for v1_endpoints->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_endpoints->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_endpointsJSON, "apiVersion");
     if (api_version) { 
@@ -134,7 +137,6 @@ v1_endpoints_t *v1_endpoints_parseFromJSON(cJSON *v1_endpointsJSON){
 
     // v1_endpoints->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_endpointsJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_endpoints_list.c
+++ b/kubernetes/model/v1_endpoints_list.c
@@ -116,6 +116,9 @@ v1_endpoints_list_t *v1_endpoints_list_parseFromJSON(cJSON *v1_endpoints_listJSO
 
     v1_endpoints_list_t *v1_endpoints_list_local_var = NULL;
 
+    // define the local variable for v1_endpoints_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_endpoints_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_endpoints_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_endpoints_list_t *v1_endpoints_list_parseFromJSON(cJSON *v1_endpoints_listJSO
 
     // v1_endpoints_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_endpoints_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_env_from_source.c
+++ b/kubernetes/model/v1_env_from_source.c
@@ -90,9 +90,14 @@ v1_env_from_source_t *v1_env_from_source_parseFromJSON(cJSON *v1_env_from_source
 
     v1_env_from_source_t *v1_env_from_source_local_var = NULL;
 
+    // define the local variable for v1_env_from_source->config_map_ref
+    v1_config_map_env_source_t *config_map_ref_local_nonprim = NULL;
+
+    // define the local variable for v1_env_from_source->secret_ref
+    v1_secret_env_source_t *secret_ref_local_nonprim = NULL;
+
     // v1_env_from_source->config_map_ref
     cJSON *config_map_ref = cJSON_GetObjectItemCaseSensitive(v1_env_from_sourceJSON, "configMapRef");
-    v1_config_map_env_source_t *config_map_ref_local_nonprim = NULL;
     if (config_map_ref) { 
     config_map_ref_local_nonprim = v1_config_map_env_source_parseFromJSON(config_map_ref); //nonprimitive
     }
@@ -108,7 +113,6 @@ v1_env_from_source_t *v1_env_from_source_parseFromJSON(cJSON *v1_env_from_source
 
     // v1_env_from_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_env_from_sourceJSON, "secretRef");
-    v1_secret_env_source_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_secret_env_source_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_env_var.c
+++ b/kubernetes/model/v1_env_var.c
@@ -87,6 +87,9 @@ v1_env_var_t *v1_env_var_parseFromJSON(cJSON *v1_env_varJSON){
 
     v1_env_var_t *v1_env_var_local_var = NULL;
 
+    // define the local variable for v1_env_var->value_from
+    v1_env_var_source_t *value_from_local_nonprim = NULL;
+
     // v1_env_var->name
     cJSON *name = cJSON_GetObjectItemCaseSensitive(v1_env_varJSON, "name");
     if (!name) {
@@ -110,7 +113,6 @@ v1_env_var_t *v1_env_var_parseFromJSON(cJSON *v1_env_varJSON){
 
     // v1_env_var->value_from
     cJSON *value_from = cJSON_GetObjectItemCaseSensitive(v1_env_varJSON, "valueFrom");
-    v1_env_var_source_t *value_from_local_nonprim = NULL;
     if (value_from) { 
     value_from_local_nonprim = v1_env_var_source_parseFromJSON(value_from); //nonprimitive
     }

--- a/kubernetes/model/v1_env_var_source.c
+++ b/kubernetes/model/v1_env_var_source.c
@@ -114,30 +114,38 @@ v1_env_var_source_t *v1_env_var_source_parseFromJSON(cJSON *v1_env_var_sourceJSO
 
     v1_env_var_source_t *v1_env_var_source_local_var = NULL;
 
+    // define the local variable for v1_env_var_source->config_map_key_ref
+    v1_config_map_key_selector_t *config_map_key_ref_local_nonprim = NULL;
+
+    // define the local variable for v1_env_var_source->field_ref
+    v1_object_field_selector_t *field_ref_local_nonprim = NULL;
+
+    // define the local variable for v1_env_var_source->resource_field_ref
+    v1_resource_field_selector_t *resource_field_ref_local_nonprim = NULL;
+
+    // define the local variable for v1_env_var_source->secret_key_ref
+    v1_secret_key_selector_t *secret_key_ref_local_nonprim = NULL;
+
     // v1_env_var_source->config_map_key_ref
     cJSON *config_map_key_ref = cJSON_GetObjectItemCaseSensitive(v1_env_var_sourceJSON, "configMapKeyRef");
-    v1_config_map_key_selector_t *config_map_key_ref_local_nonprim = NULL;
     if (config_map_key_ref) { 
     config_map_key_ref_local_nonprim = v1_config_map_key_selector_parseFromJSON(config_map_key_ref); //nonprimitive
     }
 
     // v1_env_var_source->field_ref
     cJSON *field_ref = cJSON_GetObjectItemCaseSensitive(v1_env_var_sourceJSON, "fieldRef");
-    v1_object_field_selector_t *field_ref_local_nonprim = NULL;
     if (field_ref) { 
     field_ref_local_nonprim = v1_object_field_selector_parseFromJSON(field_ref); //nonprimitive
     }
 
     // v1_env_var_source->resource_field_ref
     cJSON *resource_field_ref = cJSON_GetObjectItemCaseSensitive(v1_env_var_sourceJSON, "resourceFieldRef");
-    v1_resource_field_selector_t *resource_field_ref_local_nonprim = NULL;
     if (resource_field_ref) { 
     resource_field_ref_local_nonprim = v1_resource_field_selector_parseFromJSON(resource_field_ref); //nonprimitive
     }
 
     // v1_env_var_source->secret_key_ref
     cJSON *secret_key_ref = cJSON_GetObjectItemCaseSensitive(v1_env_var_sourceJSON, "secretKeyRef");
-    v1_secret_key_selector_t *secret_key_ref_local_nonprim = NULL;
     if (secret_key_ref) { 
     secret_key_ref_local_nonprim = v1_secret_key_selector_parseFromJSON(secret_key_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_ephemeral_container.c
+++ b/kubernetes/model/v1_ephemeral_container.c
@@ -479,6 +479,24 @@ v1_ephemeral_container_t *v1_ephemeral_container_parseFromJSON(cJSON *v1_ephemer
 
     v1_ephemeral_container_t *v1_ephemeral_container_local_var = NULL;
 
+    // define the local variable for v1_ephemeral_container->lifecycle
+    v1_lifecycle_t *lifecycle_local_nonprim = NULL;
+
+    // define the local variable for v1_ephemeral_container->liveness_probe
+    v1_probe_t *liveness_probe_local_nonprim = NULL;
+
+    // define the local variable for v1_ephemeral_container->readiness_probe
+    v1_probe_t *readiness_probe_local_nonprim = NULL;
+
+    // define the local variable for v1_ephemeral_container->resources
+    v1_resource_requirements_t *resources_local_nonprim = NULL;
+
+    // define the local variable for v1_ephemeral_container->security_context
+    v1_security_context_t *security_context_local_nonprim = NULL;
+
+    // define the local variable for v1_ephemeral_container->startup_probe
+    v1_probe_t *startup_probe_local_nonprim = NULL;
+
     // v1_ephemeral_container->args
     cJSON *args = cJSON_GetObjectItemCaseSensitive(v1_ephemeral_containerJSON, "args");
     list_t *argsList;
@@ -583,14 +601,12 @@ v1_ephemeral_container_t *v1_ephemeral_container_parseFromJSON(cJSON *v1_ephemer
 
     // v1_ephemeral_container->lifecycle
     cJSON *lifecycle = cJSON_GetObjectItemCaseSensitive(v1_ephemeral_containerJSON, "lifecycle");
-    v1_lifecycle_t *lifecycle_local_nonprim = NULL;
     if (lifecycle) { 
     lifecycle_local_nonprim = v1_lifecycle_parseFromJSON(lifecycle); //nonprimitive
     }
 
     // v1_ephemeral_container->liveness_probe
     cJSON *liveness_probe = cJSON_GetObjectItemCaseSensitive(v1_ephemeral_containerJSON, "livenessProbe");
-    v1_probe_t *liveness_probe_local_nonprim = NULL;
     if (liveness_probe) { 
     liveness_probe_local_nonprim = v1_probe_parseFromJSON(liveness_probe); //nonprimitive
     }
@@ -631,28 +647,24 @@ v1_ephemeral_container_t *v1_ephemeral_container_parseFromJSON(cJSON *v1_ephemer
 
     // v1_ephemeral_container->readiness_probe
     cJSON *readiness_probe = cJSON_GetObjectItemCaseSensitive(v1_ephemeral_containerJSON, "readinessProbe");
-    v1_probe_t *readiness_probe_local_nonprim = NULL;
     if (readiness_probe) { 
     readiness_probe_local_nonprim = v1_probe_parseFromJSON(readiness_probe); //nonprimitive
     }
 
     // v1_ephemeral_container->resources
     cJSON *resources = cJSON_GetObjectItemCaseSensitive(v1_ephemeral_containerJSON, "resources");
-    v1_resource_requirements_t *resources_local_nonprim = NULL;
     if (resources) { 
     resources_local_nonprim = v1_resource_requirements_parseFromJSON(resources); //nonprimitive
     }
 
     // v1_ephemeral_container->security_context
     cJSON *security_context = cJSON_GetObjectItemCaseSensitive(v1_ephemeral_containerJSON, "securityContext");
-    v1_security_context_t *security_context_local_nonprim = NULL;
     if (security_context) { 
     security_context_local_nonprim = v1_security_context_parseFromJSON(security_context); //nonprimitive
     }
 
     // v1_ephemeral_container->startup_probe
     cJSON *startup_probe = cJSON_GetObjectItemCaseSensitive(v1_ephemeral_containerJSON, "startupProbe");
-    v1_probe_t *startup_probe_local_nonprim = NULL;
     if (startup_probe) { 
     startup_probe_local_nonprim = v1_probe_parseFromJSON(startup_probe); //nonprimitive
     }

--- a/kubernetes/model/v1_ephemeral_volume_source.c
+++ b/kubernetes/model/v1_ephemeral_volume_source.c
@@ -57,9 +57,11 @@ v1_ephemeral_volume_source_t *v1_ephemeral_volume_source_parseFromJSON(cJSON *v1
 
     v1_ephemeral_volume_source_t *v1_ephemeral_volume_source_local_var = NULL;
 
+    // define the local variable for v1_ephemeral_volume_source->volume_claim_template
+    v1_persistent_volume_claim_template_t *volume_claim_template_local_nonprim = NULL;
+
     // v1_ephemeral_volume_source->volume_claim_template
     cJSON *volume_claim_template = cJSON_GetObjectItemCaseSensitive(v1_ephemeral_volume_sourceJSON, "volumeClaimTemplate");
-    v1_persistent_volume_claim_template_t *volume_claim_template_local_nonprim = NULL;
     if (volume_claim_template) { 
     volume_claim_template_local_nonprim = v1_persistent_volume_claim_template_parseFromJSON(volume_claim_template); //nonprimitive
     }

--- a/kubernetes/model/v1_eviction.c
+++ b/kubernetes/model/v1_eviction.c
@@ -104,6 +104,12 @@ v1_eviction_t *v1_eviction_parseFromJSON(cJSON *v1_evictionJSON){
 
     v1_eviction_t *v1_eviction_local_var = NULL;
 
+    // define the local variable for v1_eviction->delete_options
+    v1_delete_options_t *delete_options_local_nonprim = NULL;
+
+    // define the local variable for v1_eviction->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_eviction->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_evictionJSON, "apiVersion");
     if (api_version) { 
@@ -115,7 +121,6 @@ v1_eviction_t *v1_eviction_parseFromJSON(cJSON *v1_evictionJSON){
 
     // v1_eviction->delete_options
     cJSON *delete_options = cJSON_GetObjectItemCaseSensitive(v1_evictionJSON, "deleteOptions");
-    v1_delete_options_t *delete_options_local_nonprim = NULL;
     if (delete_options) { 
     delete_options_local_nonprim = v1_delete_options_parseFromJSON(delete_options); //nonprimitive
     }
@@ -131,7 +136,6 @@ v1_eviction_t *v1_eviction_parseFromJSON(cJSON *v1_evictionJSON){
 
     // v1_eviction->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_evictionJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_flex_persistent_volume_source.c
+++ b/kubernetes/model/v1_flex_persistent_volume_source.c
@@ -129,6 +129,9 @@ v1_flex_persistent_volume_source_t *v1_flex_persistent_volume_source_parseFromJS
 
     v1_flex_persistent_volume_source_t *v1_flex_persistent_volume_source_local_var = NULL;
 
+    // define the local variable for v1_flex_persistent_volume_source->secret_ref
+    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_flex_persistent_volume_source->driver
     cJSON *driver = cJSON_GetObjectItemCaseSensitive(v1_flex_persistent_volume_sourceJSON, "driver");
     if (!driver) {
@@ -183,7 +186,6 @@ v1_flex_persistent_volume_source_t *v1_flex_persistent_volume_source_parseFromJS
 
     // v1_flex_persistent_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_flex_persistent_volume_sourceJSON, "secretRef");
-    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_secret_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_flex_volume_source.c
+++ b/kubernetes/model/v1_flex_volume_source.c
@@ -129,6 +129,9 @@ v1_flex_volume_source_t *v1_flex_volume_source_parseFromJSON(cJSON *v1_flex_volu
 
     v1_flex_volume_source_t *v1_flex_volume_source_local_var = NULL;
 
+    // define the local variable for v1_flex_volume_source->secret_ref
+    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_flex_volume_source->driver
     cJSON *driver = cJSON_GetObjectItemCaseSensitive(v1_flex_volume_sourceJSON, "driver");
     if (!driver) {
@@ -183,7 +186,6 @@ v1_flex_volume_source_t *v1_flex_volume_source_parseFromJSON(cJSON *v1_flex_volu
 
     // v1_flex_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_flex_volume_sourceJSON, "secretRef");
-    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_local_object_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_handler.c
+++ b/kubernetes/model/v1_handler.c
@@ -95,23 +95,29 @@ v1_handler_t *v1_handler_parseFromJSON(cJSON *v1_handlerJSON){
 
     v1_handler_t *v1_handler_local_var = NULL;
 
+    // define the local variable for v1_handler->exec
+    v1_exec_action_t *exec_local_nonprim = NULL;
+
+    // define the local variable for v1_handler->http_get
+    v1_http_get_action_t *http_get_local_nonprim = NULL;
+
+    // define the local variable for v1_handler->tcp_socket
+    v1_tcp_socket_action_t *tcp_socket_local_nonprim = NULL;
+
     // v1_handler->exec
     cJSON *exec = cJSON_GetObjectItemCaseSensitive(v1_handlerJSON, "exec");
-    v1_exec_action_t *exec_local_nonprim = NULL;
     if (exec) { 
     exec_local_nonprim = v1_exec_action_parseFromJSON(exec); //nonprimitive
     }
 
     // v1_handler->http_get
     cJSON *http_get = cJSON_GetObjectItemCaseSensitive(v1_handlerJSON, "httpGet");
-    v1_http_get_action_t *http_get_local_nonprim = NULL;
     if (http_get) { 
     http_get_local_nonprim = v1_http_get_action_parseFromJSON(http_get); //nonprimitive
     }
 
     // v1_handler->tcp_socket
     cJSON *tcp_socket = cJSON_GetObjectItemCaseSensitive(v1_handlerJSON, "tcpSocket");
-    v1_tcp_socket_action_t *tcp_socket_local_nonprim = NULL;
     if (tcp_socket) { 
     tcp_socket_local_nonprim = v1_tcp_socket_action_parseFromJSON(tcp_socket); //nonprimitive
     }

--- a/kubernetes/model/v1_horizontal_pod_autoscaler.c
+++ b/kubernetes/model/v1_horizontal_pod_autoscaler.c
@@ -123,6 +123,15 @@ v1_horizontal_pod_autoscaler_t *v1_horizontal_pod_autoscaler_parseFromJSON(cJSON
 
     v1_horizontal_pod_autoscaler_t *v1_horizontal_pod_autoscaler_local_var = NULL;
 
+    // define the local variable for v1_horizontal_pod_autoscaler->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_horizontal_pod_autoscaler->spec
+    v1_horizontal_pod_autoscaler_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_horizontal_pod_autoscaler->status
+    v1_horizontal_pod_autoscaler_status_t *status_local_nonprim = NULL;
+
     // v1_horizontal_pod_autoscaler->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_horizontal_pod_autoscalerJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_horizontal_pod_autoscaler_t *v1_horizontal_pod_autoscaler_parseFromJSON(cJSON
 
     // v1_horizontal_pod_autoscaler->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_horizontal_pod_autoscalerJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_horizontal_pod_autoscaler->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_horizontal_pod_autoscalerJSON, "spec");
-    v1_horizontal_pod_autoscaler_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_horizontal_pod_autoscaler_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_horizontal_pod_autoscaler->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_horizontal_pod_autoscalerJSON, "status");
-    v1_horizontal_pod_autoscaler_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_horizontal_pod_autoscaler_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_horizontal_pod_autoscaler_list.c
+++ b/kubernetes/model/v1_horizontal_pod_autoscaler_list.c
@@ -116,6 +116,9 @@ v1_horizontal_pod_autoscaler_list_t *v1_horizontal_pod_autoscaler_list_parseFrom
 
     v1_horizontal_pod_autoscaler_list_t *v1_horizontal_pod_autoscaler_list_local_var = NULL;
 
+    // define the local variable for v1_horizontal_pod_autoscaler_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_horizontal_pod_autoscaler_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_horizontal_pod_autoscaler_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_horizontal_pod_autoscaler_list_t *v1_horizontal_pod_autoscaler_list_parseFrom
 
     // v1_horizontal_pod_autoscaler_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_horizontal_pod_autoscaler_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_horizontal_pod_autoscaler_spec.c
+++ b/kubernetes/model/v1_horizontal_pod_autoscaler_spec.c
@@ -91,6 +91,9 @@ v1_horizontal_pod_autoscaler_spec_t *v1_horizontal_pod_autoscaler_spec_parseFrom
 
     v1_horizontal_pod_autoscaler_spec_t *v1_horizontal_pod_autoscaler_spec_local_var = NULL;
 
+    // define the local variable for v1_horizontal_pod_autoscaler_spec->scale_target_ref
+    v1_cross_version_object_reference_t *scale_target_ref_local_nonprim = NULL;
+
     // v1_horizontal_pod_autoscaler_spec->max_replicas
     cJSON *max_replicas = cJSON_GetObjectItemCaseSensitive(v1_horizontal_pod_autoscaler_specJSON, "maxReplicas");
     if (!max_replicas) {
@@ -118,7 +121,6 @@ v1_horizontal_pod_autoscaler_spec_t *v1_horizontal_pod_autoscaler_spec_parseFrom
         goto end;
     }
 
-    v1_cross_version_object_reference_t *scale_target_ref_local_nonprim = NULL;
     
     scale_target_ref_local_nonprim = v1_cross_version_object_reference_parseFromJSON(scale_target_ref); //nonprimitive
 

--- a/kubernetes/model/v1_http_ingress_path.c
+++ b/kubernetes/model/v1_http_ingress_path.c
@@ -89,13 +89,15 @@ v1_http_ingress_path_t *v1_http_ingress_path_parseFromJSON(cJSON *v1_http_ingres
 
     v1_http_ingress_path_t *v1_http_ingress_path_local_var = NULL;
 
+    // define the local variable for v1_http_ingress_path->backend
+    v1_ingress_backend_t *backend_local_nonprim = NULL;
+
     // v1_http_ingress_path->backend
     cJSON *backend = cJSON_GetObjectItemCaseSensitive(v1_http_ingress_pathJSON, "backend");
     if (!backend) {
         goto end;
     }
 
-    v1_ingress_backend_t *backend_local_nonprim = NULL;
     
     backend_local_nonprim = v1_ingress_backend_parseFromJSON(backend); //nonprimitive
 

--- a/kubernetes/model/v1_ingress.c
+++ b/kubernetes/model/v1_ingress.c
@@ -123,6 +123,15 @@ v1_ingress_t *v1_ingress_parseFromJSON(cJSON *v1_ingressJSON){
 
     v1_ingress_t *v1_ingress_local_var = NULL;
 
+    // define the local variable for v1_ingress->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_ingress->spec
+    v1_ingress_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_ingress->status
+    v1_ingress_status_t *status_local_nonprim = NULL;
+
     // v1_ingress->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_ingressJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_ingress_t *v1_ingress_parseFromJSON(cJSON *v1_ingressJSON){
 
     // v1_ingress->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_ingressJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_ingress->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_ingressJSON, "spec");
-    v1_ingress_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_ingress_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_ingress->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_ingressJSON, "status");
-    v1_ingress_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_ingress_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_ingress_backend.c
+++ b/kubernetes/model/v1_ingress_backend.c
@@ -76,16 +76,20 @@ v1_ingress_backend_t *v1_ingress_backend_parseFromJSON(cJSON *v1_ingress_backend
 
     v1_ingress_backend_t *v1_ingress_backend_local_var = NULL;
 
+    // define the local variable for v1_ingress_backend->resource
+    v1_typed_local_object_reference_t *resource_local_nonprim = NULL;
+
+    // define the local variable for v1_ingress_backend->service
+    v1_ingress_service_backend_t *service_local_nonprim = NULL;
+
     // v1_ingress_backend->resource
     cJSON *resource = cJSON_GetObjectItemCaseSensitive(v1_ingress_backendJSON, "resource");
-    v1_typed_local_object_reference_t *resource_local_nonprim = NULL;
     if (resource) { 
     resource_local_nonprim = v1_typed_local_object_reference_parseFromJSON(resource); //nonprimitive
     }
 
     // v1_ingress_backend->service
     cJSON *service = cJSON_GetObjectItemCaseSensitive(v1_ingress_backendJSON, "service");
-    v1_ingress_service_backend_t *service_local_nonprim = NULL;
     if (service) { 
     service_local_nonprim = v1_ingress_service_backend_parseFromJSON(service); //nonprimitive
     }

--- a/kubernetes/model/v1_ingress_class.c
+++ b/kubernetes/model/v1_ingress_class.c
@@ -104,6 +104,12 @@ v1_ingress_class_t *v1_ingress_class_parseFromJSON(cJSON *v1_ingress_classJSON){
 
     v1_ingress_class_t *v1_ingress_class_local_var = NULL;
 
+    // define the local variable for v1_ingress_class->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_ingress_class->spec
+    v1_ingress_class_spec_t *spec_local_nonprim = NULL;
+
     // v1_ingress_class->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_ingress_classJSON, "apiVersion");
     if (api_version) { 
@@ -124,14 +130,12 @@ v1_ingress_class_t *v1_ingress_class_parseFromJSON(cJSON *v1_ingress_classJSON){
 
     // v1_ingress_class->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_ingress_classJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_ingress_class->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_ingress_classJSON, "spec");
-    v1_ingress_class_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_ingress_class_spec_parseFromJSON(spec); //nonprimitive
     }

--- a/kubernetes/model/v1_ingress_class_list.c
+++ b/kubernetes/model/v1_ingress_class_list.c
@@ -116,6 +116,9 @@ v1_ingress_class_list_t *v1_ingress_class_list_parseFromJSON(cJSON *v1_ingress_c
 
     v1_ingress_class_list_t *v1_ingress_class_list_local_var = NULL;
 
+    // define the local variable for v1_ingress_class_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_ingress_class_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_ingress_class_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_ingress_class_list_t *v1_ingress_class_list_parseFromJSON(cJSON *v1_ingress_c
 
     // v1_ingress_class_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_ingress_class_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_ingress_class_spec.c
+++ b/kubernetes/model/v1_ingress_class_spec.c
@@ -71,6 +71,9 @@ v1_ingress_class_spec_t *v1_ingress_class_spec_parseFromJSON(cJSON *v1_ingress_c
 
     v1_ingress_class_spec_t *v1_ingress_class_spec_local_var = NULL;
 
+    // define the local variable for v1_ingress_class_spec->parameters
+    v1_ingress_class_parameters_reference_t *parameters_local_nonprim = NULL;
+
     // v1_ingress_class_spec->controller
     cJSON *controller = cJSON_GetObjectItemCaseSensitive(v1_ingress_class_specJSON, "controller");
     if (controller) { 
@@ -82,7 +85,6 @@ v1_ingress_class_spec_t *v1_ingress_class_spec_parseFromJSON(cJSON *v1_ingress_c
 
     // v1_ingress_class_spec->parameters
     cJSON *parameters = cJSON_GetObjectItemCaseSensitive(v1_ingress_class_specJSON, "parameters");
-    v1_ingress_class_parameters_reference_t *parameters_local_nonprim = NULL;
     if (parameters) { 
     parameters_local_nonprim = v1_ingress_class_parameters_reference_parseFromJSON(parameters); //nonprimitive
     }

--- a/kubernetes/model/v1_ingress_list.c
+++ b/kubernetes/model/v1_ingress_list.c
@@ -116,6 +116,9 @@ v1_ingress_list_t *v1_ingress_list_parseFromJSON(cJSON *v1_ingress_listJSON){
 
     v1_ingress_list_t *v1_ingress_list_local_var = NULL;
 
+    // define the local variable for v1_ingress_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_ingress_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_ingress_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_ingress_list_t *v1_ingress_list_parseFromJSON(cJSON *v1_ingress_listJSON){
 
     // v1_ingress_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_ingress_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_ingress_rule.c
+++ b/kubernetes/model/v1_ingress_rule.c
@@ -71,6 +71,9 @@ v1_ingress_rule_t *v1_ingress_rule_parseFromJSON(cJSON *v1_ingress_ruleJSON){
 
     v1_ingress_rule_t *v1_ingress_rule_local_var = NULL;
 
+    // define the local variable for v1_ingress_rule->http
+    v1_http_ingress_rule_value_t *http_local_nonprim = NULL;
+
     // v1_ingress_rule->host
     cJSON *host = cJSON_GetObjectItemCaseSensitive(v1_ingress_ruleJSON, "host");
     if (host) { 
@@ -82,7 +85,6 @@ v1_ingress_rule_t *v1_ingress_rule_parseFromJSON(cJSON *v1_ingress_ruleJSON){
 
     // v1_ingress_rule->http
     cJSON *http = cJSON_GetObjectItemCaseSensitive(v1_ingress_ruleJSON, "http");
-    v1_http_ingress_rule_value_t *http_local_nonprim = NULL;
     if (http) { 
     http_local_nonprim = v1_http_ingress_rule_value_parseFromJSON(http); //nonprimitive
     }

--- a/kubernetes/model/v1_ingress_service_backend.c
+++ b/kubernetes/model/v1_ingress_service_backend.c
@@ -73,6 +73,9 @@ v1_ingress_service_backend_t *v1_ingress_service_backend_parseFromJSON(cJSON *v1
 
     v1_ingress_service_backend_t *v1_ingress_service_backend_local_var = NULL;
 
+    // define the local variable for v1_ingress_service_backend->port
+    v1_service_backend_port_t *port_local_nonprim = NULL;
+
     // v1_ingress_service_backend->name
     cJSON *name = cJSON_GetObjectItemCaseSensitive(v1_ingress_service_backendJSON, "name");
     if (!name) {
@@ -87,7 +90,6 @@ v1_ingress_service_backend_t *v1_ingress_service_backend_parseFromJSON(cJSON *v1
 
     // v1_ingress_service_backend->port
     cJSON *port = cJSON_GetObjectItemCaseSensitive(v1_ingress_service_backendJSON, "port");
-    v1_service_backend_port_t *port_local_nonprim = NULL;
     if (port) { 
     port_local_nonprim = v1_service_backend_port_parseFromJSON(port); //nonprimitive
     }

--- a/kubernetes/model/v1_ingress_spec.c
+++ b/kubernetes/model/v1_ingress_spec.c
@@ -129,9 +129,11 @@ v1_ingress_spec_t *v1_ingress_spec_parseFromJSON(cJSON *v1_ingress_specJSON){
 
     v1_ingress_spec_t *v1_ingress_spec_local_var = NULL;
 
+    // define the local variable for v1_ingress_spec->default_backend
+    v1_ingress_backend_t *default_backend_local_nonprim = NULL;
+
     // v1_ingress_spec->default_backend
     cJSON *default_backend = cJSON_GetObjectItemCaseSensitive(v1_ingress_specJSON, "defaultBackend");
-    v1_ingress_backend_t *default_backend_local_nonprim = NULL;
     if (default_backend) { 
     default_backend_local_nonprim = v1_ingress_backend_parseFromJSON(default_backend); //nonprimitive
     }

--- a/kubernetes/model/v1_ingress_status.c
+++ b/kubernetes/model/v1_ingress_status.c
@@ -57,9 +57,11 @@ v1_ingress_status_t *v1_ingress_status_parseFromJSON(cJSON *v1_ingress_statusJSO
 
     v1_ingress_status_t *v1_ingress_status_local_var = NULL;
 
+    // define the local variable for v1_ingress_status->load_balancer
+    v1_load_balancer_status_t *load_balancer_local_nonprim = NULL;
+
     // v1_ingress_status->load_balancer
     cJSON *load_balancer = cJSON_GetObjectItemCaseSensitive(v1_ingress_statusJSON, "loadBalancer");
-    v1_load_balancer_status_t *load_balancer_local_nonprim = NULL;
     if (load_balancer) { 
     load_balancer_local_nonprim = v1_load_balancer_status_parseFromJSON(load_balancer); //nonprimitive
     }

--- a/kubernetes/model/v1_iscsi_persistent_volume_source.c
+++ b/kubernetes/model/v1_iscsi_persistent_volume_source.c
@@ -199,6 +199,9 @@ v1_iscsi_persistent_volume_source_t *v1_iscsi_persistent_volume_source_parseFrom
 
     v1_iscsi_persistent_volume_source_t *v1_iscsi_persistent_volume_source_local_var = NULL;
 
+    // define the local variable for v1_iscsi_persistent_volume_source->secret_ref
+    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_iscsi_persistent_volume_source->chap_auth_discovery
     cJSON *chap_auth_discovery = cJSON_GetObjectItemCaseSensitive(v1_iscsi_persistent_volume_sourceJSON, "chapAuthDiscovery");
     if (chap_auth_discovery) { 
@@ -299,7 +302,6 @@ v1_iscsi_persistent_volume_source_t *v1_iscsi_persistent_volume_source_parseFrom
 
     // v1_iscsi_persistent_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_iscsi_persistent_volume_sourceJSON, "secretRef");
-    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_secret_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_iscsi_volume_source.c
+++ b/kubernetes/model/v1_iscsi_volume_source.c
@@ -199,6 +199,9 @@ v1_iscsi_volume_source_t *v1_iscsi_volume_source_parseFromJSON(cJSON *v1_iscsi_v
 
     v1_iscsi_volume_source_t *v1_iscsi_volume_source_local_var = NULL;
 
+    // define the local variable for v1_iscsi_volume_source->secret_ref
+    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_iscsi_volume_source->chap_auth_discovery
     cJSON *chap_auth_discovery = cJSON_GetObjectItemCaseSensitive(v1_iscsi_volume_sourceJSON, "chapAuthDiscovery");
     if (chap_auth_discovery) { 
@@ -299,7 +302,6 @@ v1_iscsi_volume_source_t *v1_iscsi_volume_source_parseFromJSON(cJSON *v1_iscsi_v
 
     // v1_iscsi_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_iscsi_volume_sourceJSON, "secretRef");
-    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_local_object_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_job.c
+++ b/kubernetes/model/v1_job.c
@@ -123,6 +123,15 @@ v1_job_t *v1_job_parseFromJSON(cJSON *v1_jobJSON){
 
     v1_job_t *v1_job_local_var = NULL;
 
+    // define the local variable for v1_job->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_job->spec
+    v1_job_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_job->status
+    v1_job_status_t *status_local_nonprim = NULL;
+
     // v1_job->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_jobJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_job_t *v1_job_parseFromJSON(cJSON *v1_jobJSON){
 
     // v1_job->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_jobJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_job->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_jobJSON, "spec");
-    v1_job_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_job_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_job->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_jobJSON, "status");
-    v1_job_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_job_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_job_list.c
+++ b/kubernetes/model/v1_job_list.c
@@ -116,6 +116,9 @@ v1_job_list_t *v1_job_list_parseFromJSON(cJSON *v1_job_listJSON){
 
     v1_job_list_t *v1_job_list_local_var = NULL;
 
+    // define the local variable for v1_job_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_job_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_job_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_job_list_t *v1_job_list_parseFromJSON(cJSON *v1_job_listJSON){
 
     // v1_job_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_job_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_job_spec.c
+++ b/kubernetes/model/v1_job_spec.c
@@ -162,6 +162,12 @@ v1_job_spec_t *v1_job_spec_parseFromJSON(cJSON *v1_job_specJSON){
 
     v1_job_spec_t *v1_job_spec_local_var = NULL;
 
+    // define the local variable for v1_job_spec->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
+    // define the local variable for v1_job_spec->_template
+    v1_pod_template_spec_t *_template_local_nonprim = NULL;
+
     // v1_job_spec->active_deadline_seconds
     cJSON *active_deadline_seconds = cJSON_GetObjectItemCaseSensitive(v1_job_specJSON, "activeDeadlineSeconds");
     if (active_deadline_seconds) { 
@@ -218,7 +224,6 @@ v1_job_spec_t *v1_job_spec_parseFromJSON(cJSON *v1_job_specJSON){
 
     // v1_job_spec->selector
     cJSON *selector = cJSON_GetObjectItemCaseSensitive(v1_job_specJSON, "selector");
-    v1_label_selector_t *selector_local_nonprim = NULL;
     if (selector) { 
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
     }
@@ -238,7 +243,6 @@ v1_job_spec_t *v1_job_spec_parseFromJSON(cJSON *v1_job_specJSON){
         goto end;
     }
 
-    v1_pod_template_spec_t *_template_local_nonprim = NULL;
     
     _template_local_nonprim = v1_pod_template_spec_parseFromJSON(_template); //nonprimitive
 

--- a/kubernetes/model/v1_job_status.c
+++ b/kubernetes/model/v1_job_status.c
@@ -158,6 +158,9 @@ v1_job_status_t *v1_job_status_parseFromJSON(cJSON *v1_job_statusJSON){
 
     v1_job_status_t *v1_job_status_local_var = NULL;
 
+    // define the local variable for v1_job_status->uncounted_terminated_pods
+    v1_uncounted_terminated_pods_t *uncounted_terminated_pods_local_nonprim = NULL;
+
     // v1_job_status->active
     cJSON *active = cJSON_GetObjectItemCaseSensitive(v1_job_statusJSON, "active");
     if (active) { 
@@ -236,7 +239,6 @@ v1_job_status_t *v1_job_status_parseFromJSON(cJSON *v1_job_statusJSON){
 
     // v1_job_status->uncounted_terminated_pods
     cJSON *uncounted_terminated_pods = cJSON_GetObjectItemCaseSensitive(v1_job_statusJSON, "uncountedTerminatedPods");
-    v1_uncounted_terminated_pods_t *uncounted_terminated_pods_local_nonprim = NULL;
     if (uncounted_terminated_pods) { 
     uncounted_terminated_pods_local_nonprim = v1_uncounted_terminated_pods_parseFromJSON(uncounted_terminated_pods); //nonprimitive
     }

--- a/kubernetes/model/v1_job_template_spec.c
+++ b/kubernetes/model/v1_job_template_spec.c
@@ -76,16 +76,20 @@ v1_job_template_spec_t *v1_job_template_spec_parseFromJSON(cJSON *v1_job_templat
 
     v1_job_template_spec_t *v1_job_template_spec_local_var = NULL;
 
+    // define the local variable for v1_job_template_spec->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_job_template_spec->spec
+    v1_job_spec_t *spec_local_nonprim = NULL;
+
     // v1_job_template_spec->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_job_template_specJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_job_template_spec->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_job_template_specJSON, "spec");
-    v1_job_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_job_spec_parseFromJSON(spec); //nonprimitive
     }

--- a/kubernetes/model/v1_json_schema_props.c
+++ b/kubernetes/model/v1_json_schema_props.c
@@ -751,6 +751,12 @@ v1_json_schema_props_t *v1_json_schema_props_parseFromJSON(cJSON *v1_json_schema
 
     v1_json_schema_props_t *v1_json_schema_props_local_var = NULL;
 
+    // define the local variable for v1_json_schema_props->external_docs
+    v1_external_documentation_t *external_docs_local_nonprim = NULL;
+
+    // define the local variable for v1_json_schema_props->_not
+    v1_json_schema_props_t *_not_local_nonprim = NULL;
+
     // v1_json_schema_props->ref
     cJSON *ref = cJSON_GetObjectItemCaseSensitive(v1_json_schema_propsJSON, "$ref");
     if (ref) { 
@@ -926,7 +932,6 @@ v1_json_schema_props_t *v1_json_schema_props_parseFromJSON(cJSON *v1_json_schema
 
     // v1_json_schema_props->external_docs
     cJSON *external_docs = cJSON_GetObjectItemCaseSensitive(v1_json_schema_propsJSON, "externalDocs");
-    v1_external_documentation_t *external_docs_local_nonprim = NULL;
     if (external_docs) { 
     external_docs_local_nonprim = v1_external_documentation_parseFromJSON(external_docs); //nonprimitive
     }
@@ -1039,7 +1044,6 @@ v1_json_schema_props_t *v1_json_schema_props_parseFromJSON(cJSON *v1_json_schema
 
     // v1_json_schema_props->_not
     cJSON *_not = cJSON_GetObjectItemCaseSensitive(v1_json_schema_propsJSON, "not");
-    v1_json_schema_props_t *_not_local_nonprim = NULL;
     if (_not) { 
     _not_local_nonprim = v1_json_schema_props_parseFromJSON(_not); //nonprimitive
     }

--- a/kubernetes/model/v1_lease.c
+++ b/kubernetes/model/v1_lease.c
@@ -104,6 +104,12 @@ v1_lease_t *v1_lease_parseFromJSON(cJSON *v1_leaseJSON){
 
     v1_lease_t *v1_lease_local_var = NULL;
 
+    // define the local variable for v1_lease->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_lease->spec
+    v1_lease_spec_t *spec_local_nonprim = NULL;
+
     // v1_lease->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_leaseJSON, "apiVersion");
     if (api_version) { 
@@ -124,14 +130,12 @@ v1_lease_t *v1_lease_parseFromJSON(cJSON *v1_leaseJSON){
 
     // v1_lease->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_leaseJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_lease->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_leaseJSON, "spec");
-    v1_lease_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_lease_spec_parseFromJSON(spec); //nonprimitive
     }

--- a/kubernetes/model/v1_lease_list.c
+++ b/kubernetes/model/v1_lease_list.c
@@ -116,6 +116,9 @@ v1_lease_list_t *v1_lease_list_parseFromJSON(cJSON *v1_lease_listJSON){
 
     v1_lease_list_t *v1_lease_list_local_var = NULL;
 
+    // define the local variable for v1_lease_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_lease_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_lease_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_lease_list_t *v1_lease_list_parseFromJSON(cJSON *v1_lease_listJSON){
 
     // v1_lease_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_lease_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_lifecycle.c
+++ b/kubernetes/model/v1_lifecycle.c
@@ -76,16 +76,20 @@ v1_lifecycle_t *v1_lifecycle_parseFromJSON(cJSON *v1_lifecycleJSON){
 
     v1_lifecycle_t *v1_lifecycle_local_var = NULL;
 
+    // define the local variable for v1_lifecycle->post_start
+    v1_handler_t *post_start_local_nonprim = NULL;
+
+    // define the local variable for v1_lifecycle->pre_stop
+    v1_handler_t *pre_stop_local_nonprim = NULL;
+
     // v1_lifecycle->post_start
     cJSON *post_start = cJSON_GetObjectItemCaseSensitive(v1_lifecycleJSON, "postStart");
-    v1_handler_t *post_start_local_nonprim = NULL;
     if (post_start) { 
     post_start_local_nonprim = v1_handler_parseFromJSON(post_start); //nonprimitive
     }
 
     // v1_lifecycle->pre_stop
     cJSON *pre_stop = cJSON_GetObjectItemCaseSensitive(v1_lifecycleJSON, "preStop");
-    v1_handler_t *pre_stop_local_nonprim = NULL;
     if (pre_stop) { 
     pre_stop_local_nonprim = v1_handler_parseFromJSON(pre_stop); //nonprimitive
     }

--- a/kubernetes/model/v1_limit_range.c
+++ b/kubernetes/model/v1_limit_range.c
@@ -104,6 +104,12 @@ v1_limit_range_t *v1_limit_range_parseFromJSON(cJSON *v1_limit_rangeJSON){
 
     v1_limit_range_t *v1_limit_range_local_var = NULL;
 
+    // define the local variable for v1_limit_range->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_limit_range->spec
+    v1_limit_range_spec_t *spec_local_nonprim = NULL;
+
     // v1_limit_range->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_limit_rangeJSON, "apiVersion");
     if (api_version) { 
@@ -124,14 +130,12 @@ v1_limit_range_t *v1_limit_range_parseFromJSON(cJSON *v1_limit_rangeJSON){
 
     // v1_limit_range->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_limit_rangeJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_limit_range->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_limit_rangeJSON, "spec");
-    v1_limit_range_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_limit_range_spec_parseFromJSON(spec); //nonprimitive
     }

--- a/kubernetes/model/v1_limit_range_list.c
+++ b/kubernetes/model/v1_limit_range_list.c
@@ -116,6 +116,9 @@ v1_limit_range_list_t *v1_limit_range_list_parseFromJSON(cJSON *v1_limit_range_l
 
     v1_limit_range_list_t *v1_limit_range_list_local_var = NULL;
 
+    // define the local variable for v1_limit_range_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_limit_range_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_limit_range_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_limit_range_list_t *v1_limit_range_list_parseFromJSON(cJSON *v1_limit_range_l
 
     // v1_limit_range_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_limit_range_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_local_subject_access_review.c
+++ b/kubernetes/model/v1_local_subject_access_review.c
@@ -125,6 +125,15 @@ v1_local_subject_access_review_t *v1_local_subject_access_review_parseFromJSON(c
 
     v1_local_subject_access_review_t *v1_local_subject_access_review_local_var = NULL;
 
+    // define the local variable for v1_local_subject_access_review->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_local_subject_access_review->spec
+    v1_subject_access_review_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_local_subject_access_review->status
+    v1_subject_access_review_status_t *status_local_nonprim = NULL;
+
     // v1_local_subject_access_review->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_local_subject_access_reviewJSON, "apiVersion");
     if (api_version) { 
@@ -145,7 +154,6 @@ v1_local_subject_access_review_t *v1_local_subject_access_review_parseFromJSON(c
 
     // v1_local_subject_access_review->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_local_subject_access_reviewJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -156,13 +164,11 @@ v1_local_subject_access_review_t *v1_local_subject_access_review_parseFromJSON(c
         goto end;
     }
 
-    v1_subject_access_review_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_subject_access_review_spec_parseFromJSON(spec); //nonprimitive
 
     // v1_local_subject_access_review->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_local_subject_access_reviewJSON, "status");
-    v1_subject_access_review_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_subject_access_review_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_mutating_webhook.c
+++ b/kubernetes/model/v1_mutating_webhook.c
@@ -238,6 +238,15 @@ v1_mutating_webhook_t *v1_mutating_webhook_parseFromJSON(cJSON *v1_mutating_webh
 
     v1_mutating_webhook_t *v1_mutating_webhook_local_var = NULL;
 
+    // define the local variable for v1_mutating_webhook->client_config
+    admissionregistration_v1_webhook_client_config_t *client_config_local_nonprim = NULL;
+
+    // define the local variable for v1_mutating_webhook->namespace_selector
+    v1_label_selector_t *namespace_selector_local_nonprim = NULL;
+
+    // define the local variable for v1_mutating_webhook->object_selector
+    v1_label_selector_t *object_selector_local_nonprim = NULL;
+
     // v1_mutating_webhook->admission_review_versions
     cJSON *admission_review_versions = cJSON_GetObjectItemCaseSensitive(v1_mutating_webhookJSON, "admissionReviewVersions");
     if (!admission_review_versions) {
@@ -267,7 +276,6 @@ v1_mutating_webhook_t *v1_mutating_webhook_parseFromJSON(cJSON *v1_mutating_webh
         goto end;
     }
 
-    admissionregistration_v1_webhook_client_config_t *client_config_local_nonprim = NULL;
     
     client_config_local_nonprim = admissionregistration_v1_webhook_client_config_parseFromJSON(client_config); //nonprimitive
 
@@ -303,14 +311,12 @@ v1_mutating_webhook_t *v1_mutating_webhook_parseFromJSON(cJSON *v1_mutating_webh
 
     // v1_mutating_webhook->namespace_selector
     cJSON *namespace_selector = cJSON_GetObjectItemCaseSensitive(v1_mutating_webhookJSON, "namespaceSelector");
-    v1_label_selector_t *namespace_selector_local_nonprim = NULL;
     if (namespace_selector) { 
     namespace_selector_local_nonprim = v1_label_selector_parseFromJSON(namespace_selector); //nonprimitive
     }
 
     // v1_mutating_webhook->object_selector
     cJSON *object_selector = cJSON_GetObjectItemCaseSensitive(v1_mutating_webhookJSON, "objectSelector");
-    v1_label_selector_t *object_selector_local_nonprim = NULL;
     if (object_selector) { 
     object_selector_local_nonprim = v1_label_selector_parseFromJSON(object_selector); //nonprimitive
     }

--- a/kubernetes/model/v1_mutating_webhook_configuration.c
+++ b/kubernetes/model/v1_mutating_webhook_configuration.c
@@ -114,6 +114,9 @@ v1_mutating_webhook_configuration_t *v1_mutating_webhook_configuration_parseFrom
 
     v1_mutating_webhook_configuration_t *v1_mutating_webhook_configuration_local_var = NULL;
 
+    // define the local variable for v1_mutating_webhook_configuration->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_mutating_webhook_configuration->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_mutating_webhook_configurationJSON, "apiVersion");
     if (api_version) { 
@@ -134,7 +137,6 @@ v1_mutating_webhook_configuration_t *v1_mutating_webhook_configuration_parseFrom
 
     // v1_mutating_webhook_configuration->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_mutating_webhook_configurationJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_mutating_webhook_configuration_list.c
+++ b/kubernetes/model/v1_mutating_webhook_configuration_list.c
@@ -116,6 +116,9 @@ v1_mutating_webhook_configuration_list_t *v1_mutating_webhook_configuration_list
 
     v1_mutating_webhook_configuration_list_t *v1_mutating_webhook_configuration_list_local_var = NULL;
 
+    // define the local variable for v1_mutating_webhook_configuration_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_mutating_webhook_configuration_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_mutating_webhook_configuration_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_mutating_webhook_configuration_list_t *v1_mutating_webhook_configuration_list
 
     // v1_mutating_webhook_configuration_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_mutating_webhook_configuration_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_namespace.c
+++ b/kubernetes/model/v1_namespace.c
@@ -123,6 +123,15 @@ v1_namespace_t *v1_namespace_parseFromJSON(cJSON *v1_namespaceJSON){
 
     v1_namespace_t *v1_namespace_local_var = NULL;
 
+    // define the local variable for v1_namespace->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_namespace->spec
+    v1_namespace_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_namespace->status
+    v1_namespace_status_t *status_local_nonprim = NULL;
+
     // v1_namespace->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_namespaceJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_namespace_t *v1_namespace_parseFromJSON(cJSON *v1_namespaceJSON){
 
     // v1_namespace->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_namespaceJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_namespace->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_namespaceJSON, "spec");
-    v1_namespace_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_namespace_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_namespace->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_namespaceJSON, "status");
-    v1_namespace_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_namespace_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_namespace_list.c
+++ b/kubernetes/model/v1_namespace_list.c
@@ -116,6 +116,9 @@ v1_namespace_list_t *v1_namespace_list_parseFromJSON(cJSON *v1_namespace_listJSO
 
     v1_namespace_list_t *v1_namespace_list_local_var = NULL;
 
+    // define the local variable for v1_namespace_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_namespace_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_namespace_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_namespace_list_t *v1_namespace_list_parseFromJSON(cJSON *v1_namespace_listJSO
 
     // v1_namespace_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_namespace_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_network_policy.c
+++ b/kubernetes/model/v1_network_policy.c
@@ -104,6 +104,12 @@ v1_network_policy_t *v1_network_policy_parseFromJSON(cJSON *v1_network_policyJSO
 
     v1_network_policy_t *v1_network_policy_local_var = NULL;
 
+    // define the local variable for v1_network_policy->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_network_policy->spec
+    v1_network_policy_spec_t *spec_local_nonprim = NULL;
+
     // v1_network_policy->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_network_policyJSON, "apiVersion");
     if (api_version) { 
@@ -124,14 +130,12 @@ v1_network_policy_t *v1_network_policy_parseFromJSON(cJSON *v1_network_policyJSO
 
     // v1_network_policy->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_network_policyJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_network_policy->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_network_policyJSON, "spec");
-    v1_network_policy_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_network_policy_spec_parseFromJSON(spec); //nonprimitive
     }

--- a/kubernetes/model/v1_network_policy_list.c
+++ b/kubernetes/model/v1_network_policy_list.c
@@ -116,6 +116,9 @@ v1_network_policy_list_t *v1_network_policy_list_parseFromJSON(cJSON *v1_network
 
     v1_network_policy_list_t *v1_network_policy_list_local_var = NULL;
 
+    // define the local variable for v1_network_policy_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_network_policy_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_network_policy_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_network_policy_list_t *v1_network_policy_list_parseFromJSON(cJSON *v1_network
 
     // v1_network_policy_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_network_policy_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_network_policy_peer.c
+++ b/kubernetes/model/v1_network_policy_peer.c
@@ -95,23 +95,29 @@ v1_network_policy_peer_t *v1_network_policy_peer_parseFromJSON(cJSON *v1_network
 
     v1_network_policy_peer_t *v1_network_policy_peer_local_var = NULL;
 
+    // define the local variable for v1_network_policy_peer->ip_block
+    v1_ip_block_t *ip_block_local_nonprim = NULL;
+
+    // define the local variable for v1_network_policy_peer->namespace_selector
+    v1_label_selector_t *namespace_selector_local_nonprim = NULL;
+
+    // define the local variable for v1_network_policy_peer->pod_selector
+    v1_label_selector_t *pod_selector_local_nonprim = NULL;
+
     // v1_network_policy_peer->ip_block
     cJSON *ip_block = cJSON_GetObjectItemCaseSensitive(v1_network_policy_peerJSON, "ipBlock");
-    v1_ip_block_t *ip_block_local_nonprim = NULL;
     if (ip_block) { 
     ip_block_local_nonprim = v1_ip_block_parseFromJSON(ip_block); //nonprimitive
     }
 
     // v1_network_policy_peer->namespace_selector
     cJSON *namespace_selector = cJSON_GetObjectItemCaseSensitive(v1_network_policy_peerJSON, "namespaceSelector");
-    v1_label_selector_t *namespace_selector_local_nonprim = NULL;
     if (namespace_selector) { 
     namespace_selector_local_nonprim = v1_label_selector_parseFromJSON(namespace_selector); //nonprimitive
     }
 
     // v1_network_policy_peer->pod_selector
     cJSON *pod_selector = cJSON_GetObjectItemCaseSensitive(v1_network_policy_peerJSON, "podSelector");
-    v1_label_selector_t *pod_selector_local_nonprim = NULL;
     if (pod_selector) { 
     pod_selector_local_nonprim = v1_label_selector_parseFromJSON(pod_selector); //nonprimitive
     }

--- a/kubernetes/model/v1_network_policy_spec.c
+++ b/kubernetes/model/v1_network_policy_spec.c
@@ -143,6 +143,9 @@ v1_network_policy_spec_t *v1_network_policy_spec_parseFromJSON(cJSON *v1_network
 
     v1_network_policy_spec_t *v1_network_policy_spec_local_var = NULL;
 
+    // define the local variable for v1_network_policy_spec->pod_selector
+    v1_label_selector_t *pod_selector_local_nonprim = NULL;
+
     // v1_network_policy_spec->egress
     cJSON *egress = cJSON_GetObjectItemCaseSensitive(v1_network_policy_specJSON, "egress");
     list_t *egressList;
@@ -193,7 +196,6 @@ v1_network_policy_spec_t *v1_network_policy_spec_parseFromJSON(cJSON *v1_network
         goto end;
     }
 
-    v1_label_selector_t *pod_selector_local_nonprim = NULL;
     
     pod_selector_local_nonprim = v1_label_selector_parseFromJSON(pod_selector); //nonprimitive
 

--- a/kubernetes/model/v1_node.c
+++ b/kubernetes/model/v1_node.c
@@ -123,6 +123,15 @@ v1_node_t *v1_node_parseFromJSON(cJSON *v1_nodeJSON){
 
     v1_node_t *v1_node_local_var = NULL;
 
+    // define the local variable for v1_node->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_node->spec
+    v1_node_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_node->status
+    v1_node_status_t *status_local_nonprim = NULL;
+
     // v1_node->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_nodeJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_node_t *v1_node_parseFromJSON(cJSON *v1_nodeJSON){
 
     // v1_node->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_nodeJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_node->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_nodeJSON, "spec");
-    v1_node_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_node_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_node->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_nodeJSON, "status");
-    v1_node_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_node_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_node_affinity.c
+++ b/kubernetes/model/v1_node_affinity.c
@@ -86,6 +86,9 @@ v1_node_affinity_t *v1_node_affinity_parseFromJSON(cJSON *v1_node_affinityJSON){
 
     v1_node_affinity_t *v1_node_affinity_local_var = NULL;
 
+    // define the local variable for v1_node_affinity->required_during_scheduling_ignored_during_execution
+    v1_node_selector_t *required_during_scheduling_ignored_during_execution_local_nonprim = NULL;
+
     // v1_node_affinity->preferred_during_scheduling_ignored_during_execution
     cJSON *preferred_during_scheduling_ignored_during_execution = cJSON_GetObjectItemCaseSensitive(v1_node_affinityJSON, "preferredDuringSchedulingIgnoredDuringExecution");
     list_t *preferred_during_scheduling_ignored_during_executionList;
@@ -110,7 +113,6 @@ v1_node_affinity_t *v1_node_affinity_parseFromJSON(cJSON *v1_node_affinityJSON){
 
     // v1_node_affinity->required_during_scheduling_ignored_during_execution
     cJSON *required_during_scheduling_ignored_during_execution = cJSON_GetObjectItemCaseSensitive(v1_node_affinityJSON, "requiredDuringSchedulingIgnoredDuringExecution");
-    v1_node_selector_t *required_during_scheduling_ignored_during_execution_local_nonprim = NULL;
     if (required_during_scheduling_ignored_during_execution) { 
     required_during_scheduling_ignored_during_execution_local_nonprim = v1_node_selector_parseFromJSON(required_during_scheduling_ignored_during_execution); //nonprimitive
     }

--- a/kubernetes/model/v1_node_config_source.c
+++ b/kubernetes/model/v1_node_config_source.c
@@ -57,9 +57,11 @@ v1_node_config_source_t *v1_node_config_source_parseFromJSON(cJSON *v1_node_conf
 
     v1_node_config_source_t *v1_node_config_source_local_var = NULL;
 
+    // define the local variable for v1_node_config_source->config_map
+    v1_config_map_node_config_source_t *config_map_local_nonprim = NULL;
+
     // v1_node_config_source->config_map
     cJSON *config_map = cJSON_GetObjectItemCaseSensitive(v1_node_config_sourceJSON, "configMap");
-    v1_config_map_node_config_source_t *config_map_local_nonprim = NULL;
     if (config_map) { 
     config_map_local_nonprim = v1_config_map_node_config_source_parseFromJSON(config_map); //nonprimitive
     }

--- a/kubernetes/model/v1_node_config_status.c
+++ b/kubernetes/model/v1_node_config_status.c
@@ -109,16 +109,23 @@ v1_node_config_status_t *v1_node_config_status_parseFromJSON(cJSON *v1_node_conf
 
     v1_node_config_status_t *v1_node_config_status_local_var = NULL;
 
+    // define the local variable for v1_node_config_status->active
+    v1_node_config_source_t *active_local_nonprim = NULL;
+
+    // define the local variable for v1_node_config_status->assigned
+    v1_node_config_source_t *assigned_local_nonprim = NULL;
+
+    // define the local variable for v1_node_config_status->last_known_good
+    v1_node_config_source_t *last_known_good_local_nonprim = NULL;
+
     // v1_node_config_status->active
     cJSON *active = cJSON_GetObjectItemCaseSensitive(v1_node_config_statusJSON, "active");
-    v1_node_config_source_t *active_local_nonprim = NULL;
     if (active) { 
     active_local_nonprim = v1_node_config_source_parseFromJSON(active); //nonprimitive
     }
 
     // v1_node_config_status->assigned
     cJSON *assigned = cJSON_GetObjectItemCaseSensitive(v1_node_config_statusJSON, "assigned");
-    v1_node_config_source_t *assigned_local_nonprim = NULL;
     if (assigned) { 
     assigned_local_nonprim = v1_node_config_source_parseFromJSON(assigned); //nonprimitive
     }
@@ -134,7 +141,6 @@ v1_node_config_status_t *v1_node_config_status_parseFromJSON(cJSON *v1_node_conf
 
     // v1_node_config_status->last_known_good
     cJSON *last_known_good = cJSON_GetObjectItemCaseSensitive(v1_node_config_statusJSON, "lastKnownGood");
-    v1_node_config_source_t *last_known_good_local_nonprim = NULL;
     if (last_known_good) { 
     last_known_good_local_nonprim = v1_node_config_source_parseFromJSON(last_known_good); //nonprimitive
     }

--- a/kubernetes/model/v1_node_daemon_endpoints.c
+++ b/kubernetes/model/v1_node_daemon_endpoints.c
@@ -57,9 +57,11 @@ v1_node_daemon_endpoints_t *v1_node_daemon_endpoints_parseFromJSON(cJSON *v1_nod
 
     v1_node_daemon_endpoints_t *v1_node_daemon_endpoints_local_var = NULL;
 
+    // define the local variable for v1_node_daemon_endpoints->kubelet_endpoint
+    v1_daemon_endpoint_t *kubelet_endpoint_local_nonprim = NULL;
+
     // v1_node_daemon_endpoints->kubelet_endpoint
     cJSON *kubelet_endpoint = cJSON_GetObjectItemCaseSensitive(v1_node_daemon_endpointsJSON, "kubeletEndpoint");
-    v1_daemon_endpoint_t *kubelet_endpoint_local_nonprim = NULL;
     if (kubelet_endpoint) { 
     kubelet_endpoint_local_nonprim = v1_daemon_endpoint_parseFromJSON(kubelet_endpoint); //nonprimitive
     }

--- a/kubernetes/model/v1_node_list.c
+++ b/kubernetes/model/v1_node_list.c
@@ -116,6 +116,9 @@ v1_node_list_t *v1_node_list_parseFromJSON(cJSON *v1_node_listJSON){
 
     v1_node_list_t *v1_node_list_local_var = NULL;
 
+    // define the local variable for v1_node_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_node_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_node_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_node_list_t *v1_node_list_parseFromJSON(cJSON *v1_node_listJSON){
 
     // v1_node_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_node_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_node_spec.c
+++ b/kubernetes/model/v1_node_spec.c
@@ -164,9 +164,11 @@ v1_node_spec_t *v1_node_spec_parseFromJSON(cJSON *v1_node_specJSON){
 
     v1_node_spec_t *v1_node_spec_local_var = NULL;
 
+    // define the local variable for v1_node_spec->config_source
+    v1_node_config_source_t *config_source_local_nonprim = NULL;
+
     // v1_node_spec->config_source
     cJSON *config_source = cJSON_GetObjectItemCaseSensitive(v1_node_specJSON, "configSource");
-    v1_node_config_source_t *config_source_local_nonprim = NULL;
     if (config_source) { 
     config_source_local_nonprim = v1_node_config_source_parseFromJSON(config_source); //nonprimitive
     }

--- a/kubernetes/model/v1_node_status.c
+++ b/kubernetes/model/v1_node_status.c
@@ -315,6 +315,15 @@ v1_node_status_t *v1_node_status_parseFromJSON(cJSON *v1_node_statusJSON){
 
     v1_node_status_t *v1_node_status_local_var = NULL;
 
+    // define the local variable for v1_node_status->config
+    v1_node_config_status_t *config_local_nonprim = NULL;
+
+    // define the local variable for v1_node_status->daemon_endpoints
+    v1_node_daemon_endpoints_t *daemon_endpoints_local_nonprim = NULL;
+
+    // define the local variable for v1_node_status->node_info
+    v1_node_system_info_t *node_info_local_nonprim = NULL;
+
     // v1_node_status->addresses
     cJSON *addresses = cJSON_GetObjectItemCaseSensitive(v1_node_statusJSON, "addresses");
     list_t *addressesList;
@@ -405,14 +414,12 @@ v1_node_status_t *v1_node_status_parseFromJSON(cJSON *v1_node_statusJSON){
 
     // v1_node_status->config
     cJSON *config = cJSON_GetObjectItemCaseSensitive(v1_node_statusJSON, "config");
-    v1_node_config_status_t *config_local_nonprim = NULL;
     if (config) { 
     config_local_nonprim = v1_node_config_status_parseFromJSON(config); //nonprimitive
     }
 
     // v1_node_status->daemon_endpoints
     cJSON *daemon_endpoints = cJSON_GetObjectItemCaseSensitive(v1_node_statusJSON, "daemonEndpoints");
-    v1_node_daemon_endpoints_t *daemon_endpoints_local_nonprim = NULL;
     if (daemon_endpoints) { 
     daemon_endpoints_local_nonprim = v1_node_daemon_endpoints_parseFromJSON(daemon_endpoints); //nonprimitive
     }
@@ -441,7 +448,6 @@ v1_node_status_t *v1_node_status_parseFromJSON(cJSON *v1_node_statusJSON){
 
     // v1_node_status->node_info
     cJSON *node_info = cJSON_GetObjectItemCaseSensitive(v1_node_statusJSON, "nodeInfo");
-    v1_node_system_info_t *node_info_local_nonprim = NULL;
     if (node_info) { 
     node_info_local_nonprim = v1_node_system_info_parseFromJSON(node_info); //nonprimitive
     }

--- a/kubernetes/model/v1_persistent_volume.c
+++ b/kubernetes/model/v1_persistent_volume.c
@@ -123,6 +123,15 @@ v1_persistent_volume_t *v1_persistent_volume_parseFromJSON(cJSON *v1_persistent_
 
     v1_persistent_volume_t *v1_persistent_volume_local_var = NULL;
 
+    // define the local variable for v1_persistent_volume->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume->spec
+    v1_persistent_volume_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume->status
+    v1_persistent_volume_status_t *status_local_nonprim = NULL;
+
     // v1_persistent_volume->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_persistent_volumeJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_persistent_volume_t *v1_persistent_volume_parseFromJSON(cJSON *v1_persistent_
 
     // v1_persistent_volume->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_persistent_volumeJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_persistent_volume->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_persistent_volumeJSON, "spec");
-    v1_persistent_volume_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_persistent_volume_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_persistent_volume->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_persistent_volumeJSON, "status");
-    v1_persistent_volume_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_persistent_volume_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_persistent_volume_claim.c
+++ b/kubernetes/model/v1_persistent_volume_claim.c
@@ -123,6 +123,15 @@ v1_persistent_volume_claim_t *v1_persistent_volume_claim_parseFromJSON(cJSON *v1
 
     v1_persistent_volume_claim_t *v1_persistent_volume_claim_local_var = NULL;
 
+    // define the local variable for v1_persistent_volume_claim->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_claim->spec
+    v1_persistent_volume_claim_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_claim->status
+    v1_persistent_volume_claim_status_t *status_local_nonprim = NULL;
+
     // v1_persistent_volume_claim->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claimJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_persistent_volume_claim_t *v1_persistent_volume_claim_parseFromJSON(cJSON *v1
 
     // v1_persistent_volume_claim->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claimJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_persistent_volume_claim->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claimJSON, "spec");
-    v1_persistent_volume_claim_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_persistent_volume_claim_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_persistent_volume_claim->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claimJSON, "status");
-    v1_persistent_volume_claim_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_persistent_volume_claim_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_persistent_volume_claim_list.c
+++ b/kubernetes/model/v1_persistent_volume_claim_list.c
@@ -116,6 +116,9 @@ v1_persistent_volume_claim_list_t *v1_persistent_volume_claim_list_parseFromJSON
 
     v1_persistent_volume_claim_list_t *v1_persistent_volume_claim_list_local_var = NULL;
 
+    // define the local variable for v1_persistent_volume_claim_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_persistent_volume_claim_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claim_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_persistent_volume_claim_list_t *v1_persistent_volume_claim_list_parseFromJSON
 
     // v1_persistent_volume_claim_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claim_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_persistent_volume_claim_spec.c
+++ b/kubernetes/model/v1_persistent_volume_claim_spec.c
@@ -182,6 +182,18 @@ v1_persistent_volume_claim_spec_t *v1_persistent_volume_claim_spec_parseFromJSON
 
     v1_persistent_volume_claim_spec_t *v1_persistent_volume_claim_spec_local_var = NULL;
 
+    // define the local variable for v1_persistent_volume_claim_spec->data_source
+    v1_typed_local_object_reference_t *data_source_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_claim_spec->data_source_ref
+    v1_typed_local_object_reference_t *data_source_ref_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_claim_spec->resources
+    v1_resource_requirements_t *resources_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_claim_spec->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
     // v1_persistent_volume_claim_spec->access_modes
     cJSON *access_modes = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claim_specJSON, "accessModes");
     list_t *access_modesList;
@@ -204,28 +216,24 @@ v1_persistent_volume_claim_spec_t *v1_persistent_volume_claim_spec_parseFromJSON
 
     // v1_persistent_volume_claim_spec->data_source
     cJSON *data_source = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claim_specJSON, "dataSource");
-    v1_typed_local_object_reference_t *data_source_local_nonprim = NULL;
     if (data_source) { 
     data_source_local_nonprim = v1_typed_local_object_reference_parseFromJSON(data_source); //nonprimitive
     }
 
     // v1_persistent_volume_claim_spec->data_source_ref
     cJSON *data_source_ref = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claim_specJSON, "dataSourceRef");
-    v1_typed_local_object_reference_t *data_source_ref_local_nonprim = NULL;
     if (data_source_ref) { 
     data_source_ref_local_nonprim = v1_typed_local_object_reference_parseFromJSON(data_source_ref); //nonprimitive
     }
 
     // v1_persistent_volume_claim_spec->resources
     cJSON *resources = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claim_specJSON, "resources");
-    v1_resource_requirements_t *resources_local_nonprim = NULL;
     if (resources) { 
     resources_local_nonprim = v1_resource_requirements_parseFromJSON(resources); //nonprimitive
     }
 
     // v1_persistent_volume_claim_spec->selector
     cJSON *selector = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claim_specJSON, "selector");
-    v1_label_selector_t *selector_local_nonprim = NULL;
     if (selector) { 
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
     }

--- a/kubernetes/model/v1_persistent_volume_claim_template.c
+++ b/kubernetes/model/v1_persistent_volume_claim_template.c
@@ -78,9 +78,14 @@ v1_persistent_volume_claim_template_t *v1_persistent_volume_claim_template_parse
 
     v1_persistent_volume_claim_template_t *v1_persistent_volume_claim_template_local_var = NULL;
 
+    // define the local variable for v1_persistent_volume_claim_template->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_claim_template->spec
+    v1_persistent_volume_claim_spec_t *spec_local_nonprim = NULL;
+
     // v1_persistent_volume_claim_template->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_claim_templateJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -91,7 +96,6 @@ v1_persistent_volume_claim_template_t *v1_persistent_volume_claim_template_parse
         goto end;
     }
 
-    v1_persistent_volume_claim_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_persistent_volume_claim_spec_parseFromJSON(spec); //nonprimitive
 

--- a/kubernetes/model/v1_persistent_volume_list.c
+++ b/kubernetes/model/v1_persistent_volume_list.c
@@ -116,6 +116,9 @@ v1_persistent_volume_list_t *v1_persistent_volume_list_parseFromJSON(cJSON *v1_p
 
     v1_persistent_volume_list_t *v1_persistent_volume_list_local_var = NULL;
 
+    // define the local variable for v1_persistent_volume_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_persistent_volume_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_persistent_volume_list_t *v1_persistent_volume_list_parseFromJSON(cJSON *v1_p
 
     // v1_persistent_volume_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_persistent_volume_spec.c
+++ b/kubernetes/model/v1_persistent_volume_spec.c
@@ -620,6 +620,78 @@ v1_persistent_volume_spec_t *v1_persistent_volume_spec_parseFromJSON(cJSON *v1_p
 
     v1_persistent_volume_spec_t *v1_persistent_volume_spec_local_var = NULL;
 
+    // define the local variable for v1_persistent_volume_spec->aws_elastic_block_store
+    v1_aws_elastic_block_store_volume_source_t *aws_elastic_block_store_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->azure_disk
+    v1_azure_disk_volume_source_t *azure_disk_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->azure_file
+    v1_azure_file_persistent_volume_source_t *azure_file_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->cephfs
+    v1_ceph_fs_persistent_volume_source_t *cephfs_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->cinder
+    v1_cinder_persistent_volume_source_t *cinder_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->claim_ref
+    v1_object_reference_t *claim_ref_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->csi
+    v1_csi_persistent_volume_source_t *csi_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->fc
+    v1_fc_volume_source_t *fc_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->flex_volume
+    v1_flex_persistent_volume_source_t *flex_volume_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->flocker
+    v1_flocker_volume_source_t *flocker_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->gce_persistent_disk
+    v1_gce_persistent_disk_volume_source_t *gce_persistent_disk_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->glusterfs
+    v1_glusterfs_persistent_volume_source_t *glusterfs_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->host_path
+    v1_host_path_volume_source_t *host_path_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->iscsi
+    v1_iscsi_persistent_volume_source_t *iscsi_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->local
+    v1_local_volume_source_t *local_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->nfs
+    v1_nfs_volume_source_t *nfs_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->node_affinity
+    v1_volume_node_affinity_t *node_affinity_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->photon_persistent_disk
+    v1_photon_persistent_disk_volume_source_t *photon_persistent_disk_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->portworx_volume
+    v1_portworx_volume_source_t *portworx_volume_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->quobyte
+    v1_quobyte_volume_source_t *quobyte_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->rbd
+    v1_rbd_persistent_volume_source_t *rbd_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->scale_io
+    v1_scale_io_persistent_volume_source_t *scale_io_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->storageos
+    v1_storage_os_persistent_volume_source_t *storageos_local_nonprim = NULL;
+
+    // define the local variable for v1_persistent_volume_spec->vsphere_volume
+    v1_vsphere_virtual_disk_volume_source_t *vsphere_volume_local_nonprim = NULL;
+
     // v1_persistent_volume_spec->access_modes
     cJSON *access_modes = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "accessModes");
     list_t *access_modesList;
@@ -642,21 +714,18 @@ v1_persistent_volume_spec_t *v1_persistent_volume_spec_parseFromJSON(cJSON *v1_p
 
     // v1_persistent_volume_spec->aws_elastic_block_store
     cJSON *aws_elastic_block_store = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "awsElasticBlockStore");
-    v1_aws_elastic_block_store_volume_source_t *aws_elastic_block_store_local_nonprim = NULL;
     if (aws_elastic_block_store) { 
     aws_elastic_block_store_local_nonprim = v1_aws_elastic_block_store_volume_source_parseFromJSON(aws_elastic_block_store); //nonprimitive
     }
 
     // v1_persistent_volume_spec->azure_disk
     cJSON *azure_disk = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "azureDisk");
-    v1_azure_disk_volume_source_t *azure_disk_local_nonprim = NULL;
     if (azure_disk) { 
     azure_disk_local_nonprim = v1_azure_disk_volume_source_parseFromJSON(azure_disk); //nonprimitive
     }
 
     // v1_persistent_volume_spec->azure_file
     cJSON *azure_file = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "azureFile");
-    v1_azure_file_persistent_volume_source_t *azure_file_local_nonprim = NULL;
     if (azure_file) { 
     azure_file_local_nonprim = v1_azure_file_persistent_volume_source_parseFromJSON(azure_file); //nonprimitive
     }
@@ -685,84 +754,72 @@ v1_persistent_volume_spec_t *v1_persistent_volume_spec_parseFromJSON(cJSON *v1_p
 
     // v1_persistent_volume_spec->cephfs
     cJSON *cephfs = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "cephfs");
-    v1_ceph_fs_persistent_volume_source_t *cephfs_local_nonprim = NULL;
     if (cephfs) { 
     cephfs_local_nonprim = v1_ceph_fs_persistent_volume_source_parseFromJSON(cephfs); //nonprimitive
     }
 
     // v1_persistent_volume_spec->cinder
     cJSON *cinder = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "cinder");
-    v1_cinder_persistent_volume_source_t *cinder_local_nonprim = NULL;
     if (cinder) { 
     cinder_local_nonprim = v1_cinder_persistent_volume_source_parseFromJSON(cinder); //nonprimitive
     }
 
     // v1_persistent_volume_spec->claim_ref
     cJSON *claim_ref = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "claimRef");
-    v1_object_reference_t *claim_ref_local_nonprim = NULL;
     if (claim_ref) { 
     claim_ref_local_nonprim = v1_object_reference_parseFromJSON(claim_ref); //nonprimitive
     }
 
     // v1_persistent_volume_spec->csi
     cJSON *csi = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "csi");
-    v1_csi_persistent_volume_source_t *csi_local_nonprim = NULL;
     if (csi) { 
     csi_local_nonprim = v1_csi_persistent_volume_source_parseFromJSON(csi); //nonprimitive
     }
 
     // v1_persistent_volume_spec->fc
     cJSON *fc = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "fc");
-    v1_fc_volume_source_t *fc_local_nonprim = NULL;
     if (fc) { 
     fc_local_nonprim = v1_fc_volume_source_parseFromJSON(fc); //nonprimitive
     }
 
     // v1_persistent_volume_spec->flex_volume
     cJSON *flex_volume = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "flexVolume");
-    v1_flex_persistent_volume_source_t *flex_volume_local_nonprim = NULL;
     if (flex_volume) { 
     flex_volume_local_nonprim = v1_flex_persistent_volume_source_parseFromJSON(flex_volume); //nonprimitive
     }
 
     // v1_persistent_volume_spec->flocker
     cJSON *flocker = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "flocker");
-    v1_flocker_volume_source_t *flocker_local_nonprim = NULL;
     if (flocker) { 
     flocker_local_nonprim = v1_flocker_volume_source_parseFromJSON(flocker); //nonprimitive
     }
 
     // v1_persistent_volume_spec->gce_persistent_disk
     cJSON *gce_persistent_disk = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "gcePersistentDisk");
-    v1_gce_persistent_disk_volume_source_t *gce_persistent_disk_local_nonprim = NULL;
     if (gce_persistent_disk) { 
     gce_persistent_disk_local_nonprim = v1_gce_persistent_disk_volume_source_parseFromJSON(gce_persistent_disk); //nonprimitive
     }
 
     // v1_persistent_volume_spec->glusterfs
     cJSON *glusterfs = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "glusterfs");
-    v1_glusterfs_persistent_volume_source_t *glusterfs_local_nonprim = NULL;
     if (glusterfs) { 
     glusterfs_local_nonprim = v1_glusterfs_persistent_volume_source_parseFromJSON(glusterfs); //nonprimitive
     }
 
     // v1_persistent_volume_spec->host_path
     cJSON *host_path = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "hostPath");
-    v1_host_path_volume_source_t *host_path_local_nonprim = NULL;
     if (host_path) { 
     host_path_local_nonprim = v1_host_path_volume_source_parseFromJSON(host_path); //nonprimitive
     }
 
     // v1_persistent_volume_spec->iscsi
     cJSON *iscsi = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "iscsi");
-    v1_iscsi_persistent_volume_source_t *iscsi_local_nonprim = NULL;
     if (iscsi) { 
     iscsi_local_nonprim = v1_iscsi_persistent_volume_source_parseFromJSON(iscsi); //nonprimitive
     }
 
     // v1_persistent_volume_spec->local
     cJSON *local = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "local");
-    v1_local_volume_source_t *local_local_nonprim = NULL;
     if (local) { 
     local_local_nonprim = v1_local_volume_source_parseFromJSON(local); //nonprimitive
     }
@@ -789,14 +846,12 @@ v1_persistent_volume_spec_t *v1_persistent_volume_spec_parseFromJSON(cJSON *v1_p
 
     // v1_persistent_volume_spec->nfs
     cJSON *nfs = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "nfs");
-    v1_nfs_volume_source_t *nfs_local_nonprim = NULL;
     if (nfs) { 
     nfs_local_nonprim = v1_nfs_volume_source_parseFromJSON(nfs); //nonprimitive
     }
 
     // v1_persistent_volume_spec->node_affinity
     cJSON *node_affinity = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "nodeAffinity");
-    v1_volume_node_affinity_t *node_affinity_local_nonprim = NULL;
     if (node_affinity) { 
     node_affinity_local_nonprim = v1_volume_node_affinity_parseFromJSON(node_affinity); //nonprimitive
     }
@@ -812,35 +867,30 @@ v1_persistent_volume_spec_t *v1_persistent_volume_spec_parseFromJSON(cJSON *v1_p
 
     // v1_persistent_volume_spec->photon_persistent_disk
     cJSON *photon_persistent_disk = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "photonPersistentDisk");
-    v1_photon_persistent_disk_volume_source_t *photon_persistent_disk_local_nonprim = NULL;
     if (photon_persistent_disk) { 
     photon_persistent_disk_local_nonprim = v1_photon_persistent_disk_volume_source_parseFromJSON(photon_persistent_disk); //nonprimitive
     }
 
     // v1_persistent_volume_spec->portworx_volume
     cJSON *portworx_volume = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "portworxVolume");
-    v1_portworx_volume_source_t *portworx_volume_local_nonprim = NULL;
     if (portworx_volume) { 
     portworx_volume_local_nonprim = v1_portworx_volume_source_parseFromJSON(portworx_volume); //nonprimitive
     }
 
     // v1_persistent_volume_spec->quobyte
     cJSON *quobyte = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "quobyte");
-    v1_quobyte_volume_source_t *quobyte_local_nonprim = NULL;
     if (quobyte) { 
     quobyte_local_nonprim = v1_quobyte_volume_source_parseFromJSON(quobyte); //nonprimitive
     }
 
     // v1_persistent_volume_spec->rbd
     cJSON *rbd = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "rbd");
-    v1_rbd_persistent_volume_source_t *rbd_local_nonprim = NULL;
     if (rbd) { 
     rbd_local_nonprim = v1_rbd_persistent_volume_source_parseFromJSON(rbd); //nonprimitive
     }
 
     // v1_persistent_volume_spec->scale_io
     cJSON *scale_io = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "scaleIO");
-    v1_scale_io_persistent_volume_source_t *scale_io_local_nonprim = NULL;
     if (scale_io) { 
     scale_io_local_nonprim = v1_scale_io_persistent_volume_source_parseFromJSON(scale_io); //nonprimitive
     }
@@ -856,7 +906,6 @@ v1_persistent_volume_spec_t *v1_persistent_volume_spec_parseFromJSON(cJSON *v1_p
 
     // v1_persistent_volume_spec->storageos
     cJSON *storageos = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "storageos");
-    v1_storage_os_persistent_volume_source_t *storageos_local_nonprim = NULL;
     if (storageos) { 
     storageos_local_nonprim = v1_storage_os_persistent_volume_source_parseFromJSON(storageos); //nonprimitive
     }
@@ -872,7 +921,6 @@ v1_persistent_volume_spec_t *v1_persistent_volume_spec_parseFromJSON(cJSON *v1_p
 
     // v1_persistent_volume_spec->vsphere_volume
     cJSON *vsphere_volume = cJSON_GetObjectItemCaseSensitive(v1_persistent_volume_specJSON, "vsphereVolume");
-    v1_vsphere_virtual_disk_volume_source_t *vsphere_volume_local_nonprim = NULL;
     if (vsphere_volume) { 
     vsphere_volume_local_nonprim = v1_vsphere_virtual_disk_volume_source_parseFromJSON(vsphere_volume); //nonprimitive
     }

--- a/kubernetes/model/v1_pod.c
+++ b/kubernetes/model/v1_pod.c
@@ -123,6 +123,15 @@ v1_pod_t *v1_pod_parseFromJSON(cJSON *v1_podJSON){
 
     v1_pod_t *v1_pod_local_var = NULL;
 
+    // define the local variable for v1_pod->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_pod->spec
+    v1_pod_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_pod->status
+    v1_pod_status_t *status_local_nonprim = NULL;
+
     // v1_pod->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_podJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_pod_t *v1_pod_parseFromJSON(cJSON *v1_podJSON){
 
     // v1_pod->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_podJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_pod->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_podJSON, "spec");
-    v1_pod_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_pod_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_pod->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_podJSON, "status");
-    v1_pod_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_pod_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_pod_affinity_term.c
+++ b/kubernetes/model/v1_pod_affinity_term.c
@@ -118,16 +118,20 @@ v1_pod_affinity_term_t *v1_pod_affinity_term_parseFromJSON(cJSON *v1_pod_affinit
 
     v1_pod_affinity_term_t *v1_pod_affinity_term_local_var = NULL;
 
+    // define the local variable for v1_pod_affinity_term->label_selector
+    v1_label_selector_t *label_selector_local_nonprim = NULL;
+
+    // define the local variable for v1_pod_affinity_term->namespace_selector
+    v1_label_selector_t *namespace_selector_local_nonprim = NULL;
+
     // v1_pod_affinity_term->label_selector
     cJSON *label_selector = cJSON_GetObjectItemCaseSensitive(v1_pod_affinity_termJSON, "labelSelector");
-    v1_label_selector_t *label_selector_local_nonprim = NULL;
     if (label_selector) { 
     label_selector_local_nonprim = v1_label_selector_parseFromJSON(label_selector); //nonprimitive
     }
 
     // v1_pod_affinity_term->namespace_selector
     cJSON *namespace_selector = cJSON_GetObjectItemCaseSensitive(v1_pod_affinity_termJSON, "namespaceSelector");
-    v1_label_selector_t *namespace_selector_local_nonprim = NULL;
     if (namespace_selector) { 
     namespace_selector_local_nonprim = v1_label_selector_parseFromJSON(namespace_selector); //nonprimitive
     }

--- a/kubernetes/model/v1_pod_disruption_budget.c
+++ b/kubernetes/model/v1_pod_disruption_budget.c
@@ -123,6 +123,15 @@ v1_pod_disruption_budget_t *v1_pod_disruption_budget_parseFromJSON(cJSON *v1_pod
 
     v1_pod_disruption_budget_t *v1_pod_disruption_budget_local_var = NULL;
 
+    // define the local variable for v1_pod_disruption_budget->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_pod_disruption_budget->spec
+    v1_pod_disruption_budget_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_pod_disruption_budget->status
+    v1_pod_disruption_budget_status_t *status_local_nonprim = NULL;
+
     // v1_pod_disruption_budget->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_pod_disruption_budgetJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_pod_disruption_budget_t *v1_pod_disruption_budget_parseFromJSON(cJSON *v1_pod
 
     // v1_pod_disruption_budget->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_pod_disruption_budgetJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_pod_disruption_budget->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_pod_disruption_budgetJSON, "spec");
-    v1_pod_disruption_budget_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_pod_disruption_budget_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_pod_disruption_budget->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_pod_disruption_budgetJSON, "status");
-    v1_pod_disruption_budget_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_pod_disruption_budget_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_pod_disruption_budget_list.c
+++ b/kubernetes/model/v1_pod_disruption_budget_list.c
@@ -116,6 +116,9 @@ v1_pod_disruption_budget_list_t *v1_pod_disruption_budget_list_parseFromJSON(cJS
 
     v1_pod_disruption_budget_list_t *v1_pod_disruption_budget_list_local_var = NULL;
 
+    // define the local variable for v1_pod_disruption_budget_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_pod_disruption_budget_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_pod_disruption_budget_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_pod_disruption_budget_list_t *v1_pod_disruption_budget_list_parseFromJSON(cJS
 
     // v1_pod_disruption_budget_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_pod_disruption_budget_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_pod_disruption_budget_spec.c
+++ b/kubernetes/model/v1_pod_disruption_budget_spec.c
@@ -95,6 +95,9 @@ v1_pod_disruption_budget_spec_t *v1_pod_disruption_budget_spec_parseFromJSON(cJS
 
     v1_pod_disruption_budget_spec_t *v1_pod_disruption_budget_spec_local_var = NULL;
 
+    // define the local variable for v1_pod_disruption_budget_spec->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
     // v1_pod_disruption_budget_spec->max_unavailable
     cJSON *max_unavailable = cJSON_GetObjectItemCaseSensitive(v1_pod_disruption_budget_specJSON, "maxUnavailable");
     object_t *max_unavailable_local_object = NULL;
@@ -111,7 +114,6 @@ v1_pod_disruption_budget_spec_t *v1_pod_disruption_budget_spec_parseFromJSON(cJS
 
     // v1_pod_disruption_budget_spec->selector
     cJSON *selector = cJSON_GetObjectItemCaseSensitive(v1_pod_disruption_budget_specJSON, "selector");
-    v1_label_selector_t *selector_local_nonprim = NULL;
     if (selector) { 
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
     }

--- a/kubernetes/model/v1_pod_list.c
+++ b/kubernetes/model/v1_pod_list.c
@@ -116,6 +116,9 @@ v1_pod_list_t *v1_pod_list_parseFromJSON(cJSON *v1_pod_listJSON){
 
     v1_pod_list_t *v1_pod_list_local_var = NULL;
 
+    // define the local variable for v1_pod_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_pod_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_pod_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_pod_list_t *v1_pod_list_parseFromJSON(cJSON *v1_pod_listJSON){
 
     // v1_pod_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_pod_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_pod_security_context.c
+++ b/kubernetes/model/v1_pod_security_context.c
@@ -204,6 +204,15 @@ v1_pod_security_context_t *v1_pod_security_context_parseFromJSON(cJSON *v1_pod_s
 
     v1_pod_security_context_t *v1_pod_security_context_local_var = NULL;
 
+    // define the local variable for v1_pod_security_context->se_linux_options
+    v1_se_linux_options_t *se_linux_options_local_nonprim = NULL;
+
+    // define the local variable for v1_pod_security_context->seccomp_profile
+    v1_seccomp_profile_t *seccomp_profile_local_nonprim = NULL;
+
+    // define the local variable for v1_pod_security_context->windows_options
+    v1_windows_security_context_options_t *windows_options_local_nonprim = NULL;
+
     // v1_pod_security_context->fs_group
     cJSON *fs_group = cJSON_GetObjectItemCaseSensitive(v1_pod_security_contextJSON, "fsGroup");
     if (fs_group) { 
@@ -251,14 +260,12 @@ v1_pod_security_context_t *v1_pod_security_context_parseFromJSON(cJSON *v1_pod_s
 
     // v1_pod_security_context->se_linux_options
     cJSON *se_linux_options = cJSON_GetObjectItemCaseSensitive(v1_pod_security_contextJSON, "seLinuxOptions");
-    v1_se_linux_options_t *se_linux_options_local_nonprim = NULL;
     if (se_linux_options) { 
     se_linux_options_local_nonprim = v1_se_linux_options_parseFromJSON(se_linux_options); //nonprimitive
     }
 
     // v1_pod_security_context->seccomp_profile
     cJSON *seccomp_profile = cJSON_GetObjectItemCaseSensitive(v1_pod_security_contextJSON, "seccompProfile");
-    v1_seccomp_profile_t *seccomp_profile_local_nonprim = NULL;
     if (seccomp_profile) { 
     seccomp_profile_local_nonprim = v1_seccomp_profile_parseFromJSON(seccomp_profile); //nonprimitive
     }
@@ -313,7 +320,6 @@ v1_pod_security_context_t *v1_pod_security_context_parseFromJSON(cJSON *v1_pod_s
 
     // v1_pod_security_context->windows_options
     cJSON *windows_options = cJSON_GetObjectItemCaseSensitive(v1_pod_security_contextJSON, "windowsOptions");
-    v1_windows_security_context_options_t *windows_options_local_nonprim = NULL;
     if (windows_options) { 
     windows_options_local_nonprim = v1_windows_security_context_options_parseFromJSON(windows_options); //nonprimitive
     }

--- a/kubernetes/model/v1_pod_spec.c
+++ b/kubernetes/model/v1_pod_spec.c
@@ -676,6 +676,15 @@ v1_pod_spec_t *v1_pod_spec_parseFromJSON(cJSON *v1_pod_specJSON){
 
     v1_pod_spec_t *v1_pod_spec_local_var = NULL;
 
+    // define the local variable for v1_pod_spec->affinity
+    v1_affinity_t *affinity_local_nonprim = NULL;
+
+    // define the local variable for v1_pod_spec->dns_config
+    v1_pod_dns_config_t *dns_config_local_nonprim = NULL;
+
+    // define the local variable for v1_pod_spec->security_context
+    v1_pod_security_context_t *security_context_local_nonprim = NULL;
+
     // v1_pod_spec->active_deadline_seconds
     cJSON *active_deadline_seconds = cJSON_GetObjectItemCaseSensitive(v1_pod_specJSON, "activeDeadlineSeconds");
     if (active_deadline_seconds) { 
@@ -687,7 +696,6 @@ v1_pod_spec_t *v1_pod_spec_parseFromJSON(cJSON *v1_pod_specJSON){
 
     // v1_pod_spec->affinity
     cJSON *affinity = cJSON_GetObjectItemCaseSensitive(v1_pod_specJSON, "affinity");
-    v1_affinity_t *affinity_local_nonprim = NULL;
     if (affinity) { 
     affinity_local_nonprim = v1_affinity_parseFromJSON(affinity); //nonprimitive
     }
@@ -728,7 +736,6 @@ v1_pod_spec_t *v1_pod_spec_parseFromJSON(cJSON *v1_pod_specJSON){
 
     // v1_pod_spec->dns_config
     cJSON *dns_config = cJSON_GetObjectItemCaseSensitive(v1_pod_specJSON, "dnsConfig");
-    v1_pod_dns_config_t *dns_config_local_nonprim = NULL;
     if (dns_config) { 
     dns_config_local_nonprim = v1_pod_dns_config_parseFromJSON(dns_config); //nonprimitive
     }
@@ -1006,7 +1013,6 @@ v1_pod_spec_t *v1_pod_spec_parseFromJSON(cJSON *v1_pod_specJSON){
 
     // v1_pod_spec->security_context
     cJSON *security_context = cJSON_GetObjectItemCaseSensitive(v1_pod_specJSON, "securityContext");
-    v1_pod_security_context_t *security_context_local_nonprim = NULL;
     if (security_context) { 
     security_context_local_nonprim = v1_pod_security_context_parseFromJSON(security_context); //nonprimitive
     }

--- a/kubernetes/model/v1_pod_template.c
+++ b/kubernetes/model/v1_pod_template.c
@@ -104,6 +104,12 @@ v1_pod_template_t *v1_pod_template_parseFromJSON(cJSON *v1_pod_templateJSON){
 
     v1_pod_template_t *v1_pod_template_local_var = NULL;
 
+    // define the local variable for v1_pod_template->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_pod_template->_template
+    v1_pod_template_spec_t *_template_local_nonprim = NULL;
+
     // v1_pod_template->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_pod_templateJSON, "apiVersion");
     if (api_version) { 
@@ -124,14 +130,12 @@ v1_pod_template_t *v1_pod_template_parseFromJSON(cJSON *v1_pod_templateJSON){
 
     // v1_pod_template->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_pod_templateJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_pod_template->_template
     cJSON *_template = cJSON_GetObjectItemCaseSensitive(v1_pod_templateJSON, "template");
-    v1_pod_template_spec_t *_template_local_nonprim = NULL;
     if (_template) { 
     _template_local_nonprim = v1_pod_template_spec_parseFromJSON(_template); //nonprimitive
     }

--- a/kubernetes/model/v1_pod_template_list.c
+++ b/kubernetes/model/v1_pod_template_list.c
@@ -116,6 +116,9 @@ v1_pod_template_list_t *v1_pod_template_list_parseFromJSON(cJSON *v1_pod_templat
 
     v1_pod_template_list_t *v1_pod_template_list_local_var = NULL;
 
+    // define the local variable for v1_pod_template_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_pod_template_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_pod_template_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_pod_template_list_t *v1_pod_template_list_parseFromJSON(cJSON *v1_pod_templat
 
     // v1_pod_template_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_pod_template_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_pod_template_spec.c
+++ b/kubernetes/model/v1_pod_template_spec.c
@@ -76,16 +76,20 @@ v1_pod_template_spec_t *v1_pod_template_spec_parseFromJSON(cJSON *v1_pod_templat
 
     v1_pod_template_spec_t *v1_pod_template_spec_local_var = NULL;
 
+    // define the local variable for v1_pod_template_spec->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_pod_template_spec->spec
+    v1_pod_spec_t *spec_local_nonprim = NULL;
+
     // v1_pod_template_spec->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_pod_template_specJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_pod_template_spec->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_pod_template_specJSON, "spec");
-    v1_pod_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_pod_spec_parseFromJSON(spec); //nonprimitive
     }

--- a/kubernetes/model/v1_preferred_scheduling_term.c
+++ b/kubernetes/model/v1_preferred_scheduling_term.c
@@ -71,13 +71,15 @@ v1_preferred_scheduling_term_t *v1_preferred_scheduling_term_parseFromJSON(cJSON
 
     v1_preferred_scheduling_term_t *v1_preferred_scheduling_term_local_var = NULL;
 
+    // define the local variable for v1_preferred_scheduling_term->preference
+    v1_node_selector_term_t *preference_local_nonprim = NULL;
+
     // v1_preferred_scheduling_term->preference
     cJSON *preference = cJSON_GetObjectItemCaseSensitive(v1_preferred_scheduling_termJSON, "preference");
     if (!preference) {
         goto end;
     }
 
-    v1_node_selector_term_t *preference_local_nonprim = NULL;
     
     preference_local_nonprim = v1_node_selector_term_parseFromJSON(preference); //nonprimitive
 

--- a/kubernetes/model/v1_priority_class.c
+++ b/kubernetes/model/v1_priority_class.c
@@ -135,6 +135,9 @@ v1_priority_class_t *v1_priority_class_parseFromJSON(cJSON *v1_priority_classJSO
 
     v1_priority_class_t *v1_priority_class_local_var = NULL;
 
+    // define the local variable for v1_priority_class->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_priority_class->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_priority_classJSON, "apiVersion");
     if (api_version) { 
@@ -173,7 +176,6 @@ v1_priority_class_t *v1_priority_class_parseFromJSON(cJSON *v1_priority_classJSO
 
     // v1_priority_class->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_priority_classJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_priority_class_list.c
+++ b/kubernetes/model/v1_priority_class_list.c
@@ -116,6 +116,9 @@ v1_priority_class_list_t *v1_priority_class_list_parseFromJSON(cJSON *v1_priorit
 
     v1_priority_class_list_t *v1_priority_class_list_local_var = NULL;
 
+    // define the local variable for v1_priority_class_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_priority_class_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_priority_class_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_priority_class_list_t *v1_priority_class_list_parseFromJSON(cJSON *v1_priorit
 
     // v1_priority_class_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_priority_class_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_probe.c
+++ b/kubernetes/model/v1_probe.c
@@ -155,9 +155,17 @@ v1_probe_t *v1_probe_parseFromJSON(cJSON *v1_probeJSON){
 
     v1_probe_t *v1_probe_local_var = NULL;
 
+    // define the local variable for v1_probe->exec
+    v1_exec_action_t *exec_local_nonprim = NULL;
+
+    // define the local variable for v1_probe->http_get
+    v1_http_get_action_t *http_get_local_nonprim = NULL;
+
+    // define the local variable for v1_probe->tcp_socket
+    v1_tcp_socket_action_t *tcp_socket_local_nonprim = NULL;
+
     // v1_probe->exec
     cJSON *exec = cJSON_GetObjectItemCaseSensitive(v1_probeJSON, "exec");
-    v1_exec_action_t *exec_local_nonprim = NULL;
     if (exec) { 
     exec_local_nonprim = v1_exec_action_parseFromJSON(exec); //nonprimitive
     }
@@ -173,7 +181,6 @@ v1_probe_t *v1_probe_parseFromJSON(cJSON *v1_probeJSON){
 
     // v1_probe->http_get
     cJSON *http_get = cJSON_GetObjectItemCaseSensitive(v1_probeJSON, "httpGet");
-    v1_http_get_action_t *http_get_local_nonprim = NULL;
     if (http_get) { 
     http_get_local_nonprim = v1_http_get_action_parseFromJSON(http_get); //nonprimitive
     }
@@ -207,7 +214,6 @@ v1_probe_t *v1_probe_parseFromJSON(cJSON *v1_probeJSON){
 
     // v1_probe->tcp_socket
     cJSON *tcp_socket = cJSON_GetObjectItemCaseSensitive(v1_probeJSON, "tcpSocket");
-    v1_tcp_socket_action_t *tcp_socket_local_nonprim = NULL;
     if (tcp_socket) { 
     tcp_socket_local_nonprim = v1_tcp_socket_action_parseFromJSON(tcp_socket); //nonprimitive
     }

--- a/kubernetes/model/v1_rbd_persistent_volume_source.c
+++ b/kubernetes/model/v1_rbd_persistent_volume_source.c
@@ -167,6 +167,9 @@ v1_rbd_persistent_volume_source_t *v1_rbd_persistent_volume_source_parseFromJSON
 
     v1_rbd_persistent_volume_source_t *v1_rbd_persistent_volume_source_local_var = NULL;
 
+    // define the local variable for v1_rbd_persistent_volume_source->secret_ref
+    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_rbd_persistent_volume_source->fs_type
     cJSON *fs_type = cJSON_GetObjectItemCaseSensitive(v1_rbd_persistent_volume_sourceJSON, "fsType");
     if (fs_type) { 
@@ -240,7 +243,6 @@ v1_rbd_persistent_volume_source_t *v1_rbd_persistent_volume_source_parseFromJSON
 
     // v1_rbd_persistent_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_rbd_persistent_volume_sourceJSON, "secretRef");
-    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_secret_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_rbd_volume_source.c
+++ b/kubernetes/model/v1_rbd_volume_source.c
@@ -167,6 +167,9 @@ v1_rbd_volume_source_t *v1_rbd_volume_source_parseFromJSON(cJSON *v1_rbd_volume_
 
     v1_rbd_volume_source_t *v1_rbd_volume_source_local_var = NULL;
 
+    // define the local variable for v1_rbd_volume_source->secret_ref
+    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_rbd_volume_source->fs_type
     cJSON *fs_type = cJSON_GetObjectItemCaseSensitive(v1_rbd_volume_sourceJSON, "fsType");
     if (fs_type) { 
@@ -240,7 +243,6 @@ v1_rbd_volume_source_t *v1_rbd_volume_source_parseFromJSON(cJSON *v1_rbd_volume_
 
     // v1_rbd_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_rbd_volume_sourceJSON, "secretRef");
-    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_local_object_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_replica_set.c
+++ b/kubernetes/model/v1_replica_set.c
@@ -123,6 +123,15 @@ v1_replica_set_t *v1_replica_set_parseFromJSON(cJSON *v1_replica_setJSON){
 
     v1_replica_set_t *v1_replica_set_local_var = NULL;
 
+    // define the local variable for v1_replica_set->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_replica_set->spec
+    v1_replica_set_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_replica_set->status
+    v1_replica_set_status_t *status_local_nonprim = NULL;
+
     // v1_replica_set->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_replica_setJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_replica_set_t *v1_replica_set_parseFromJSON(cJSON *v1_replica_setJSON){
 
     // v1_replica_set->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_replica_setJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_replica_set->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_replica_setJSON, "spec");
-    v1_replica_set_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_replica_set_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_replica_set->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_replica_setJSON, "status");
-    v1_replica_set_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_replica_set_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_replica_set_list.c
+++ b/kubernetes/model/v1_replica_set_list.c
@@ -116,6 +116,9 @@ v1_replica_set_list_t *v1_replica_set_list_parseFromJSON(cJSON *v1_replica_set_l
 
     v1_replica_set_list_t *v1_replica_set_list_local_var = NULL;
 
+    // define the local variable for v1_replica_set_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_replica_set_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_replica_set_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_replica_set_list_t *v1_replica_set_list_parseFromJSON(cJSON *v1_replica_set_l
 
     // v1_replica_set_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_replica_set_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_replica_set_spec.c
+++ b/kubernetes/model/v1_replica_set_spec.c
@@ -98,6 +98,12 @@ v1_replica_set_spec_t *v1_replica_set_spec_parseFromJSON(cJSON *v1_replica_set_s
 
     v1_replica_set_spec_t *v1_replica_set_spec_local_var = NULL;
 
+    // define the local variable for v1_replica_set_spec->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
+    // define the local variable for v1_replica_set_spec->_template
+    v1_pod_template_spec_t *_template_local_nonprim = NULL;
+
     // v1_replica_set_spec->min_ready_seconds
     cJSON *min_ready_seconds = cJSON_GetObjectItemCaseSensitive(v1_replica_set_specJSON, "minReadySeconds");
     if (min_ready_seconds) { 
@@ -122,13 +128,11 @@ v1_replica_set_spec_t *v1_replica_set_spec_parseFromJSON(cJSON *v1_replica_set_s
         goto end;
     }
 
-    v1_label_selector_t *selector_local_nonprim = NULL;
     
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
 
     // v1_replica_set_spec->_template
     cJSON *_template = cJSON_GetObjectItemCaseSensitive(v1_replica_set_specJSON, "template");
-    v1_pod_template_spec_t *_template_local_nonprim = NULL;
     if (_template) { 
     _template_local_nonprim = v1_pod_template_spec_parseFromJSON(_template); //nonprimitive
     }

--- a/kubernetes/model/v1_replication_controller.c
+++ b/kubernetes/model/v1_replication_controller.c
@@ -123,6 +123,15 @@ v1_replication_controller_t *v1_replication_controller_parseFromJSON(cJSON *v1_r
 
     v1_replication_controller_t *v1_replication_controller_local_var = NULL;
 
+    // define the local variable for v1_replication_controller->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_replication_controller->spec
+    v1_replication_controller_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_replication_controller->status
+    v1_replication_controller_status_t *status_local_nonprim = NULL;
+
     // v1_replication_controller->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_replication_controllerJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_replication_controller_t *v1_replication_controller_parseFromJSON(cJSON *v1_r
 
     // v1_replication_controller->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_replication_controllerJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_replication_controller->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_replication_controllerJSON, "spec");
-    v1_replication_controller_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_replication_controller_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_replication_controller->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_replication_controllerJSON, "status");
-    v1_replication_controller_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_replication_controller_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_replication_controller_list.c
+++ b/kubernetes/model/v1_replication_controller_list.c
@@ -116,6 +116,9 @@ v1_replication_controller_list_t *v1_replication_controller_list_parseFromJSON(c
 
     v1_replication_controller_list_t *v1_replication_controller_list_local_var = NULL;
 
+    // define the local variable for v1_replication_controller_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_replication_controller_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_replication_controller_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_replication_controller_list_t *v1_replication_controller_list_parseFromJSON(c
 
     // v1_replication_controller_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_replication_controller_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_replication_controller_spec.c
+++ b/kubernetes/model/v1_replication_controller_spec.c
@@ -109,6 +109,9 @@ v1_replication_controller_spec_t *v1_replication_controller_spec_parseFromJSON(c
 
     v1_replication_controller_spec_t *v1_replication_controller_spec_local_var = NULL;
 
+    // define the local variable for v1_replication_controller_spec->_template
+    v1_pod_template_spec_t *_template_local_nonprim = NULL;
+
     // v1_replication_controller_spec->min_ready_seconds
     cJSON *min_ready_seconds = cJSON_GetObjectItemCaseSensitive(v1_replication_controller_specJSON, "minReadySeconds");
     if (min_ready_seconds) { 
@@ -151,7 +154,6 @@ v1_replication_controller_spec_t *v1_replication_controller_spec_parseFromJSON(c
 
     // v1_replication_controller_spec->_template
     cJSON *_template = cJSON_GetObjectItemCaseSensitive(v1_replication_controller_specJSON, "template");
-    v1_pod_template_spec_t *_template_local_nonprim = NULL;
     if (_template) { 
     _template_local_nonprim = v1_pod_template_spec_parseFromJSON(_template); //nonprimitive
     }

--- a/kubernetes/model/v1_resource_quota.c
+++ b/kubernetes/model/v1_resource_quota.c
@@ -123,6 +123,15 @@ v1_resource_quota_t *v1_resource_quota_parseFromJSON(cJSON *v1_resource_quotaJSO
 
     v1_resource_quota_t *v1_resource_quota_local_var = NULL;
 
+    // define the local variable for v1_resource_quota->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_resource_quota->spec
+    v1_resource_quota_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_resource_quota->status
+    v1_resource_quota_status_t *status_local_nonprim = NULL;
+
     // v1_resource_quota->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_resource_quotaJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_resource_quota_t *v1_resource_quota_parseFromJSON(cJSON *v1_resource_quotaJSO
 
     // v1_resource_quota->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_resource_quotaJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_resource_quota->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_resource_quotaJSON, "spec");
-    v1_resource_quota_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_resource_quota_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_resource_quota->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_resource_quotaJSON, "status");
-    v1_resource_quota_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_resource_quota_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_resource_quota_list.c
+++ b/kubernetes/model/v1_resource_quota_list.c
@@ -116,6 +116,9 @@ v1_resource_quota_list_t *v1_resource_quota_list_parseFromJSON(cJSON *v1_resourc
 
     v1_resource_quota_list_t *v1_resource_quota_list_local_var = NULL;
 
+    // define the local variable for v1_resource_quota_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_resource_quota_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_resource_quota_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_resource_quota_list_t *v1_resource_quota_list_parseFromJSON(cJSON *v1_resourc
 
     // v1_resource_quota_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_resource_quota_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_resource_quota_spec.c
+++ b/kubernetes/model/v1_resource_quota_spec.c
@@ -115,6 +115,9 @@ v1_resource_quota_spec_t *v1_resource_quota_spec_parseFromJSON(cJSON *v1_resourc
 
     v1_resource_quota_spec_t *v1_resource_quota_spec_local_var = NULL;
 
+    // define the local variable for v1_resource_quota_spec->scope_selector
+    v1_scope_selector_t *scope_selector_local_nonprim = NULL;
+
     // v1_resource_quota_spec->hard
     cJSON *hard = cJSON_GetObjectItemCaseSensitive(v1_resource_quota_specJSON, "hard");
     list_t *hardList;
@@ -139,7 +142,6 @@ v1_resource_quota_spec_t *v1_resource_quota_spec_parseFromJSON(cJSON *v1_resourc
 
     // v1_resource_quota_spec->scope_selector
     cJSON *scope_selector = cJSON_GetObjectItemCaseSensitive(v1_resource_quota_specJSON, "scopeSelector");
-    v1_scope_selector_t *scope_selector_local_nonprim = NULL;
     if (scope_selector) { 
     scope_selector_local_nonprim = v1_scope_selector_parseFromJSON(scope_selector); //nonprimitive
     }

--- a/kubernetes/model/v1_role.c
+++ b/kubernetes/model/v1_role.c
@@ -114,6 +114,9 @@ v1_role_t *v1_role_parseFromJSON(cJSON *v1_roleJSON){
 
     v1_role_t *v1_role_local_var = NULL;
 
+    // define the local variable for v1_role->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_role->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_roleJSON, "apiVersion");
     if (api_version) { 
@@ -134,7 +137,6 @@ v1_role_t *v1_role_parseFromJSON(cJSON *v1_roleJSON){
 
     // v1_role->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_roleJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_role_binding.c
+++ b/kubernetes/model/v1_role_binding.c
@@ -135,6 +135,12 @@ v1_role_binding_t *v1_role_binding_parseFromJSON(cJSON *v1_role_bindingJSON){
 
     v1_role_binding_t *v1_role_binding_local_var = NULL;
 
+    // define the local variable for v1_role_binding->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_role_binding->role_ref
+    v1_role_ref_t *role_ref_local_nonprim = NULL;
+
     // v1_role_binding->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_role_bindingJSON, "apiVersion");
     if (api_version) { 
@@ -155,7 +161,6 @@ v1_role_binding_t *v1_role_binding_parseFromJSON(cJSON *v1_role_bindingJSON){
 
     // v1_role_binding->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_role_bindingJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -166,7 +171,6 @@ v1_role_binding_t *v1_role_binding_parseFromJSON(cJSON *v1_role_bindingJSON){
         goto end;
     }
 
-    v1_role_ref_t *role_ref_local_nonprim = NULL;
     
     role_ref_local_nonprim = v1_role_ref_parseFromJSON(role_ref); //nonprimitive
 

--- a/kubernetes/model/v1_role_binding_list.c
+++ b/kubernetes/model/v1_role_binding_list.c
@@ -116,6 +116,9 @@ v1_role_binding_list_t *v1_role_binding_list_parseFromJSON(cJSON *v1_role_bindin
 
     v1_role_binding_list_t *v1_role_binding_list_local_var = NULL;
 
+    // define the local variable for v1_role_binding_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_role_binding_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_role_binding_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_role_binding_list_t *v1_role_binding_list_parseFromJSON(cJSON *v1_role_bindin
 
     // v1_role_binding_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_role_binding_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_role_list.c
+++ b/kubernetes/model/v1_role_list.c
@@ -116,6 +116,9 @@ v1_role_list_t *v1_role_list_parseFromJSON(cJSON *v1_role_listJSON){
 
     v1_role_list_t *v1_role_list_local_var = NULL;
 
+    // define the local variable for v1_role_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_role_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_role_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_role_list_t *v1_role_list_parseFromJSON(cJSON *v1_role_listJSON){
 
     // v1_role_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_role_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_runtime_class.c
+++ b/kubernetes/model/v1_runtime_class.c
@@ -139,6 +139,15 @@ v1_runtime_class_t *v1_runtime_class_parseFromJSON(cJSON *v1_runtime_classJSON){
 
     v1_runtime_class_t *v1_runtime_class_local_var = NULL;
 
+    // define the local variable for v1_runtime_class->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_runtime_class->overhead
+    v1_overhead_t *overhead_local_nonprim = NULL;
+
+    // define the local variable for v1_runtime_class->scheduling
+    v1_scheduling_t *scheduling_local_nonprim = NULL;
+
     // v1_runtime_class->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_runtime_classJSON, "apiVersion");
     if (api_version) { 
@@ -171,21 +180,18 @@ v1_runtime_class_t *v1_runtime_class_parseFromJSON(cJSON *v1_runtime_classJSON){
 
     // v1_runtime_class->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_runtime_classJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_runtime_class->overhead
     cJSON *overhead = cJSON_GetObjectItemCaseSensitive(v1_runtime_classJSON, "overhead");
-    v1_overhead_t *overhead_local_nonprim = NULL;
     if (overhead) { 
     overhead_local_nonprim = v1_overhead_parseFromJSON(overhead); //nonprimitive
     }
 
     // v1_runtime_class->scheduling
     cJSON *scheduling = cJSON_GetObjectItemCaseSensitive(v1_runtime_classJSON, "scheduling");
-    v1_scheduling_t *scheduling_local_nonprim = NULL;
     if (scheduling) { 
     scheduling_local_nonprim = v1_scheduling_parseFromJSON(scheduling); //nonprimitive
     }

--- a/kubernetes/model/v1_runtime_class_list.c
+++ b/kubernetes/model/v1_runtime_class_list.c
@@ -116,6 +116,9 @@ v1_runtime_class_list_t *v1_runtime_class_list_parseFromJSON(cJSON *v1_runtime_c
 
     v1_runtime_class_list_t *v1_runtime_class_list_local_var = NULL;
 
+    // define the local variable for v1_runtime_class_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_runtime_class_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_runtime_class_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_runtime_class_list_t *v1_runtime_class_list_parseFromJSON(cJSON *v1_runtime_c
 
     // v1_runtime_class_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_runtime_class_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_scale.c
+++ b/kubernetes/model/v1_scale.c
@@ -123,6 +123,15 @@ v1_scale_t *v1_scale_parseFromJSON(cJSON *v1_scaleJSON){
 
     v1_scale_t *v1_scale_local_var = NULL;
 
+    // define the local variable for v1_scale->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_scale->spec
+    v1_scale_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_scale->status
+    v1_scale_status_t *status_local_nonprim = NULL;
+
     // v1_scale->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_scaleJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_scale_t *v1_scale_parseFromJSON(cJSON *v1_scaleJSON){
 
     // v1_scale->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_scaleJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_scale->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_scaleJSON, "spec");
-    v1_scale_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_scale_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_scale->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_scaleJSON, "status");
-    v1_scale_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_scale_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_scale_io_persistent_volume_source.c
+++ b/kubernetes/model/v1_scale_io_persistent_volume_source.c
@@ -181,6 +181,9 @@ v1_scale_io_persistent_volume_source_t *v1_scale_io_persistent_volume_source_par
 
     v1_scale_io_persistent_volume_source_t *v1_scale_io_persistent_volume_source_local_var = NULL;
 
+    // define the local variable for v1_scale_io_persistent_volume_source->secret_ref
+    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_scale_io_persistent_volume_source->fs_type
     cJSON *fs_type = cJSON_GetObjectItemCaseSensitive(v1_scale_io_persistent_volume_sourceJSON, "fsType");
     if (fs_type) { 
@@ -226,7 +229,6 @@ v1_scale_io_persistent_volume_source_t *v1_scale_io_persistent_volume_source_par
         goto end;
     }
 
-    v1_secret_reference_t *secret_ref_local_nonprim = NULL;
     
     secret_ref_local_nonprim = v1_secret_reference_parseFromJSON(secret_ref); //nonprimitive
 

--- a/kubernetes/model/v1_scale_io_volume_source.c
+++ b/kubernetes/model/v1_scale_io_volume_source.c
@@ -181,6 +181,9 @@ v1_scale_io_volume_source_t *v1_scale_io_volume_source_parseFromJSON(cJSON *v1_s
 
     v1_scale_io_volume_source_t *v1_scale_io_volume_source_local_var = NULL;
 
+    // define the local variable for v1_scale_io_volume_source->secret_ref
+    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_scale_io_volume_source->fs_type
     cJSON *fs_type = cJSON_GetObjectItemCaseSensitive(v1_scale_io_volume_sourceJSON, "fsType");
     if (fs_type) { 
@@ -226,7 +229,6 @@ v1_scale_io_volume_source_t *v1_scale_io_volume_source_parseFromJSON(cJSON *v1_s
         goto end;
     }
 
-    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
     
     secret_ref_local_nonprim = v1_local_object_reference_parseFromJSON(secret_ref); //nonprimitive
 

--- a/kubernetes/model/v1_secret.c
+++ b/kubernetes/model/v1_secret.c
@@ -173,6 +173,9 @@ v1_secret_t *v1_secret_parseFromJSON(cJSON *v1_secretJSON){
 
     v1_secret_t *v1_secret_local_var = NULL;
 
+    // define the local variable for v1_secret->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_secret->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_secretJSON, "apiVersion");
     if (api_version) { 
@@ -224,7 +227,6 @@ v1_secret_t *v1_secret_parseFromJSON(cJSON *v1_secretJSON){
 
     // v1_secret->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_secretJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_secret_list.c
+++ b/kubernetes/model/v1_secret_list.c
@@ -116,6 +116,9 @@ v1_secret_list_t *v1_secret_list_parseFromJSON(cJSON *v1_secret_listJSON){
 
     v1_secret_list_t *v1_secret_list_local_var = NULL;
 
+    // define the local variable for v1_secret_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_secret_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_secret_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_secret_list_t *v1_secret_list_parseFromJSON(cJSON *v1_secret_listJSON){
 
     // v1_secret_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_secret_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_security_context.c
+++ b/kubernetes/model/v1_security_context.c
@@ -188,6 +188,18 @@ v1_security_context_t *v1_security_context_parseFromJSON(cJSON *v1_security_cont
 
     v1_security_context_t *v1_security_context_local_var = NULL;
 
+    // define the local variable for v1_security_context->capabilities
+    v1_capabilities_t *capabilities_local_nonprim = NULL;
+
+    // define the local variable for v1_security_context->se_linux_options
+    v1_se_linux_options_t *se_linux_options_local_nonprim = NULL;
+
+    // define the local variable for v1_security_context->seccomp_profile
+    v1_seccomp_profile_t *seccomp_profile_local_nonprim = NULL;
+
+    // define the local variable for v1_security_context->windows_options
+    v1_windows_security_context_options_t *windows_options_local_nonprim = NULL;
+
     // v1_security_context->allow_privilege_escalation
     cJSON *allow_privilege_escalation = cJSON_GetObjectItemCaseSensitive(v1_security_contextJSON, "allowPrivilegeEscalation");
     if (allow_privilege_escalation) { 
@@ -199,7 +211,6 @@ v1_security_context_t *v1_security_context_parseFromJSON(cJSON *v1_security_cont
 
     // v1_security_context->capabilities
     cJSON *capabilities = cJSON_GetObjectItemCaseSensitive(v1_security_contextJSON, "capabilities");
-    v1_capabilities_t *capabilities_local_nonprim = NULL;
     if (capabilities) { 
     capabilities_local_nonprim = v1_capabilities_parseFromJSON(capabilities); //nonprimitive
     }
@@ -260,21 +271,18 @@ v1_security_context_t *v1_security_context_parseFromJSON(cJSON *v1_security_cont
 
     // v1_security_context->se_linux_options
     cJSON *se_linux_options = cJSON_GetObjectItemCaseSensitive(v1_security_contextJSON, "seLinuxOptions");
-    v1_se_linux_options_t *se_linux_options_local_nonprim = NULL;
     if (se_linux_options) { 
     se_linux_options_local_nonprim = v1_se_linux_options_parseFromJSON(se_linux_options); //nonprimitive
     }
 
     // v1_security_context->seccomp_profile
     cJSON *seccomp_profile = cJSON_GetObjectItemCaseSensitive(v1_security_contextJSON, "seccompProfile");
-    v1_seccomp_profile_t *seccomp_profile_local_nonprim = NULL;
     if (seccomp_profile) { 
     seccomp_profile_local_nonprim = v1_seccomp_profile_parseFromJSON(seccomp_profile); //nonprimitive
     }
 
     // v1_security_context->windows_options
     cJSON *windows_options = cJSON_GetObjectItemCaseSensitive(v1_security_contextJSON, "windowsOptions");
-    v1_windows_security_context_options_t *windows_options_local_nonprim = NULL;
     if (windows_options) { 
     windows_options_local_nonprim = v1_windows_security_context_options_parseFromJSON(windows_options); //nonprimitive
     }

--- a/kubernetes/model/v1_self_subject_access_review.c
+++ b/kubernetes/model/v1_self_subject_access_review.c
@@ -125,6 +125,15 @@ v1_self_subject_access_review_t *v1_self_subject_access_review_parseFromJSON(cJS
 
     v1_self_subject_access_review_t *v1_self_subject_access_review_local_var = NULL;
 
+    // define the local variable for v1_self_subject_access_review->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_self_subject_access_review->spec
+    v1_self_subject_access_review_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_self_subject_access_review->status
+    v1_subject_access_review_status_t *status_local_nonprim = NULL;
+
     // v1_self_subject_access_review->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_self_subject_access_reviewJSON, "apiVersion");
     if (api_version) { 
@@ -145,7 +154,6 @@ v1_self_subject_access_review_t *v1_self_subject_access_review_parseFromJSON(cJS
 
     // v1_self_subject_access_review->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_self_subject_access_reviewJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -156,13 +164,11 @@ v1_self_subject_access_review_t *v1_self_subject_access_review_parseFromJSON(cJS
         goto end;
     }
 
-    v1_self_subject_access_review_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_self_subject_access_review_spec_parseFromJSON(spec); //nonprimitive
 
     // v1_self_subject_access_review->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_self_subject_access_reviewJSON, "status");
-    v1_subject_access_review_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_subject_access_review_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_self_subject_access_review_spec.c
+++ b/kubernetes/model/v1_self_subject_access_review_spec.c
@@ -76,16 +76,20 @@ v1_self_subject_access_review_spec_t *v1_self_subject_access_review_spec_parseFr
 
     v1_self_subject_access_review_spec_t *v1_self_subject_access_review_spec_local_var = NULL;
 
+    // define the local variable for v1_self_subject_access_review_spec->non_resource_attributes
+    v1_non_resource_attributes_t *non_resource_attributes_local_nonprim = NULL;
+
+    // define the local variable for v1_self_subject_access_review_spec->resource_attributes
+    v1_resource_attributes_t *resource_attributes_local_nonprim = NULL;
+
     // v1_self_subject_access_review_spec->non_resource_attributes
     cJSON *non_resource_attributes = cJSON_GetObjectItemCaseSensitive(v1_self_subject_access_review_specJSON, "nonResourceAttributes");
-    v1_non_resource_attributes_t *non_resource_attributes_local_nonprim = NULL;
     if (non_resource_attributes) { 
     non_resource_attributes_local_nonprim = v1_non_resource_attributes_parseFromJSON(non_resource_attributes); //nonprimitive
     }
 
     // v1_self_subject_access_review_spec->resource_attributes
     cJSON *resource_attributes = cJSON_GetObjectItemCaseSensitive(v1_self_subject_access_review_specJSON, "resourceAttributes");
-    v1_resource_attributes_t *resource_attributes_local_nonprim = NULL;
     if (resource_attributes) { 
     resource_attributes_local_nonprim = v1_resource_attributes_parseFromJSON(resource_attributes); //nonprimitive
     }

--- a/kubernetes/model/v1_self_subject_rules_review.c
+++ b/kubernetes/model/v1_self_subject_rules_review.c
@@ -125,6 +125,15 @@ v1_self_subject_rules_review_t *v1_self_subject_rules_review_parseFromJSON(cJSON
 
     v1_self_subject_rules_review_t *v1_self_subject_rules_review_local_var = NULL;
 
+    // define the local variable for v1_self_subject_rules_review->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_self_subject_rules_review->spec
+    v1_self_subject_rules_review_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_self_subject_rules_review->status
+    v1_subject_rules_review_status_t *status_local_nonprim = NULL;
+
     // v1_self_subject_rules_review->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_self_subject_rules_reviewJSON, "apiVersion");
     if (api_version) { 
@@ -145,7 +154,6 @@ v1_self_subject_rules_review_t *v1_self_subject_rules_review_parseFromJSON(cJSON
 
     // v1_self_subject_rules_review->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_self_subject_rules_reviewJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -156,13 +164,11 @@ v1_self_subject_rules_review_t *v1_self_subject_rules_review_parseFromJSON(cJSON
         goto end;
     }
 
-    v1_self_subject_rules_review_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_self_subject_rules_review_spec_parseFromJSON(spec); //nonprimitive
 
     // v1_self_subject_rules_review->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_self_subject_rules_reviewJSON, "status");
-    v1_subject_rules_review_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_subject_rules_review_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_service.c
+++ b/kubernetes/model/v1_service.c
@@ -123,6 +123,15 @@ v1_service_t *v1_service_parseFromJSON(cJSON *v1_serviceJSON){
 
     v1_service_t *v1_service_local_var = NULL;
 
+    // define the local variable for v1_service->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_service->spec
+    v1_service_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_service->status
+    v1_service_status_t *status_local_nonprim = NULL;
+
     // v1_service->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_serviceJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_service_t *v1_service_parseFromJSON(cJSON *v1_serviceJSON){
 
     // v1_service->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_serviceJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_service->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_serviceJSON, "spec");
-    v1_service_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_service_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_service->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_serviceJSON, "status");
-    v1_service_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_service_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_service_account.c
+++ b/kubernetes/model/v1_service_account.c
@@ -153,6 +153,9 @@ v1_service_account_t *v1_service_account_parseFromJSON(cJSON *v1_service_account
 
     v1_service_account_t *v1_service_account_local_var = NULL;
 
+    // define the local variable for v1_service_account->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_service_account->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_service_accountJSON, "apiVersion");
     if (api_version) { 
@@ -204,7 +207,6 @@ v1_service_account_t *v1_service_account_parseFromJSON(cJSON *v1_service_account
 
     // v1_service_account->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_service_accountJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_service_account_list.c
+++ b/kubernetes/model/v1_service_account_list.c
@@ -116,6 +116,9 @@ v1_service_account_list_t *v1_service_account_list_parseFromJSON(cJSON *v1_servi
 
     v1_service_account_list_t *v1_service_account_list_local_var = NULL;
 
+    // define the local variable for v1_service_account_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_service_account_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_service_account_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_service_account_list_t *v1_service_account_list_parseFromJSON(cJSON *v1_servi
 
     // v1_service_account_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_service_account_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_service_list.c
+++ b/kubernetes/model/v1_service_list.c
@@ -116,6 +116,9 @@ v1_service_list_t *v1_service_list_parseFromJSON(cJSON *v1_service_listJSON){
 
     v1_service_list_t *v1_service_list_local_var = NULL;
 
+    // define the local variable for v1_service_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_service_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_service_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_service_list_t *v1_service_list_parseFromJSON(cJSON *v1_service_listJSON){
 
     // v1_service_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_service_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_service_spec.c
+++ b/kubernetes/model/v1_service_spec.c
@@ -378,6 +378,9 @@ v1_service_spec_t *v1_service_spec_parseFromJSON(cJSON *v1_service_specJSON){
 
     v1_service_spec_t *v1_service_spec_local_var = NULL;
 
+    // define the local variable for v1_service_spec->session_affinity_config
+    v1_session_affinity_config_t *session_affinity_config_local_nonprim = NULL;
+
     // v1_service_spec->allocate_load_balancer_node_ports
     cJSON *allocate_load_balancer_node_ports = cJSON_GetObjectItemCaseSensitive(v1_service_specJSON, "allocateLoadBalancerNodePorts");
     if (allocate_load_balancer_node_ports) { 
@@ -603,7 +606,6 @@ v1_service_spec_t *v1_service_spec_parseFromJSON(cJSON *v1_service_specJSON){
 
     // v1_service_spec->session_affinity_config
     cJSON *session_affinity_config = cJSON_GetObjectItemCaseSensitive(v1_service_specJSON, "sessionAffinityConfig");
-    v1_session_affinity_config_t *session_affinity_config_local_nonprim = NULL;
     if (session_affinity_config) { 
     session_affinity_config_local_nonprim = v1_session_affinity_config_parseFromJSON(session_affinity_config); //nonprimitive
     }

--- a/kubernetes/model/v1_service_status.c
+++ b/kubernetes/model/v1_service_status.c
@@ -86,6 +86,9 @@ v1_service_status_t *v1_service_status_parseFromJSON(cJSON *v1_service_statusJSO
 
     v1_service_status_t *v1_service_status_local_var = NULL;
 
+    // define the local variable for v1_service_status->load_balancer
+    v1_load_balancer_status_t *load_balancer_local_nonprim = NULL;
+
     // v1_service_status->conditions
     cJSON *conditions = cJSON_GetObjectItemCaseSensitive(v1_service_statusJSON, "conditions");
     list_t *conditionsList;
@@ -110,7 +113,6 @@ v1_service_status_t *v1_service_status_parseFromJSON(cJSON *v1_service_statusJSO
 
     // v1_service_status->load_balancer
     cJSON *load_balancer = cJSON_GetObjectItemCaseSensitive(v1_service_statusJSON, "loadBalancer");
-    v1_load_balancer_status_t *load_balancer_local_nonprim = NULL;
     if (load_balancer) { 
     load_balancer_local_nonprim = v1_load_balancer_status_parseFromJSON(load_balancer); //nonprimitive
     }

--- a/kubernetes/model/v1_session_affinity_config.c
+++ b/kubernetes/model/v1_session_affinity_config.c
@@ -57,9 +57,11 @@ v1_session_affinity_config_t *v1_session_affinity_config_parseFromJSON(cJSON *v1
 
     v1_session_affinity_config_t *v1_session_affinity_config_local_var = NULL;
 
+    // define the local variable for v1_session_affinity_config->client_ip
+    v1_client_ip_config_t *client_ip_local_nonprim = NULL;
+
     // v1_session_affinity_config->client_ip
     cJSON *client_ip = cJSON_GetObjectItemCaseSensitive(v1_session_affinity_configJSON, "clientIP");
-    v1_client_ip_config_t *client_ip_local_nonprim = NULL;
     if (client_ip) { 
     client_ip_local_nonprim = v1_client_ip_config_parseFromJSON(client_ip); //nonprimitive
     }

--- a/kubernetes/model/v1_stateful_set.c
+++ b/kubernetes/model/v1_stateful_set.c
@@ -123,6 +123,15 @@ v1_stateful_set_t *v1_stateful_set_parseFromJSON(cJSON *v1_stateful_setJSON){
 
     v1_stateful_set_t *v1_stateful_set_local_var = NULL;
 
+    // define the local variable for v1_stateful_set->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_stateful_set->spec
+    v1_stateful_set_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_stateful_set->status
+    v1_stateful_set_status_t *status_local_nonprim = NULL;
+
     // v1_stateful_set->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_stateful_setJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1_stateful_set_t *v1_stateful_set_parseFromJSON(cJSON *v1_stateful_setJSON){
 
     // v1_stateful_set->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_stateful_setJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1_stateful_set->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1_stateful_setJSON, "spec");
-    v1_stateful_set_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_stateful_set_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1_stateful_set->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_stateful_setJSON, "status");
-    v1_stateful_set_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_stateful_set_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_stateful_set_list.c
+++ b/kubernetes/model/v1_stateful_set_list.c
@@ -116,6 +116,9 @@ v1_stateful_set_list_t *v1_stateful_set_list_parseFromJSON(cJSON *v1_stateful_se
 
     v1_stateful_set_list_t *v1_stateful_set_list_local_var = NULL;
 
+    // define the local variable for v1_stateful_set_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_stateful_set_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_stateful_set_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_stateful_set_list_t *v1_stateful_set_list_parseFromJSON(cJSON *v1_stateful_se
 
     // v1_stateful_set_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_stateful_set_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_stateful_set_spec.c
+++ b/kubernetes/model/v1_stateful_set_spec.c
@@ -188,6 +188,15 @@ v1_stateful_set_spec_t *v1_stateful_set_spec_parseFromJSON(cJSON *v1_stateful_se
 
     v1_stateful_set_spec_t *v1_stateful_set_spec_local_var = NULL;
 
+    // define the local variable for v1_stateful_set_spec->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
+    // define the local variable for v1_stateful_set_spec->_template
+    v1_pod_template_spec_t *_template_local_nonprim = NULL;
+
+    // define the local variable for v1_stateful_set_spec->update_strategy
+    v1_stateful_set_update_strategy_t *update_strategy_local_nonprim = NULL;
+
     // v1_stateful_set_spec->min_ready_seconds
     cJSON *min_ready_seconds = cJSON_GetObjectItemCaseSensitive(v1_stateful_set_specJSON, "minReadySeconds");
     if (min_ready_seconds) { 
@@ -230,7 +239,6 @@ v1_stateful_set_spec_t *v1_stateful_set_spec_parseFromJSON(cJSON *v1_stateful_se
         goto end;
     }
 
-    v1_label_selector_t *selector_local_nonprim = NULL;
     
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
 
@@ -252,13 +260,11 @@ v1_stateful_set_spec_t *v1_stateful_set_spec_parseFromJSON(cJSON *v1_stateful_se
         goto end;
     }
 
-    v1_pod_template_spec_t *_template_local_nonprim = NULL;
     
     _template_local_nonprim = v1_pod_template_spec_parseFromJSON(_template); //nonprimitive
 
     // v1_stateful_set_spec->update_strategy
     cJSON *update_strategy = cJSON_GetObjectItemCaseSensitive(v1_stateful_set_specJSON, "updateStrategy");
-    v1_stateful_set_update_strategy_t *update_strategy_local_nonprim = NULL;
     if (update_strategy) { 
     update_strategy_local_nonprim = v1_stateful_set_update_strategy_parseFromJSON(update_strategy); //nonprimitive
     }

--- a/kubernetes/model/v1_stateful_set_update_strategy.c
+++ b/kubernetes/model/v1_stateful_set_update_strategy.c
@@ -71,9 +71,11 @@ v1_stateful_set_update_strategy_t *v1_stateful_set_update_strategy_parseFromJSON
 
     v1_stateful_set_update_strategy_t *v1_stateful_set_update_strategy_local_var = NULL;
 
+    // define the local variable for v1_stateful_set_update_strategy->rolling_update
+    v1_rolling_update_stateful_set_strategy_t *rolling_update_local_nonprim = NULL;
+
     // v1_stateful_set_update_strategy->rolling_update
     cJSON *rolling_update = cJSON_GetObjectItemCaseSensitive(v1_stateful_set_update_strategyJSON, "rollingUpdate");
-    v1_rolling_update_stateful_set_strategy_t *rolling_update_local_nonprim = NULL;
     if (rolling_update) { 
     rolling_update_local_nonprim = v1_rolling_update_stateful_set_strategy_parseFromJSON(rolling_update); //nonprimitive
     }

--- a/kubernetes/model/v1_status.c
+++ b/kubernetes/model/v1_status.c
@@ -156,6 +156,12 @@ v1_status_t *v1_status_parseFromJSON(cJSON *v1_statusJSON){
 
     v1_status_t *v1_status_local_var = NULL;
 
+    // define the local variable for v1_status->details
+    v1_status_details_t *details_local_nonprim = NULL;
+
+    // define the local variable for v1_status->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_status->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_statusJSON, "apiVersion");
     if (api_version) { 
@@ -176,7 +182,6 @@ v1_status_t *v1_status_parseFromJSON(cJSON *v1_statusJSON){
 
     // v1_status->details
     cJSON *details = cJSON_GetObjectItemCaseSensitive(v1_statusJSON, "details");
-    v1_status_details_t *details_local_nonprim = NULL;
     if (details) { 
     details_local_nonprim = v1_status_details_parseFromJSON(details); //nonprimitive
     }
@@ -201,7 +206,6 @@ v1_status_t *v1_status_parseFromJSON(cJSON *v1_statusJSON){
 
     // v1_status->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_statusJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_storage_class.c
+++ b/kubernetes/model/v1_storage_class.c
@@ -226,6 +226,9 @@ v1_storage_class_t *v1_storage_class_parseFromJSON(cJSON *v1_storage_classJSON){
 
     v1_storage_class_t *v1_storage_class_local_var = NULL;
 
+    // define the local variable for v1_storage_class->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_storage_class->allow_volume_expansion
     cJSON *allow_volume_expansion = cJSON_GetObjectItemCaseSensitive(v1_storage_classJSON, "allowVolumeExpansion");
     if (allow_volume_expansion) { 
@@ -277,7 +280,6 @@ v1_storage_class_t *v1_storage_class_parseFromJSON(cJSON *v1_storage_classJSON){
 
     // v1_storage_class->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_storage_classJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_storage_class_list.c
+++ b/kubernetes/model/v1_storage_class_list.c
@@ -116,6 +116,9 @@ v1_storage_class_list_t *v1_storage_class_list_parseFromJSON(cJSON *v1_storage_c
 
     v1_storage_class_list_t *v1_storage_class_list_local_var = NULL;
 
+    // define the local variable for v1_storage_class_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_storage_class_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_storage_class_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_storage_class_list_t *v1_storage_class_list_parseFromJSON(cJSON *v1_storage_c
 
     // v1_storage_class_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_storage_class_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_storage_os_persistent_volume_source.c
+++ b/kubernetes/model/v1_storage_os_persistent_volume_source.c
@@ -109,6 +109,9 @@ v1_storage_os_persistent_volume_source_t *v1_storage_os_persistent_volume_source
 
     v1_storage_os_persistent_volume_source_t *v1_storage_os_persistent_volume_source_local_var = NULL;
 
+    // define the local variable for v1_storage_os_persistent_volume_source->secret_ref
+    v1_object_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_storage_os_persistent_volume_source->fs_type
     cJSON *fs_type = cJSON_GetObjectItemCaseSensitive(v1_storage_os_persistent_volume_sourceJSON, "fsType");
     if (fs_type) { 
@@ -129,7 +132,6 @@ v1_storage_os_persistent_volume_source_t *v1_storage_os_persistent_volume_source
 
     // v1_storage_os_persistent_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_storage_os_persistent_volume_sourceJSON, "secretRef");
-    v1_object_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_object_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_storage_os_volume_source.c
+++ b/kubernetes/model/v1_storage_os_volume_source.c
@@ -109,6 +109,9 @@ v1_storage_os_volume_source_t *v1_storage_os_volume_source_parseFromJSON(cJSON *
 
     v1_storage_os_volume_source_t *v1_storage_os_volume_source_local_var = NULL;
 
+    // define the local variable for v1_storage_os_volume_source->secret_ref
+    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
+
     // v1_storage_os_volume_source->fs_type
     cJSON *fs_type = cJSON_GetObjectItemCaseSensitive(v1_storage_os_volume_sourceJSON, "fsType");
     if (fs_type) { 
@@ -129,7 +132,6 @@ v1_storage_os_volume_source_t *v1_storage_os_volume_source_parseFromJSON(cJSON *
 
     // v1_storage_os_volume_source->secret_ref
     cJSON *secret_ref = cJSON_GetObjectItemCaseSensitive(v1_storage_os_volume_sourceJSON, "secretRef");
-    v1_local_object_reference_t *secret_ref_local_nonprim = NULL;
     if (secret_ref) { 
     secret_ref_local_nonprim = v1_local_object_reference_parseFromJSON(secret_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_subject_access_review.c
+++ b/kubernetes/model/v1_subject_access_review.c
@@ -125,6 +125,15 @@ v1_subject_access_review_t *v1_subject_access_review_parseFromJSON(cJSON *v1_sub
 
     v1_subject_access_review_t *v1_subject_access_review_local_var = NULL;
 
+    // define the local variable for v1_subject_access_review->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_subject_access_review->spec
+    v1_subject_access_review_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_subject_access_review->status
+    v1_subject_access_review_status_t *status_local_nonprim = NULL;
+
     // v1_subject_access_review->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_subject_access_reviewJSON, "apiVersion");
     if (api_version) { 
@@ -145,7 +154,6 @@ v1_subject_access_review_t *v1_subject_access_review_parseFromJSON(cJSON *v1_sub
 
     // v1_subject_access_review->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_subject_access_reviewJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -156,13 +164,11 @@ v1_subject_access_review_t *v1_subject_access_review_parseFromJSON(cJSON *v1_sub
         goto end;
     }
 
-    v1_subject_access_review_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_subject_access_review_spec_parseFromJSON(spec); //nonprimitive
 
     // v1_subject_access_review->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_subject_access_reviewJSON, "status");
-    v1_subject_access_review_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_subject_access_review_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_subject_access_review_spec.c
+++ b/kubernetes/model/v1_subject_access_review_spec.c
@@ -158,6 +158,12 @@ v1_subject_access_review_spec_t *v1_subject_access_review_spec_parseFromJSON(cJS
 
     v1_subject_access_review_spec_t *v1_subject_access_review_spec_local_var = NULL;
 
+    // define the local variable for v1_subject_access_review_spec->non_resource_attributes
+    v1_non_resource_attributes_t *non_resource_attributes_local_nonprim = NULL;
+
+    // define the local variable for v1_subject_access_review_spec->resource_attributes
+    v1_resource_attributes_t *resource_attributes_local_nonprim = NULL;
+
     // v1_subject_access_review_spec->extra
     cJSON *extra = cJSON_GetObjectItemCaseSensitive(v1_subject_access_review_specJSON, "extra");
     list_t *extraList;
@@ -197,14 +203,12 @@ v1_subject_access_review_spec_t *v1_subject_access_review_spec_parseFromJSON(cJS
 
     // v1_subject_access_review_spec->non_resource_attributes
     cJSON *non_resource_attributes = cJSON_GetObjectItemCaseSensitive(v1_subject_access_review_specJSON, "nonResourceAttributes");
-    v1_non_resource_attributes_t *non_resource_attributes_local_nonprim = NULL;
     if (non_resource_attributes) { 
     non_resource_attributes_local_nonprim = v1_non_resource_attributes_parseFromJSON(non_resource_attributes); //nonprimitive
     }
 
     // v1_subject_access_review_spec->resource_attributes
     cJSON *resource_attributes = cJSON_GetObjectItemCaseSensitive(v1_subject_access_review_specJSON, "resourceAttributes");
-    v1_resource_attributes_t *resource_attributes_local_nonprim = NULL;
     if (resource_attributes) { 
     resource_attributes_local_nonprim = v1_resource_attributes_parseFromJSON(resource_attributes); //nonprimitive
     }

--- a/kubernetes/model/v1_token_request_spec.c
+++ b/kubernetes/model/v1_token_request_spec.c
@@ -95,6 +95,9 @@ v1_token_request_spec_t *v1_token_request_spec_parseFromJSON(cJSON *v1_token_req
 
     v1_token_request_spec_t *v1_token_request_spec_local_var = NULL;
 
+    // define the local variable for v1_token_request_spec->bound_object_ref
+    v1_bound_object_reference_t *bound_object_ref_local_nonprim = NULL;
+
     // v1_token_request_spec->audiences
     cJSON *audiences = cJSON_GetObjectItemCaseSensitive(v1_token_request_specJSON, "audiences");
     if (!audiences) {
@@ -120,7 +123,6 @@ v1_token_request_spec_t *v1_token_request_spec_parseFromJSON(cJSON *v1_token_req
 
     // v1_token_request_spec->bound_object_ref
     cJSON *bound_object_ref = cJSON_GetObjectItemCaseSensitive(v1_token_request_specJSON, "boundObjectRef");
-    v1_bound_object_reference_t *bound_object_ref_local_nonprim = NULL;
     if (bound_object_ref) { 
     bound_object_ref_local_nonprim = v1_bound_object_reference_parseFromJSON(bound_object_ref); //nonprimitive
     }

--- a/kubernetes/model/v1_token_review.c
+++ b/kubernetes/model/v1_token_review.c
@@ -125,6 +125,15 @@ v1_token_review_t *v1_token_review_parseFromJSON(cJSON *v1_token_reviewJSON){
 
     v1_token_review_t *v1_token_review_local_var = NULL;
 
+    // define the local variable for v1_token_review->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_token_review->spec
+    v1_token_review_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_token_review->status
+    v1_token_review_status_t *status_local_nonprim = NULL;
+
     // v1_token_review->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_token_reviewJSON, "apiVersion");
     if (api_version) { 
@@ -145,7 +154,6 @@ v1_token_review_t *v1_token_review_parseFromJSON(cJSON *v1_token_reviewJSON){
 
     // v1_token_review->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_token_reviewJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -156,13 +164,11 @@ v1_token_review_t *v1_token_review_parseFromJSON(cJSON *v1_token_reviewJSON){
         goto end;
     }
 
-    v1_token_review_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_token_review_spec_parseFromJSON(spec); //nonprimitive
 
     // v1_token_review->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_token_reviewJSON, "status");
-    v1_token_review_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_token_review_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_token_review_status.c
+++ b/kubernetes/model/v1_token_review_status.c
@@ -107,6 +107,9 @@ v1_token_review_status_t *v1_token_review_status_parseFromJSON(cJSON *v1_token_r
 
     v1_token_review_status_t *v1_token_review_status_local_var = NULL;
 
+    // define the local variable for v1_token_review_status->user
+    v1_user_info_t *user_local_nonprim = NULL;
+
     // v1_token_review_status->audiences
     cJSON *audiences = cJSON_GetObjectItemCaseSensitive(v1_token_review_statusJSON, "audiences");
     list_t *audiencesList;
@@ -147,7 +150,6 @@ v1_token_review_status_t *v1_token_review_status_parseFromJSON(cJSON *v1_token_r
 
     // v1_token_review_status->user
     cJSON *user = cJSON_GetObjectItemCaseSensitive(v1_token_review_statusJSON, "user");
-    v1_user_info_t *user_local_nonprim = NULL;
     if (user) { 
     user_local_nonprim = v1_user_info_parseFromJSON(user); //nonprimitive
     }

--- a/kubernetes/model/v1_topology_spread_constraint.c
+++ b/kubernetes/model/v1_topology_spread_constraint.c
@@ -101,9 +101,11 @@ v1_topology_spread_constraint_t *v1_topology_spread_constraint_parseFromJSON(cJS
 
     v1_topology_spread_constraint_t *v1_topology_spread_constraint_local_var = NULL;
 
+    // define the local variable for v1_topology_spread_constraint->label_selector
+    v1_label_selector_t *label_selector_local_nonprim = NULL;
+
     // v1_topology_spread_constraint->label_selector
     cJSON *label_selector = cJSON_GetObjectItemCaseSensitive(v1_topology_spread_constraintJSON, "labelSelector");
-    v1_label_selector_t *label_selector_local_nonprim = NULL;
     if (label_selector) { 
     label_selector_local_nonprim = v1_label_selector_parseFromJSON(label_selector); //nonprimitive
     }

--- a/kubernetes/model/v1_validating_webhook.c
+++ b/kubernetes/model/v1_validating_webhook.c
@@ -224,6 +224,15 @@ v1_validating_webhook_t *v1_validating_webhook_parseFromJSON(cJSON *v1_validatin
 
     v1_validating_webhook_t *v1_validating_webhook_local_var = NULL;
 
+    // define the local variable for v1_validating_webhook->client_config
+    admissionregistration_v1_webhook_client_config_t *client_config_local_nonprim = NULL;
+
+    // define the local variable for v1_validating_webhook->namespace_selector
+    v1_label_selector_t *namespace_selector_local_nonprim = NULL;
+
+    // define the local variable for v1_validating_webhook->object_selector
+    v1_label_selector_t *object_selector_local_nonprim = NULL;
+
     // v1_validating_webhook->admission_review_versions
     cJSON *admission_review_versions = cJSON_GetObjectItemCaseSensitive(v1_validating_webhookJSON, "admissionReviewVersions");
     if (!admission_review_versions) {
@@ -253,7 +262,6 @@ v1_validating_webhook_t *v1_validating_webhook_parseFromJSON(cJSON *v1_validatin
         goto end;
     }
 
-    admissionregistration_v1_webhook_client_config_t *client_config_local_nonprim = NULL;
     
     client_config_local_nonprim = admissionregistration_v1_webhook_client_config_parseFromJSON(client_config); //nonprimitive
 
@@ -289,14 +297,12 @@ v1_validating_webhook_t *v1_validating_webhook_parseFromJSON(cJSON *v1_validatin
 
     // v1_validating_webhook->namespace_selector
     cJSON *namespace_selector = cJSON_GetObjectItemCaseSensitive(v1_validating_webhookJSON, "namespaceSelector");
-    v1_label_selector_t *namespace_selector_local_nonprim = NULL;
     if (namespace_selector) { 
     namespace_selector_local_nonprim = v1_label_selector_parseFromJSON(namespace_selector); //nonprimitive
     }
 
     // v1_validating_webhook->object_selector
     cJSON *object_selector = cJSON_GetObjectItemCaseSensitive(v1_validating_webhookJSON, "objectSelector");
-    v1_label_selector_t *object_selector_local_nonprim = NULL;
     if (object_selector) { 
     object_selector_local_nonprim = v1_label_selector_parseFromJSON(object_selector); //nonprimitive
     }

--- a/kubernetes/model/v1_validating_webhook_configuration.c
+++ b/kubernetes/model/v1_validating_webhook_configuration.c
@@ -114,6 +114,9 @@ v1_validating_webhook_configuration_t *v1_validating_webhook_configuration_parse
 
     v1_validating_webhook_configuration_t *v1_validating_webhook_configuration_local_var = NULL;
 
+    // define the local variable for v1_validating_webhook_configuration->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1_validating_webhook_configuration->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_validating_webhook_configurationJSON, "apiVersion");
     if (api_version) { 
@@ -134,7 +137,6 @@ v1_validating_webhook_configuration_t *v1_validating_webhook_configuration_parse
 
     // v1_validating_webhook_configuration->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_validating_webhook_configurationJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_validating_webhook_configuration_list.c
+++ b/kubernetes/model/v1_validating_webhook_configuration_list.c
@@ -116,6 +116,9 @@ v1_validating_webhook_configuration_list_t *v1_validating_webhook_configuration_
 
     v1_validating_webhook_configuration_list_t *v1_validating_webhook_configuration_list_local_var = NULL;
 
+    // define the local variable for v1_validating_webhook_configuration_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_validating_webhook_configuration_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_validating_webhook_configuration_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_validating_webhook_configuration_list_t *v1_validating_webhook_configuration_
 
     // v1_validating_webhook_configuration_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_validating_webhook_configuration_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_volume.c
+++ b/kubernetes/model/v1_volume.c
@@ -605,128 +605,197 @@ v1_volume_t *v1_volume_parseFromJSON(cJSON *v1_volumeJSON){
 
     v1_volume_t *v1_volume_local_var = NULL;
 
+    // define the local variable for v1_volume->aws_elastic_block_store
+    v1_aws_elastic_block_store_volume_source_t *aws_elastic_block_store_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->azure_disk
+    v1_azure_disk_volume_source_t *azure_disk_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->azure_file
+    v1_azure_file_volume_source_t *azure_file_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->cephfs
+    v1_ceph_fs_volume_source_t *cephfs_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->cinder
+    v1_cinder_volume_source_t *cinder_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->config_map
+    v1_config_map_volume_source_t *config_map_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->csi
+    v1_csi_volume_source_t *csi_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->downward_api
+    v1_downward_api_volume_source_t *downward_api_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->empty_dir
+    v1_empty_dir_volume_source_t *empty_dir_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->ephemeral
+    v1_ephemeral_volume_source_t *ephemeral_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->fc
+    v1_fc_volume_source_t *fc_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->flex_volume
+    v1_flex_volume_source_t *flex_volume_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->flocker
+    v1_flocker_volume_source_t *flocker_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->gce_persistent_disk
+    v1_gce_persistent_disk_volume_source_t *gce_persistent_disk_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->git_repo
+    v1_git_repo_volume_source_t *git_repo_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->glusterfs
+    v1_glusterfs_volume_source_t *glusterfs_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->host_path
+    v1_host_path_volume_source_t *host_path_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->iscsi
+    v1_iscsi_volume_source_t *iscsi_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->nfs
+    v1_nfs_volume_source_t *nfs_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->persistent_volume_claim
+    v1_persistent_volume_claim_volume_source_t *persistent_volume_claim_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->photon_persistent_disk
+    v1_photon_persistent_disk_volume_source_t *photon_persistent_disk_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->portworx_volume
+    v1_portworx_volume_source_t *portworx_volume_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->projected
+    v1_projected_volume_source_t *projected_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->quobyte
+    v1_quobyte_volume_source_t *quobyte_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->rbd
+    v1_rbd_volume_source_t *rbd_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->scale_io
+    v1_scale_io_volume_source_t *scale_io_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->secret
+    v1_secret_volume_source_t *secret_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->storageos
+    v1_storage_os_volume_source_t *storageos_local_nonprim = NULL;
+
+    // define the local variable for v1_volume->vsphere_volume
+    v1_vsphere_virtual_disk_volume_source_t *vsphere_volume_local_nonprim = NULL;
+
     // v1_volume->aws_elastic_block_store
     cJSON *aws_elastic_block_store = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "awsElasticBlockStore");
-    v1_aws_elastic_block_store_volume_source_t *aws_elastic_block_store_local_nonprim = NULL;
     if (aws_elastic_block_store) { 
     aws_elastic_block_store_local_nonprim = v1_aws_elastic_block_store_volume_source_parseFromJSON(aws_elastic_block_store); //nonprimitive
     }
 
     // v1_volume->azure_disk
     cJSON *azure_disk = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "azureDisk");
-    v1_azure_disk_volume_source_t *azure_disk_local_nonprim = NULL;
     if (azure_disk) { 
     azure_disk_local_nonprim = v1_azure_disk_volume_source_parseFromJSON(azure_disk); //nonprimitive
     }
 
     // v1_volume->azure_file
     cJSON *azure_file = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "azureFile");
-    v1_azure_file_volume_source_t *azure_file_local_nonprim = NULL;
     if (azure_file) { 
     azure_file_local_nonprim = v1_azure_file_volume_source_parseFromJSON(azure_file); //nonprimitive
     }
 
     // v1_volume->cephfs
     cJSON *cephfs = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "cephfs");
-    v1_ceph_fs_volume_source_t *cephfs_local_nonprim = NULL;
     if (cephfs) { 
     cephfs_local_nonprim = v1_ceph_fs_volume_source_parseFromJSON(cephfs); //nonprimitive
     }
 
     // v1_volume->cinder
     cJSON *cinder = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "cinder");
-    v1_cinder_volume_source_t *cinder_local_nonprim = NULL;
     if (cinder) { 
     cinder_local_nonprim = v1_cinder_volume_source_parseFromJSON(cinder); //nonprimitive
     }
 
     // v1_volume->config_map
     cJSON *config_map = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "configMap");
-    v1_config_map_volume_source_t *config_map_local_nonprim = NULL;
     if (config_map) { 
     config_map_local_nonprim = v1_config_map_volume_source_parseFromJSON(config_map); //nonprimitive
     }
 
     // v1_volume->csi
     cJSON *csi = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "csi");
-    v1_csi_volume_source_t *csi_local_nonprim = NULL;
     if (csi) { 
     csi_local_nonprim = v1_csi_volume_source_parseFromJSON(csi); //nonprimitive
     }
 
     // v1_volume->downward_api
     cJSON *downward_api = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "downwardAPI");
-    v1_downward_api_volume_source_t *downward_api_local_nonprim = NULL;
     if (downward_api) { 
     downward_api_local_nonprim = v1_downward_api_volume_source_parseFromJSON(downward_api); //nonprimitive
     }
 
     // v1_volume->empty_dir
     cJSON *empty_dir = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "emptyDir");
-    v1_empty_dir_volume_source_t *empty_dir_local_nonprim = NULL;
     if (empty_dir) { 
     empty_dir_local_nonprim = v1_empty_dir_volume_source_parseFromJSON(empty_dir); //nonprimitive
     }
 
     // v1_volume->ephemeral
     cJSON *ephemeral = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "ephemeral");
-    v1_ephemeral_volume_source_t *ephemeral_local_nonprim = NULL;
     if (ephemeral) { 
     ephemeral_local_nonprim = v1_ephemeral_volume_source_parseFromJSON(ephemeral); //nonprimitive
     }
 
     // v1_volume->fc
     cJSON *fc = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "fc");
-    v1_fc_volume_source_t *fc_local_nonprim = NULL;
     if (fc) { 
     fc_local_nonprim = v1_fc_volume_source_parseFromJSON(fc); //nonprimitive
     }
 
     // v1_volume->flex_volume
     cJSON *flex_volume = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "flexVolume");
-    v1_flex_volume_source_t *flex_volume_local_nonprim = NULL;
     if (flex_volume) { 
     flex_volume_local_nonprim = v1_flex_volume_source_parseFromJSON(flex_volume); //nonprimitive
     }
 
     // v1_volume->flocker
     cJSON *flocker = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "flocker");
-    v1_flocker_volume_source_t *flocker_local_nonprim = NULL;
     if (flocker) { 
     flocker_local_nonprim = v1_flocker_volume_source_parseFromJSON(flocker); //nonprimitive
     }
 
     // v1_volume->gce_persistent_disk
     cJSON *gce_persistent_disk = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "gcePersistentDisk");
-    v1_gce_persistent_disk_volume_source_t *gce_persistent_disk_local_nonprim = NULL;
     if (gce_persistent_disk) { 
     gce_persistent_disk_local_nonprim = v1_gce_persistent_disk_volume_source_parseFromJSON(gce_persistent_disk); //nonprimitive
     }
 
     // v1_volume->git_repo
     cJSON *git_repo = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "gitRepo");
-    v1_git_repo_volume_source_t *git_repo_local_nonprim = NULL;
     if (git_repo) { 
     git_repo_local_nonprim = v1_git_repo_volume_source_parseFromJSON(git_repo); //nonprimitive
     }
 
     // v1_volume->glusterfs
     cJSON *glusterfs = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "glusterfs");
-    v1_glusterfs_volume_source_t *glusterfs_local_nonprim = NULL;
     if (glusterfs) { 
     glusterfs_local_nonprim = v1_glusterfs_volume_source_parseFromJSON(glusterfs); //nonprimitive
     }
 
     // v1_volume->host_path
     cJSON *host_path = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "hostPath");
-    v1_host_path_volume_source_t *host_path_local_nonprim = NULL;
     if (host_path) { 
     host_path_local_nonprim = v1_host_path_volume_source_parseFromJSON(host_path); //nonprimitive
     }
 
     // v1_volume->iscsi
     cJSON *iscsi = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "iscsi");
-    v1_iscsi_volume_source_t *iscsi_local_nonprim = NULL;
     if (iscsi) { 
     iscsi_local_nonprim = v1_iscsi_volume_source_parseFromJSON(iscsi); //nonprimitive
     }
@@ -745,77 +814,66 @@ v1_volume_t *v1_volume_parseFromJSON(cJSON *v1_volumeJSON){
 
     // v1_volume->nfs
     cJSON *nfs = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "nfs");
-    v1_nfs_volume_source_t *nfs_local_nonprim = NULL;
     if (nfs) { 
     nfs_local_nonprim = v1_nfs_volume_source_parseFromJSON(nfs); //nonprimitive
     }
 
     // v1_volume->persistent_volume_claim
     cJSON *persistent_volume_claim = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "persistentVolumeClaim");
-    v1_persistent_volume_claim_volume_source_t *persistent_volume_claim_local_nonprim = NULL;
     if (persistent_volume_claim) { 
     persistent_volume_claim_local_nonprim = v1_persistent_volume_claim_volume_source_parseFromJSON(persistent_volume_claim); //nonprimitive
     }
 
     // v1_volume->photon_persistent_disk
     cJSON *photon_persistent_disk = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "photonPersistentDisk");
-    v1_photon_persistent_disk_volume_source_t *photon_persistent_disk_local_nonprim = NULL;
     if (photon_persistent_disk) { 
     photon_persistent_disk_local_nonprim = v1_photon_persistent_disk_volume_source_parseFromJSON(photon_persistent_disk); //nonprimitive
     }
 
     // v1_volume->portworx_volume
     cJSON *portworx_volume = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "portworxVolume");
-    v1_portworx_volume_source_t *portworx_volume_local_nonprim = NULL;
     if (portworx_volume) { 
     portworx_volume_local_nonprim = v1_portworx_volume_source_parseFromJSON(portworx_volume); //nonprimitive
     }
 
     // v1_volume->projected
     cJSON *projected = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "projected");
-    v1_projected_volume_source_t *projected_local_nonprim = NULL;
     if (projected) { 
     projected_local_nonprim = v1_projected_volume_source_parseFromJSON(projected); //nonprimitive
     }
 
     // v1_volume->quobyte
     cJSON *quobyte = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "quobyte");
-    v1_quobyte_volume_source_t *quobyte_local_nonprim = NULL;
     if (quobyte) { 
     quobyte_local_nonprim = v1_quobyte_volume_source_parseFromJSON(quobyte); //nonprimitive
     }
 
     // v1_volume->rbd
     cJSON *rbd = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "rbd");
-    v1_rbd_volume_source_t *rbd_local_nonprim = NULL;
     if (rbd) { 
     rbd_local_nonprim = v1_rbd_volume_source_parseFromJSON(rbd); //nonprimitive
     }
 
     // v1_volume->scale_io
     cJSON *scale_io = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "scaleIO");
-    v1_scale_io_volume_source_t *scale_io_local_nonprim = NULL;
     if (scale_io) { 
     scale_io_local_nonprim = v1_scale_io_volume_source_parseFromJSON(scale_io); //nonprimitive
     }
 
     // v1_volume->secret
     cJSON *secret = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "secret");
-    v1_secret_volume_source_t *secret_local_nonprim = NULL;
     if (secret) { 
     secret_local_nonprim = v1_secret_volume_source_parseFromJSON(secret); //nonprimitive
     }
 
     // v1_volume->storageos
     cJSON *storageos = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "storageos");
-    v1_storage_os_volume_source_t *storageos_local_nonprim = NULL;
     if (storageos) { 
     storageos_local_nonprim = v1_storage_os_volume_source_parseFromJSON(storageos); //nonprimitive
     }
 
     // v1_volume->vsphere_volume
     cJSON *vsphere_volume = cJSON_GetObjectItemCaseSensitive(v1_volumeJSON, "vsphereVolume");
-    v1_vsphere_virtual_disk_volume_source_t *vsphere_volume_local_nonprim = NULL;
     if (vsphere_volume) { 
     vsphere_volume_local_nonprim = v1_vsphere_virtual_disk_volume_source_parseFromJSON(vsphere_volume); //nonprimitive
     }

--- a/kubernetes/model/v1_volume_attachment.c
+++ b/kubernetes/model/v1_volume_attachment.c
@@ -125,6 +125,15 @@ v1_volume_attachment_t *v1_volume_attachment_parseFromJSON(cJSON *v1_volume_atta
 
     v1_volume_attachment_t *v1_volume_attachment_local_var = NULL;
 
+    // define the local variable for v1_volume_attachment->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1_volume_attachment->spec
+    v1_volume_attachment_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1_volume_attachment->status
+    v1_volume_attachment_status_t *status_local_nonprim = NULL;
+
     // v1_volume_attachment->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_volume_attachmentJSON, "apiVersion");
     if (api_version) { 
@@ -145,7 +154,6 @@ v1_volume_attachment_t *v1_volume_attachment_parseFromJSON(cJSON *v1_volume_atta
 
     // v1_volume_attachment->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_volume_attachmentJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -156,13 +164,11 @@ v1_volume_attachment_t *v1_volume_attachment_parseFromJSON(cJSON *v1_volume_atta
         goto end;
     }
 
-    v1_volume_attachment_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1_volume_attachment_spec_parseFromJSON(spec); //nonprimitive
 
     // v1_volume_attachment->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1_volume_attachmentJSON, "status");
-    v1_volume_attachment_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1_volume_attachment_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1_volume_attachment_list.c
+++ b/kubernetes/model/v1_volume_attachment_list.c
@@ -116,6 +116,9 @@ v1_volume_attachment_list_t *v1_volume_attachment_list_parseFromJSON(cJSON *v1_v
 
     v1_volume_attachment_list_t *v1_volume_attachment_list_local_var = NULL;
 
+    // define the local variable for v1_volume_attachment_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1_volume_attachment_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1_volume_attachment_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1_volume_attachment_list_t *v1_volume_attachment_list_parseFromJSON(cJSON *v1_v
 
     // v1_volume_attachment_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1_volume_attachment_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1_volume_attachment_source.c
+++ b/kubernetes/model/v1_volume_attachment_source.c
@@ -71,9 +71,11 @@ v1_volume_attachment_source_t *v1_volume_attachment_source_parseFromJSON(cJSON *
 
     v1_volume_attachment_source_t *v1_volume_attachment_source_local_var = NULL;
 
+    // define the local variable for v1_volume_attachment_source->inline_volume_spec
+    v1_persistent_volume_spec_t *inline_volume_spec_local_nonprim = NULL;
+
     // v1_volume_attachment_source->inline_volume_spec
     cJSON *inline_volume_spec = cJSON_GetObjectItemCaseSensitive(v1_volume_attachment_sourceJSON, "inlineVolumeSpec");
-    v1_persistent_volume_spec_t *inline_volume_spec_local_nonprim = NULL;
     if (inline_volume_spec) { 
     inline_volume_spec_local_nonprim = v1_persistent_volume_spec_parseFromJSON(inline_volume_spec); //nonprimitive
     }

--- a/kubernetes/model/v1_volume_attachment_spec.c
+++ b/kubernetes/model/v1_volume_attachment_spec.c
@@ -91,6 +91,9 @@ v1_volume_attachment_spec_t *v1_volume_attachment_spec_parseFromJSON(cJSON *v1_v
 
     v1_volume_attachment_spec_t *v1_volume_attachment_spec_local_var = NULL;
 
+    // define the local variable for v1_volume_attachment_spec->source
+    v1_volume_attachment_source_t *source_local_nonprim = NULL;
+
     // v1_volume_attachment_spec->attacher
     cJSON *attacher = cJSON_GetObjectItemCaseSensitive(v1_volume_attachment_specJSON, "attacher");
     if (!attacher) {
@@ -121,7 +124,6 @@ v1_volume_attachment_spec_t *v1_volume_attachment_spec_parseFromJSON(cJSON *v1_v
         goto end;
     }
 
-    v1_volume_attachment_source_t *source_local_nonprim = NULL;
     
     source_local_nonprim = v1_volume_attachment_source_parseFromJSON(source); //nonprimitive
 

--- a/kubernetes/model/v1_volume_attachment_status.c
+++ b/kubernetes/model/v1_volume_attachment_status.c
@@ -120,9 +120,14 @@ v1_volume_attachment_status_t *v1_volume_attachment_status_parseFromJSON(cJSON *
 
     v1_volume_attachment_status_t *v1_volume_attachment_status_local_var = NULL;
 
+    // define the local variable for v1_volume_attachment_status->attach_error
+    v1_volume_error_t *attach_error_local_nonprim = NULL;
+
+    // define the local variable for v1_volume_attachment_status->detach_error
+    v1_volume_error_t *detach_error_local_nonprim = NULL;
+
     // v1_volume_attachment_status->attach_error
     cJSON *attach_error = cJSON_GetObjectItemCaseSensitive(v1_volume_attachment_statusJSON, "attachError");
-    v1_volume_error_t *attach_error_local_nonprim = NULL;
     if (attach_error) { 
     attach_error_local_nonprim = v1_volume_error_parseFromJSON(attach_error); //nonprimitive
     }
@@ -163,7 +168,6 @@ v1_volume_attachment_status_t *v1_volume_attachment_status_parseFromJSON(cJSON *
 
     // v1_volume_attachment_status->detach_error
     cJSON *detach_error = cJSON_GetObjectItemCaseSensitive(v1_volume_attachment_statusJSON, "detachError");
-    v1_volume_error_t *detach_error_local_nonprim = NULL;
     if (detach_error) { 
     detach_error_local_nonprim = v1_volume_error_parseFromJSON(detach_error); //nonprimitive
     }

--- a/kubernetes/model/v1_volume_node_affinity.c
+++ b/kubernetes/model/v1_volume_node_affinity.c
@@ -57,9 +57,11 @@ v1_volume_node_affinity_t *v1_volume_node_affinity_parseFromJSON(cJSON *v1_volum
 
     v1_volume_node_affinity_t *v1_volume_node_affinity_local_var = NULL;
 
+    // define the local variable for v1_volume_node_affinity->required
+    v1_node_selector_t *required_local_nonprim = NULL;
+
     // v1_volume_node_affinity->required
     cJSON *required = cJSON_GetObjectItemCaseSensitive(v1_volume_node_affinityJSON, "required");
-    v1_node_selector_t *required_local_nonprim = NULL;
     if (required) { 
     required_local_nonprim = v1_node_selector_parseFromJSON(required); //nonprimitive
     }

--- a/kubernetes/model/v1_volume_projection.c
+++ b/kubernetes/model/v1_volume_projection.c
@@ -114,30 +114,38 @@ v1_volume_projection_t *v1_volume_projection_parseFromJSON(cJSON *v1_volume_proj
 
     v1_volume_projection_t *v1_volume_projection_local_var = NULL;
 
+    // define the local variable for v1_volume_projection->config_map
+    v1_config_map_projection_t *config_map_local_nonprim = NULL;
+
+    // define the local variable for v1_volume_projection->downward_api
+    v1_downward_api_projection_t *downward_api_local_nonprim = NULL;
+
+    // define the local variable for v1_volume_projection->secret
+    v1_secret_projection_t *secret_local_nonprim = NULL;
+
+    // define the local variable for v1_volume_projection->service_account_token
+    v1_service_account_token_projection_t *service_account_token_local_nonprim = NULL;
+
     // v1_volume_projection->config_map
     cJSON *config_map = cJSON_GetObjectItemCaseSensitive(v1_volume_projectionJSON, "configMap");
-    v1_config_map_projection_t *config_map_local_nonprim = NULL;
     if (config_map) { 
     config_map_local_nonprim = v1_config_map_projection_parseFromJSON(config_map); //nonprimitive
     }
 
     // v1_volume_projection->downward_api
     cJSON *downward_api = cJSON_GetObjectItemCaseSensitive(v1_volume_projectionJSON, "downwardAPI");
-    v1_downward_api_projection_t *downward_api_local_nonprim = NULL;
     if (downward_api) { 
     downward_api_local_nonprim = v1_downward_api_projection_parseFromJSON(downward_api); //nonprimitive
     }
 
     // v1_volume_projection->secret
     cJSON *secret = cJSON_GetObjectItemCaseSensitive(v1_volume_projectionJSON, "secret");
-    v1_secret_projection_t *secret_local_nonprim = NULL;
     if (secret) { 
     secret_local_nonprim = v1_secret_projection_parseFromJSON(secret); //nonprimitive
     }
 
     // v1_volume_projection->service_account_token
     cJSON *service_account_token = cJSON_GetObjectItemCaseSensitive(v1_volume_projectionJSON, "serviceAccountToken");
-    v1_service_account_token_projection_t *service_account_token_local_nonprim = NULL;
     if (service_account_token) { 
     service_account_token_local_nonprim = v1_service_account_token_projection_parseFromJSON(service_account_token); //nonprimitive
     }

--- a/kubernetes/model/v1_webhook_conversion.c
+++ b/kubernetes/model/v1_webhook_conversion.c
@@ -85,9 +85,11 @@ v1_webhook_conversion_t *v1_webhook_conversion_parseFromJSON(cJSON *v1_webhook_c
 
     v1_webhook_conversion_t *v1_webhook_conversion_local_var = NULL;
 
+    // define the local variable for v1_webhook_conversion->client_config
+    apiextensions_v1_webhook_client_config_t *client_config_local_nonprim = NULL;
+
     // v1_webhook_conversion->client_config
     cJSON *client_config = cJSON_GetObjectItemCaseSensitive(v1_webhook_conversionJSON, "clientConfig");
-    apiextensions_v1_webhook_client_config_t *client_config_local_nonprim = NULL;
     if (client_config) { 
     client_config_local_nonprim = apiextensions_v1_webhook_client_config_parseFromJSON(client_config); //nonprimitive
     }

--- a/kubernetes/model/v1_weighted_pod_affinity_term.c
+++ b/kubernetes/model/v1_weighted_pod_affinity_term.c
@@ -71,13 +71,15 @@ v1_weighted_pod_affinity_term_t *v1_weighted_pod_affinity_term_parseFromJSON(cJS
 
     v1_weighted_pod_affinity_term_t *v1_weighted_pod_affinity_term_local_var = NULL;
 
+    // define the local variable for v1_weighted_pod_affinity_term->pod_affinity_term
+    v1_pod_affinity_term_t *pod_affinity_term_local_nonprim = NULL;
+
     // v1_weighted_pod_affinity_term->pod_affinity_term
     cJSON *pod_affinity_term = cJSON_GetObjectItemCaseSensitive(v1_weighted_pod_affinity_termJSON, "podAffinityTerm");
     if (!pod_affinity_term) {
         goto end;
     }
 
-    v1_pod_affinity_term_t *pod_affinity_term_local_nonprim = NULL;
     
     pod_affinity_term_local_nonprim = v1_pod_affinity_term_parseFromJSON(pod_affinity_term); //nonprimitive
 

--- a/kubernetes/model/v1alpha1_cluster_role.c
+++ b/kubernetes/model/v1alpha1_cluster_role.c
@@ -133,9 +133,14 @@ v1alpha1_cluster_role_t *v1alpha1_cluster_role_parseFromJSON(cJSON *v1alpha1_clu
 
     v1alpha1_cluster_role_t *v1alpha1_cluster_role_local_var = NULL;
 
+    // define the local variable for v1alpha1_cluster_role->aggregation_rule
+    v1alpha1_aggregation_rule_t *aggregation_rule_local_nonprim = NULL;
+
+    // define the local variable for v1alpha1_cluster_role->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_cluster_role->aggregation_rule
     cJSON *aggregation_rule = cJSON_GetObjectItemCaseSensitive(v1alpha1_cluster_roleJSON, "aggregationRule");
-    v1alpha1_aggregation_rule_t *aggregation_rule_local_nonprim = NULL;
     if (aggregation_rule) { 
     aggregation_rule_local_nonprim = v1alpha1_aggregation_rule_parseFromJSON(aggregation_rule); //nonprimitive
     }
@@ -160,7 +165,6 @@ v1alpha1_cluster_role_t *v1alpha1_cluster_role_parseFromJSON(cJSON *v1alpha1_clu
 
     // v1alpha1_cluster_role->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_cluster_roleJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_cluster_role_binding.c
+++ b/kubernetes/model/v1alpha1_cluster_role_binding.c
@@ -135,6 +135,12 @@ v1alpha1_cluster_role_binding_t *v1alpha1_cluster_role_binding_parseFromJSON(cJS
 
     v1alpha1_cluster_role_binding_t *v1alpha1_cluster_role_binding_local_var = NULL;
 
+    // define the local variable for v1alpha1_cluster_role_binding->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1alpha1_cluster_role_binding->role_ref
+    v1alpha1_role_ref_t *role_ref_local_nonprim = NULL;
+
     // v1alpha1_cluster_role_binding->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_cluster_role_bindingJSON, "apiVersion");
     if (api_version) { 
@@ -155,7 +161,6 @@ v1alpha1_cluster_role_binding_t *v1alpha1_cluster_role_binding_parseFromJSON(cJS
 
     // v1alpha1_cluster_role_binding->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_cluster_role_bindingJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -166,7 +171,6 @@ v1alpha1_cluster_role_binding_t *v1alpha1_cluster_role_binding_parseFromJSON(cJS
         goto end;
     }
 
-    v1alpha1_role_ref_t *role_ref_local_nonprim = NULL;
     
     role_ref_local_nonprim = v1alpha1_role_ref_parseFromJSON(role_ref); //nonprimitive
 

--- a/kubernetes/model/v1alpha1_cluster_role_binding_list.c
+++ b/kubernetes/model/v1alpha1_cluster_role_binding_list.c
@@ -116,6 +116,9 @@ v1alpha1_cluster_role_binding_list_t *v1alpha1_cluster_role_binding_list_parseFr
 
     v1alpha1_cluster_role_binding_list_t *v1alpha1_cluster_role_binding_list_local_var = NULL;
 
+    // define the local variable for v1alpha1_cluster_role_binding_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_cluster_role_binding_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_cluster_role_binding_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1alpha1_cluster_role_binding_list_t *v1alpha1_cluster_role_binding_list_parseFr
 
     // v1alpha1_cluster_role_binding_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_cluster_role_binding_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_cluster_role_list.c
+++ b/kubernetes/model/v1alpha1_cluster_role_list.c
@@ -116,6 +116,9 @@ v1alpha1_cluster_role_list_t *v1alpha1_cluster_role_list_parseFromJSON(cJSON *v1
 
     v1alpha1_cluster_role_list_t *v1alpha1_cluster_role_list_local_var = NULL;
 
+    // define the local variable for v1alpha1_cluster_role_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_cluster_role_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_cluster_role_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1alpha1_cluster_role_list_t *v1alpha1_cluster_role_list_parseFromJSON(cJSON *v1
 
     // v1alpha1_cluster_role_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_cluster_role_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_csi_storage_capacity.c
+++ b/kubernetes/model/v1alpha1_csi_storage_capacity.c
@@ -148,6 +148,12 @@ v1alpha1_csi_storage_capacity_t *v1alpha1_csi_storage_capacity_parseFromJSON(cJS
 
     v1alpha1_csi_storage_capacity_t *v1alpha1_csi_storage_capacity_local_var = NULL;
 
+    // define the local variable for v1alpha1_csi_storage_capacity->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1alpha1_csi_storage_capacity->node_topology
+    v1_label_selector_t *node_topology_local_nonprim = NULL;
+
     // v1alpha1_csi_storage_capacity->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_csi_storage_capacityJSON, "apiVersion");
     if (api_version) { 
@@ -186,14 +192,12 @@ v1alpha1_csi_storage_capacity_t *v1alpha1_csi_storage_capacity_parseFromJSON(cJS
 
     // v1alpha1_csi_storage_capacity->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_csi_storage_capacityJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1alpha1_csi_storage_capacity->node_topology
     cJSON *node_topology = cJSON_GetObjectItemCaseSensitive(v1alpha1_csi_storage_capacityJSON, "nodeTopology");
-    v1_label_selector_t *node_topology_local_nonprim = NULL;
     if (node_topology) { 
     node_topology_local_nonprim = v1_label_selector_parseFromJSON(node_topology); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_csi_storage_capacity_list.c
+++ b/kubernetes/model/v1alpha1_csi_storage_capacity_list.c
@@ -116,6 +116,9 @@ v1alpha1_csi_storage_capacity_list_t *v1alpha1_csi_storage_capacity_list_parseFr
 
     v1alpha1_csi_storage_capacity_list_t *v1alpha1_csi_storage_capacity_list_local_var = NULL;
 
+    // define the local variable for v1alpha1_csi_storage_capacity_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_csi_storage_capacity_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_csi_storage_capacity_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1alpha1_csi_storage_capacity_list_t *v1alpha1_csi_storage_capacity_list_parseFr
 
     // v1alpha1_csi_storage_capacity_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_csi_storage_capacity_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_priority_class.c
+++ b/kubernetes/model/v1alpha1_priority_class.c
@@ -135,6 +135,9 @@ v1alpha1_priority_class_t *v1alpha1_priority_class_parseFromJSON(cJSON *v1alpha1
 
     v1alpha1_priority_class_t *v1alpha1_priority_class_local_var = NULL;
 
+    // define the local variable for v1alpha1_priority_class->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_priority_class->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_priority_classJSON, "apiVersion");
     if (api_version) { 
@@ -173,7 +176,6 @@ v1alpha1_priority_class_t *v1alpha1_priority_class_parseFromJSON(cJSON *v1alpha1
 
     // v1alpha1_priority_class->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_priority_classJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_priority_class_list.c
+++ b/kubernetes/model/v1alpha1_priority_class_list.c
@@ -116,6 +116,9 @@ v1alpha1_priority_class_list_t *v1alpha1_priority_class_list_parseFromJSON(cJSON
 
     v1alpha1_priority_class_list_t *v1alpha1_priority_class_list_local_var = NULL;
 
+    // define the local variable for v1alpha1_priority_class_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_priority_class_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_priority_class_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1alpha1_priority_class_list_t *v1alpha1_priority_class_list_parseFromJSON(cJSON
 
     // v1alpha1_priority_class_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_priority_class_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_role.c
+++ b/kubernetes/model/v1alpha1_role.c
@@ -114,6 +114,9 @@ v1alpha1_role_t *v1alpha1_role_parseFromJSON(cJSON *v1alpha1_roleJSON){
 
     v1alpha1_role_t *v1alpha1_role_local_var = NULL;
 
+    // define the local variable for v1alpha1_role->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_role->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_roleJSON, "apiVersion");
     if (api_version) { 
@@ -134,7 +137,6 @@ v1alpha1_role_t *v1alpha1_role_parseFromJSON(cJSON *v1alpha1_roleJSON){
 
     // v1alpha1_role->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_roleJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_role_binding.c
+++ b/kubernetes/model/v1alpha1_role_binding.c
@@ -135,6 +135,12 @@ v1alpha1_role_binding_t *v1alpha1_role_binding_parseFromJSON(cJSON *v1alpha1_rol
 
     v1alpha1_role_binding_t *v1alpha1_role_binding_local_var = NULL;
 
+    // define the local variable for v1alpha1_role_binding->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1alpha1_role_binding->role_ref
+    v1alpha1_role_ref_t *role_ref_local_nonprim = NULL;
+
     // v1alpha1_role_binding->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_role_bindingJSON, "apiVersion");
     if (api_version) { 
@@ -155,7 +161,6 @@ v1alpha1_role_binding_t *v1alpha1_role_binding_parseFromJSON(cJSON *v1alpha1_rol
 
     // v1alpha1_role_binding->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_role_bindingJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -166,7 +171,6 @@ v1alpha1_role_binding_t *v1alpha1_role_binding_parseFromJSON(cJSON *v1alpha1_rol
         goto end;
     }
 
-    v1alpha1_role_ref_t *role_ref_local_nonprim = NULL;
     
     role_ref_local_nonprim = v1alpha1_role_ref_parseFromJSON(role_ref); //nonprimitive
 

--- a/kubernetes/model/v1alpha1_role_binding_list.c
+++ b/kubernetes/model/v1alpha1_role_binding_list.c
@@ -116,6 +116,9 @@ v1alpha1_role_binding_list_t *v1alpha1_role_binding_list_parseFromJSON(cJSON *v1
 
     v1alpha1_role_binding_list_t *v1alpha1_role_binding_list_local_var = NULL;
 
+    // define the local variable for v1alpha1_role_binding_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_role_binding_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_role_binding_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1alpha1_role_binding_list_t *v1alpha1_role_binding_list_parseFromJSON(cJSON *v1
 
     // v1alpha1_role_binding_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_role_binding_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_role_list.c
+++ b/kubernetes/model/v1alpha1_role_list.c
@@ -116,6 +116,9 @@ v1alpha1_role_list_t *v1alpha1_role_list_parseFromJSON(cJSON *v1alpha1_role_list
 
     v1alpha1_role_list_t *v1alpha1_role_list_local_var = NULL;
 
+    // define the local variable for v1alpha1_role_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_role_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_role_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1alpha1_role_list_t *v1alpha1_role_list_parseFromJSON(cJSON *v1alpha1_role_list
 
     // v1alpha1_role_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_role_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_runtime_class.c
+++ b/kubernetes/model/v1alpha1_runtime_class.c
@@ -106,6 +106,12 @@ v1alpha1_runtime_class_t *v1alpha1_runtime_class_parseFromJSON(cJSON *v1alpha1_r
 
     v1alpha1_runtime_class_t *v1alpha1_runtime_class_local_var = NULL;
 
+    // define the local variable for v1alpha1_runtime_class->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1alpha1_runtime_class->spec
+    v1alpha1_runtime_class_spec_t *spec_local_nonprim = NULL;
+
     // v1alpha1_runtime_class->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_runtime_classJSON, "apiVersion");
     if (api_version) { 
@@ -126,7 +132,6 @@ v1alpha1_runtime_class_t *v1alpha1_runtime_class_parseFromJSON(cJSON *v1alpha1_r
 
     // v1alpha1_runtime_class->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_runtime_classJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -137,7 +142,6 @@ v1alpha1_runtime_class_t *v1alpha1_runtime_class_parseFromJSON(cJSON *v1alpha1_r
         goto end;
     }
 
-    v1alpha1_runtime_class_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1alpha1_runtime_class_spec_parseFromJSON(spec); //nonprimitive
 

--- a/kubernetes/model/v1alpha1_runtime_class_list.c
+++ b/kubernetes/model/v1alpha1_runtime_class_list.c
@@ -116,6 +116,9 @@ v1alpha1_runtime_class_list_t *v1alpha1_runtime_class_list_parseFromJSON(cJSON *
 
     v1alpha1_runtime_class_list_t *v1alpha1_runtime_class_list_local_var = NULL;
 
+    // define the local variable for v1alpha1_runtime_class_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_runtime_class_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_runtime_class_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1alpha1_runtime_class_list_t *v1alpha1_runtime_class_list_parseFromJSON(cJSON *
 
     // v1alpha1_runtime_class_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_runtime_class_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_runtime_class_spec.c
+++ b/kubernetes/model/v1alpha1_runtime_class_spec.c
@@ -92,9 +92,14 @@ v1alpha1_runtime_class_spec_t *v1alpha1_runtime_class_spec_parseFromJSON(cJSON *
 
     v1alpha1_runtime_class_spec_t *v1alpha1_runtime_class_spec_local_var = NULL;
 
+    // define the local variable for v1alpha1_runtime_class_spec->overhead
+    v1alpha1_overhead_t *overhead_local_nonprim = NULL;
+
+    // define the local variable for v1alpha1_runtime_class_spec->scheduling
+    v1alpha1_scheduling_t *scheduling_local_nonprim = NULL;
+
     // v1alpha1_runtime_class_spec->overhead
     cJSON *overhead = cJSON_GetObjectItemCaseSensitive(v1alpha1_runtime_class_specJSON, "overhead");
-    v1alpha1_overhead_t *overhead_local_nonprim = NULL;
     if (overhead) { 
     overhead_local_nonprim = v1alpha1_overhead_parseFromJSON(overhead); //nonprimitive
     }
@@ -113,7 +118,6 @@ v1alpha1_runtime_class_spec_t *v1alpha1_runtime_class_spec_parseFromJSON(cJSON *
 
     // v1alpha1_runtime_class_spec->scheduling
     cJSON *scheduling = cJSON_GetObjectItemCaseSensitive(v1alpha1_runtime_class_specJSON, "scheduling");
-    v1alpha1_scheduling_t *scheduling_local_nonprim = NULL;
     if (scheduling) { 
     scheduling_local_nonprim = v1alpha1_scheduling_parseFromJSON(scheduling); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_storage_version.c
+++ b/kubernetes/model/v1alpha1_storage_version.c
@@ -127,6 +127,12 @@ v1alpha1_storage_version_t *v1alpha1_storage_version_parseFromJSON(cJSON *v1alph
 
     v1alpha1_storage_version_t *v1alpha1_storage_version_local_var = NULL;
 
+    // define the local variable for v1alpha1_storage_version->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1alpha1_storage_version->status
+    v1alpha1_storage_version_status_t *status_local_nonprim = NULL;
+
     // v1alpha1_storage_version->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_storage_versionJSON, "apiVersion");
     if (api_version) { 
@@ -147,7 +153,6 @@ v1alpha1_storage_version_t *v1alpha1_storage_version_parseFromJSON(cJSON *v1alph
 
     // v1alpha1_storage_version->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_storage_versionJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -168,7 +173,6 @@ v1alpha1_storage_version_t *v1alpha1_storage_version_parseFromJSON(cJSON *v1alph
         goto end;
     }
 
-    v1alpha1_storage_version_status_t *status_local_nonprim = NULL;
     
     status_local_nonprim = v1alpha1_storage_version_status_parseFromJSON(status); //nonprimitive
 

--- a/kubernetes/model/v1alpha1_storage_version_list.c
+++ b/kubernetes/model/v1alpha1_storage_version_list.c
@@ -116,6 +116,9 @@ v1alpha1_storage_version_list_t *v1alpha1_storage_version_list_parseFromJSON(cJS
 
     v1alpha1_storage_version_list_t *v1alpha1_storage_version_list_local_var = NULL;
 
+    // define the local variable for v1alpha1_storage_version_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_storage_version_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_storage_version_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1alpha1_storage_version_list_t *v1alpha1_storage_version_list_parseFromJSON(cJS
 
     // v1alpha1_storage_version_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_storage_version_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_volume_attachment.c
+++ b/kubernetes/model/v1alpha1_volume_attachment.c
@@ -125,6 +125,15 @@ v1alpha1_volume_attachment_t *v1alpha1_volume_attachment_parseFromJSON(cJSON *v1
 
     v1alpha1_volume_attachment_t *v1alpha1_volume_attachment_local_var = NULL;
 
+    // define the local variable for v1alpha1_volume_attachment->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1alpha1_volume_attachment->spec
+    v1alpha1_volume_attachment_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1alpha1_volume_attachment->status
+    v1alpha1_volume_attachment_status_t *status_local_nonprim = NULL;
+
     // v1alpha1_volume_attachment->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_volume_attachmentJSON, "apiVersion");
     if (api_version) { 
@@ -145,7 +154,6 @@ v1alpha1_volume_attachment_t *v1alpha1_volume_attachment_parseFromJSON(cJSON *v1
 
     // v1alpha1_volume_attachment->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_volume_attachmentJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -156,13 +164,11 @@ v1alpha1_volume_attachment_t *v1alpha1_volume_attachment_parseFromJSON(cJSON *v1
         goto end;
     }
 
-    v1alpha1_volume_attachment_spec_t *spec_local_nonprim = NULL;
     
     spec_local_nonprim = v1alpha1_volume_attachment_spec_parseFromJSON(spec); //nonprimitive
 
     // v1alpha1_volume_attachment->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1alpha1_volume_attachmentJSON, "status");
-    v1alpha1_volume_attachment_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1alpha1_volume_attachment_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_volume_attachment_list.c
+++ b/kubernetes/model/v1alpha1_volume_attachment_list.c
@@ -116,6 +116,9 @@ v1alpha1_volume_attachment_list_t *v1alpha1_volume_attachment_list_parseFromJSON
 
     v1alpha1_volume_attachment_list_t *v1alpha1_volume_attachment_list_local_var = NULL;
 
+    // define the local variable for v1alpha1_volume_attachment_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1alpha1_volume_attachment_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1alpha1_volume_attachment_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1alpha1_volume_attachment_list_t *v1alpha1_volume_attachment_list_parseFromJSON
 
     // v1alpha1_volume_attachment_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1alpha1_volume_attachment_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_volume_attachment_source.c
+++ b/kubernetes/model/v1alpha1_volume_attachment_source.c
@@ -71,9 +71,11 @@ v1alpha1_volume_attachment_source_t *v1alpha1_volume_attachment_source_parseFrom
 
     v1alpha1_volume_attachment_source_t *v1alpha1_volume_attachment_source_local_var = NULL;
 
+    // define the local variable for v1alpha1_volume_attachment_source->inline_volume_spec
+    v1_persistent_volume_spec_t *inline_volume_spec_local_nonprim = NULL;
+
     // v1alpha1_volume_attachment_source->inline_volume_spec
     cJSON *inline_volume_spec = cJSON_GetObjectItemCaseSensitive(v1alpha1_volume_attachment_sourceJSON, "inlineVolumeSpec");
-    v1_persistent_volume_spec_t *inline_volume_spec_local_nonprim = NULL;
     if (inline_volume_spec) { 
     inline_volume_spec_local_nonprim = v1_persistent_volume_spec_parseFromJSON(inline_volume_spec); //nonprimitive
     }

--- a/kubernetes/model/v1alpha1_volume_attachment_spec.c
+++ b/kubernetes/model/v1alpha1_volume_attachment_spec.c
@@ -91,6 +91,9 @@ v1alpha1_volume_attachment_spec_t *v1alpha1_volume_attachment_spec_parseFromJSON
 
     v1alpha1_volume_attachment_spec_t *v1alpha1_volume_attachment_spec_local_var = NULL;
 
+    // define the local variable for v1alpha1_volume_attachment_spec->source
+    v1alpha1_volume_attachment_source_t *source_local_nonprim = NULL;
+
     // v1alpha1_volume_attachment_spec->attacher
     cJSON *attacher = cJSON_GetObjectItemCaseSensitive(v1alpha1_volume_attachment_specJSON, "attacher");
     if (!attacher) {
@@ -121,7 +124,6 @@ v1alpha1_volume_attachment_spec_t *v1alpha1_volume_attachment_spec_parseFromJSON
         goto end;
     }
 
-    v1alpha1_volume_attachment_source_t *source_local_nonprim = NULL;
     
     source_local_nonprim = v1alpha1_volume_attachment_source_parseFromJSON(source); //nonprimitive
 

--- a/kubernetes/model/v1alpha1_volume_attachment_status.c
+++ b/kubernetes/model/v1alpha1_volume_attachment_status.c
@@ -120,9 +120,14 @@ v1alpha1_volume_attachment_status_t *v1alpha1_volume_attachment_status_parseFrom
 
     v1alpha1_volume_attachment_status_t *v1alpha1_volume_attachment_status_local_var = NULL;
 
+    // define the local variable for v1alpha1_volume_attachment_status->attach_error
+    v1alpha1_volume_error_t *attach_error_local_nonprim = NULL;
+
+    // define the local variable for v1alpha1_volume_attachment_status->detach_error
+    v1alpha1_volume_error_t *detach_error_local_nonprim = NULL;
+
     // v1alpha1_volume_attachment_status->attach_error
     cJSON *attach_error = cJSON_GetObjectItemCaseSensitive(v1alpha1_volume_attachment_statusJSON, "attachError");
-    v1alpha1_volume_error_t *attach_error_local_nonprim = NULL;
     if (attach_error) { 
     attach_error_local_nonprim = v1alpha1_volume_error_parseFromJSON(attach_error); //nonprimitive
     }
@@ -163,7 +168,6 @@ v1alpha1_volume_attachment_status_t *v1alpha1_volume_attachment_status_parseFrom
 
     // v1alpha1_volume_attachment_status->detach_error
     cJSON *detach_error = cJSON_GetObjectItemCaseSensitive(v1alpha1_volume_attachment_statusJSON, "detachError");
-    v1alpha1_volume_error_t *detach_error_local_nonprim = NULL;
     if (detach_error) { 
     detach_error_local_nonprim = v1alpha1_volume_error_parseFromJSON(detach_error); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_cron_job.c
+++ b/kubernetes/model/v1beta1_cron_job.c
@@ -123,6 +123,15 @@ v1beta1_cron_job_t *v1beta1_cron_job_parseFromJSON(cJSON *v1beta1_cron_jobJSON){
 
     v1beta1_cron_job_t *v1beta1_cron_job_local_var = NULL;
 
+    // define the local variable for v1beta1_cron_job->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_cron_job->spec
+    v1beta1_cron_job_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_cron_job->status
+    v1beta1_cron_job_status_t *status_local_nonprim = NULL;
+
     // v1beta1_cron_job->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_cron_jobJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1beta1_cron_job_t *v1beta1_cron_job_parseFromJSON(cJSON *v1beta1_cron_jobJSON){
 
     // v1beta1_cron_job->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_cron_jobJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1beta1_cron_job->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1beta1_cron_jobJSON, "spec");
-    v1beta1_cron_job_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1beta1_cron_job_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1beta1_cron_job->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1beta1_cron_jobJSON, "status");
-    v1beta1_cron_job_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1beta1_cron_job_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_cron_job_list.c
+++ b/kubernetes/model/v1beta1_cron_job_list.c
@@ -116,6 +116,9 @@ v1beta1_cron_job_list_t *v1beta1_cron_job_list_parseFromJSON(cJSON *v1beta1_cron
 
     v1beta1_cron_job_list_t *v1beta1_cron_job_list_local_var = NULL;
 
+    // define the local variable for v1beta1_cron_job_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1beta1_cron_job_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_cron_job_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1beta1_cron_job_list_t *v1beta1_cron_job_list_parseFromJSON(cJSON *v1beta1_cron
 
     // v1beta1_cron_job_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_cron_job_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_cron_job_spec.c
+++ b/kubernetes/model/v1beta1_cron_job_spec.c
@@ -129,6 +129,9 @@ v1beta1_cron_job_spec_t *v1beta1_cron_job_spec_parseFromJSON(cJSON *v1beta1_cron
 
     v1beta1_cron_job_spec_t *v1beta1_cron_job_spec_local_var = NULL;
 
+    // define the local variable for v1beta1_cron_job_spec->job_template
+    v1beta1_job_template_spec_t *job_template_local_nonprim = NULL;
+
     // v1beta1_cron_job_spec->concurrency_policy
     cJSON *concurrency_policy = cJSON_GetObjectItemCaseSensitive(v1beta1_cron_job_specJSON, "concurrencyPolicy");
     if (concurrency_policy) { 
@@ -153,7 +156,6 @@ v1beta1_cron_job_spec_t *v1beta1_cron_job_spec_parseFromJSON(cJSON *v1beta1_cron
         goto end;
     }
 
-    v1beta1_job_template_spec_t *job_template_local_nonprim = NULL;
     
     job_template_local_nonprim = v1beta1_job_template_spec_parseFromJSON(job_template); //nonprimitive
 

--- a/kubernetes/model/v1beta1_csi_storage_capacity.c
+++ b/kubernetes/model/v1beta1_csi_storage_capacity.c
@@ -148,6 +148,12 @@ v1beta1_csi_storage_capacity_t *v1beta1_csi_storage_capacity_parseFromJSON(cJSON
 
     v1beta1_csi_storage_capacity_t *v1beta1_csi_storage_capacity_local_var = NULL;
 
+    // define the local variable for v1beta1_csi_storage_capacity->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_csi_storage_capacity->node_topology
+    v1_label_selector_t *node_topology_local_nonprim = NULL;
+
     // v1beta1_csi_storage_capacity->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_csi_storage_capacityJSON, "apiVersion");
     if (api_version) { 
@@ -186,14 +192,12 @@ v1beta1_csi_storage_capacity_t *v1beta1_csi_storage_capacity_parseFromJSON(cJSON
 
     // v1beta1_csi_storage_capacity->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_csi_storage_capacityJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1beta1_csi_storage_capacity->node_topology
     cJSON *node_topology = cJSON_GetObjectItemCaseSensitive(v1beta1_csi_storage_capacityJSON, "nodeTopology");
-    v1_label_selector_t *node_topology_local_nonprim = NULL;
     if (node_topology) { 
     node_topology_local_nonprim = v1_label_selector_parseFromJSON(node_topology); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_csi_storage_capacity_list.c
+++ b/kubernetes/model/v1beta1_csi_storage_capacity_list.c
@@ -116,6 +116,9 @@ v1beta1_csi_storage_capacity_list_t *v1beta1_csi_storage_capacity_list_parseFrom
 
     v1beta1_csi_storage_capacity_list_t *v1beta1_csi_storage_capacity_list_local_var = NULL;
 
+    // define the local variable for v1beta1_csi_storage_capacity_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1beta1_csi_storage_capacity_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_csi_storage_capacity_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1beta1_csi_storage_capacity_list_t *v1beta1_csi_storage_capacity_list_parseFrom
 
     // v1beta1_csi_storage_capacity_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_csi_storage_capacity_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_endpoint.c
+++ b/kubernetes/model/v1beta1_endpoint.c
@@ -183,6 +183,15 @@ v1beta1_endpoint_t *v1beta1_endpoint_parseFromJSON(cJSON *v1beta1_endpointJSON){
 
     v1beta1_endpoint_t *v1beta1_endpoint_local_var = NULL;
 
+    // define the local variable for v1beta1_endpoint->conditions
+    v1beta1_endpoint_conditions_t *conditions_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_endpoint->hints
+    v1beta1_endpoint_hints_t *hints_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_endpoint->target_ref
+    v1_object_reference_t *target_ref_local_nonprim = NULL;
+
     // v1beta1_endpoint->addresses
     cJSON *addresses = cJSON_GetObjectItemCaseSensitive(v1beta1_endpointJSON, "addresses");
     if (!addresses) {
@@ -208,14 +217,12 @@ v1beta1_endpoint_t *v1beta1_endpoint_parseFromJSON(cJSON *v1beta1_endpointJSON){
 
     // v1beta1_endpoint->conditions
     cJSON *conditions = cJSON_GetObjectItemCaseSensitive(v1beta1_endpointJSON, "conditions");
-    v1beta1_endpoint_conditions_t *conditions_local_nonprim = NULL;
     if (conditions) { 
     conditions_local_nonprim = v1beta1_endpoint_conditions_parseFromJSON(conditions); //nonprimitive
     }
 
     // v1beta1_endpoint->hints
     cJSON *hints = cJSON_GetObjectItemCaseSensitive(v1beta1_endpointJSON, "hints");
-    v1beta1_endpoint_hints_t *hints_local_nonprim = NULL;
     if (hints) { 
     hints_local_nonprim = v1beta1_endpoint_hints_parseFromJSON(hints); //nonprimitive
     }
@@ -240,7 +247,6 @@ v1beta1_endpoint_t *v1beta1_endpoint_parseFromJSON(cJSON *v1beta1_endpointJSON){
 
     // v1beta1_endpoint->target_ref
     cJSON *target_ref = cJSON_GetObjectItemCaseSensitive(v1beta1_endpointJSON, "targetRef");
-    v1_object_reference_t *target_ref_local_nonprim = NULL;
     if (target_ref) { 
     target_ref_local_nonprim = v1_object_reference_parseFromJSON(target_ref); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_endpoint_slice.c
+++ b/kubernetes/model/v1beta1_endpoint_slice.c
@@ -161,6 +161,9 @@ v1beta1_endpoint_slice_t *v1beta1_endpoint_slice_parseFromJSON(cJSON *v1beta1_en
 
     v1beta1_endpoint_slice_t *v1beta1_endpoint_slice_local_var = NULL;
 
+    // define the local variable for v1beta1_endpoint_slice->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
     // v1beta1_endpoint_slice->address_type
     cJSON *address_type = cJSON_GetObjectItemCaseSensitive(v1beta1_endpoint_sliceJSON, "addressType");
     if (!address_type) {
@@ -218,7 +221,6 @@ v1beta1_endpoint_slice_t *v1beta1_endpoint_slice_parseFromJSON(cJSON *v1beta1_en
 
     // v1beta1_endpoint_slice->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_endpoint_sliceJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_endpoint_slice_list.c
+++ b/kubernetes/model/v1beta1_endpoint_slice_list.c
@@ -116,6 +116,9 @@ v1beta1_endpoint_slice_list_t *v1beta1_endpoint_slice_list_parseFromJSON(cJSON *
 
     v1beta1_endpoint_slice_list_t *v1beta1_endpoint_slice_list_local_var = NULL;
 
+    // define the local variable for v1beta1_endpoint_slice_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1beta1_endpoint_slice_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_endpoint_slice_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1beta1_endpoint_slice_list_t *v1beta1_endpoint_slice_list_parseFromJSON(cJSON *
 
     // v1beta1_endpoint_slice_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_endpoint_slice_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_event.c
+++ b/kubernetes/model/v1beta1_event.c
@@ -299,6 +299,21 @@ v1beta1_event_t *v1beta1_event_parseFromJSON(cJSON *v1beta1_eventJSON){
 
     v1beta1_event_t *v1beta1_event_local_var = NULL;
 
+    // define the local variable for v1beta1_event->deprecated_source
+    v1_event_source_t *deprecated_source_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_event->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_event->regarding
+    v1_object_reference_t *regarding_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_event->related
+    v1_object_reference_t *related_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_event->series
+    v1beta1_event_series_t *series_local_nonprim = NULL;
+
     // v1beta1_event->action
     cJSON *action = cJSON_GetObjectItemCaseSensitive(v1beta1_eventJSON, "action");
     if (action) { 
@@ -346,7 +361,6 @@ v1beta1_event_t *v1beta1_event_parseFromJSON(cJSON *v1beta1_eventJSON){
 
     // v1beta1_event->deprecated_source
     cJSON *deprecated_source = cJSON_GetObjectItemCaseSensitive(v1beta1_eventJSON, "deprecatedSource");
-    v1_event_source_t *deprecated_source_local_nonprim = NULL;
     if (deprecated_source) { 
     deprecated_source_local_nonprim = v1_event_source_parseFromJSON(deprecated_source); //nonprimitive
     }
@@ -374,7 +388,6 @@ v1beta1_event_t *v1beta1_event_parseFromJSON(cJSON *v1beta1_eventJSON){
 
     // v1beta1_event->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_eventJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
@@ -399,14 +412,12 @@ v1beta1_event_t *v1beta1_event_parseFromJSON(cJSON *v1beta1_eventJSON){
 
     // v1beta1_event->regarding
     cJSON *regarding = cJSON_GetObjectItemCaseSensitive(v1beta1_eventJSON, "regarding");
-    v1_object_reference_t *regarding_local_nonprim = NULL;
     if (regarding) { 
     regarding_local_nonprim = v1_object_reference_parseFromJSON(regarding); //nonprimitive
     }
 
     // v1beta1_event->related
     cJSON *related = cJSON_GetObjectItemCaseSensitive(v1beta1_eventJSON, "related");
-    v1_object_reference_t *related_local_nonprim = NULL;
     if (related) { 
     related_local_nonprim = v1_object_reference_parseFromJSON(related); //nonprimitive
     }
@@ -431,7 +442,6 @@ v1beta1_event_t *v1beta1_event_parseFromJSON(cJSON *v1beta1_eventJSON){
 
     // v1beta1_event->series
     cJSON *series = cJSON_GetObjectItemCaseSensitive(v1beta1_eventJSON, "series");
-    v1beta1_event_series_t *series_local_nonprim = NULL;
     if (series) { 
     series_local_nonprim = v1beta1_event_series_parseFromJSON(series); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_event_list.c
+++ b/kubernetes/model/v1beta1_event_list.c
@@ -116,6 +116,9 @@ v1beta1_event_list_t *v1beta1_event_list_parseFromJSON(cJSON *v1beta1_event_list
 
     v1beta1_event_list_t *v1beta1_event_list_local_var = NULL;
 
+    // define the local variable for v1beta1_event_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1beta1_event_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_event_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1beta1_event_list_t *v1beta1_event_list_parseFromJSON(cJSON *v1beta1_event_list
 
     // v1beta1_event_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_event_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_flow_schema.c
+++ b/kubernetes/model/v1beta1_flow_schema.c
@@ -123,6 +123,15 @@ v1beta1_flow_schema_t *v1beta1_flow_schema_parseFromJSON(cJSON *v1beta1_flow_sch
 
     v1beta1_flow_schema_t *v1beta1_flow_schema_local_var = NULL;
 
+    // define the local variable for v1beta1_flow_schema->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_flow_schema->spec
+    v1beta1_flow_schema_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_flow_schema->status
+    v1beta1_flow_schema_status_t *status_local_nonprim = NULL;
+
     // v1beta1_flow_schema->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_flow_schemaJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1beta1_flow_schema_t *v1beta1_flow_schema_parseFromJSON(cJSON *v1beta1_flow_sch
 
     // v1beta1_flow_schema->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_flow_schemaJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1beta1_flow_schema->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1beta1_flow_schemaJSON, "spec");
-    v1beta1_flow_schema_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1beta1_flow_schema_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1beta1_flow_schema->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1beta1_flow_schemaJSON, "status");
-    v1beta1_flow_schema_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1beta1_flow_schema_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_flow_schema_list.c
+++ b/kubernetes/model/v1beta1_flow_schema_list.c
@@ -116,6 +116,9 @@ v1beta1_flow_schema_list_t *v1beta1_flow_schema_list_parseFromJSON(cJSON *v1beta
 
     v1beta1_flow_schema_list_t *v1beta1_flow_schema_list_local_var = NULL;
 
+    // define the local variable for v1beta1_flow_schema_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1beta1_flow_schema_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_flow_schema_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1beta1_flow_schema_list_t *v1beta1_flow_schema_list_parseFromJSON(cJSON *v1beta
 
     // v1beta1_flow_schema_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_flow_schema_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_flow_schema_spec.c
+++ b/kubernetes/model/v1beta1_flow_schema_spec.c
@@ -117,9 +117,14 @@ v1beta1_flow_schema_spec_t *v1beta1_flow_schema_spec_parseFromJSON(cJSON *v1beta
 
     v1beta1_flow_schema_spec_t *v1beta1_flow_schema_spec_local_var = NULL;
 
+    // define the local variable for v1beta1_flow_schema_spec->distinguisher_method
+    v1beta1_flow_distinguisher_method_t *distinguisher_method_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_flow_schema_spec->priority_level_configuration
+    v1beta1_priority_level_configuration_reference_t *priority_level_configuration_local_nonprim = NULL;
+
     // v1beta1_flow_schema_spec->distinguisher_method
     cJSON *distinguisher_method = cJSON_GetObjectItemCaseSensitive(v1beta1_flow_schema_specJSON, "distinguisherMethod");
-    v1beta1_flow_distinguisher_method_t *distinguisher_method_local_nonprim = NULL;
     if (distinguisher_method) { 
     distinguisher_method_local_nonprim = v1beta1_flow_distinguisher_method_parseFromJSON(distinguisher_method); //nonprimitive
     }
@@ -139,7 +144,6 @@ v1beta1_flow_schema_spec_t *v1beta1_flow_schema_spec_parseFromJSON(cJSON *v1beta
         goto end;
     }
 
-    v1beta1_priority_level_configuration_reference_t *priority_level_configuration_local_nonprim = NULL;
     
     priority_level_configuration_local_nonprim = v1beta1_priority_level_configuration_reference_parseFromJSON(priority_level_configuration); //nonprimitive
 

--- a/kubernetes/model/v1beta1_job_template_spec.c
+++ b/kubernetes/model/v1beta1_job_template_spec.c
@@ -76,16 +76,20 @@ v1beta1_job_template_spec_t *v1beta1_job_template_spec_parseFromJSON(cJSON *v1be
 
     v1beta1_job_template_spec_t *v1beta1_job_template_spec_local_var = NULL;
 
+    // define the local variable for v1beta1_job_template_spec->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_job_template_spec->spec
+    v1_job_spec_t *spec_local_nonprim = NULL;
+
     // v1beta1_job_template_spec->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_job_template_specJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1beta1_job_template_spec->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1beta1_job_template_specJSON, "spec");
-    v1_job_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1_job_spec_parseFromJSON(spec); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_limit_response.c
+++ b/kubernetes/model/v1beta1_limit_response.c
@@ -73,9 +73,11 @@ v1beta1_limit_response_t *v1beta1_limit_response_parseFromJSON(cJSON *v1beta1_li
 
     v1beta1_limit_response_t *v1beta1_limit_response_local_var = NULL;
 
+    // define the local variable for v1beta1_limit_response->queuing
+    v1beta1_queuing_configuration_t *queuing_local_nonprim = NULL;
+
     // v1beta1_limit_response->queuing
     cJSON *queuing = cJSON_GetObjectItemCaseSensitive(v1beta1_limit_responseJSON, "queuing");
-    v1beta1_queuing_configuration_t *queuing_local_nonprim = NULL;
     if (queuing) { 
     queuing_local_nonprim = v1beta1_queuing_configuration_parseFromJSON(queuing); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_limited_priority_level_configuration.c
+++ b/kubernetes/model/v1beta1_limited_priority_level_configuration.c
@@ -67,6 +67,9 @@ v1beta1_limited_priority_level_configuration_t *v1beta1_limited_priority_level_c
 
     v1beta1_limited_priority_level_configuration_t *v1beta1_limited_priority_level_configuration_local_var = NULL;
 
+    // define the local variable for v1beta1_limited_priority_level_configuration->limit_response
+    v1beta1_limit_response_t *limit_response_local_nonprim = NULL;
+
     // v1beta1_limited_priority_level_configuration->assured_concurrency_shares
     cJSON *assured_concurrency_shares = cJSON_GetObjectItemCaseSensitive(v1beta1_limited_priority_level_configurationJSON, "assuredConcurrencyShares");
     if (assured_concurrency_shares) { 
@@ -78,7 +81,6 @@ v1beta1_limited_priority_level_configuration_t *v1beta1_limited_priority_level_c
 
     // v1beta1_limited_priority_level_configuration->limit_response
     cJSON *limit_response = cJSON_GetObjectItemCaseSensitive(v1beta1_limited_priority_level_configurationJSON, "limitResponse");
-    v1beta1_limit_response_t *limit_response_local_nonprim = NULL;
     if (limit_response) { 
     limit_response_local_nonprim = v1beta1_limit_response_parseFromJSON(limit_response); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_pod_disruption_budget.c
+++ b/kubernetes/model/v1beta1_pod_disruption_budget.c
@@ -123,6 +123,15 @@ v1beta1_pod_disruption_budget_t *v1beta1_pod_disruption_budget_parseFromJSON(cJS
 
     v1beta1_pod_disruption_budget_t *v1beta1_pod_disruption_budget_local_var = NULL;
 
+    // define the local variable for v1beta1_pod_disruption_budget->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_pod_disruption_budget->spec
+    v1beta1_pod_disruption_budget_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_pod_disruption_budget->status
+    v1beta1_pod_disruption_budget_status_t *status_local_nonprim = NULL;
+
     // v1beta1_pod_disruption_budget->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_disruption_budgetJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1beta1_pod_disruption_budget_t *v1beta1_pod_disruption_budget_parseFromJSON(cJS
 
     // v1beta1_pod_disruption_budget->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_disruption_budgetJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1beta1_pod_disruption_budget->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_disruption_budgetJSON, "spec");
-    v1beta1_pod_disruption_budget_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1beta1_pod_disruption_budget_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1beta1_pod_disruption_budget->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_disruption_budgetJSON, "status");
-    v1beta1_pod_disruption_budget_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1beta1_pod_disruption_budget_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_pod_disruption_budget_list.c
+++ b/kubernetes/model/v1beta1_pod_disruption_budget_list.c
@@ -116,6 +116,9 @@ v1beta1_pod_disruption_budget_list_t *v1beta1_pod_disruption_budget_list_parseFr
 
     v1beta1_pod_disruption_budget_list_t *v1beta1_pod_disruption_budget_list_local_var = NULL;
 
+    // define the local variable for v1beta1_pod_disruption_budget_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1beta1_pod_disruption_budget_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_disruption_budget_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1beta1_pod_disruption_budget_list_t *v1beta1_pod_disruption_budget_list_parseFr
 
     // v1beta1_pod_disruption_budget_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_disruption_budget_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_pod_disruption_budget_spec.c
+++ b/kubernetes/model/v1beta1_pod_disruption_budget_spec.c
@@ -95,6 +95,9 @@ v1beta1_pod_disruption_budget_spec_t *v1beta1_pod_disruption_budget_spec_parseFr
 
     v1beta1_pod_disruption_budget_spec_t *v1beta1_pod_disruption_budget_spec_local_var = NULL;
 
+    // define the local variable for v1beta1_pod_disruption_budget_spec->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
     // v1beta1_pod_disruption_budget_spec->max_unavailable
     cJSON *max_unavailable = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_disruption_budget_specJSON, "maxUnavailable");
     object_t *max_unavailable_local_object = NULL;
@@ -111,7 +114,6 @@ v1beta1_pod_disruption_budget_spec_t *v1beta1_pod_disruption_budget_spec_parseFr
 
     // v1beta1_pod_disruption_budget_spec->selector
     cJSON *selector = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_disruption_budget_specJSON, "selector");
-    v1_label_selector_t *selector_local_nonprim = NULL;
     if (selector) { 
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_pod_security_policy.c
+++ b/kubernetes/model/v1beta1_pod_security_policy.c
@@ -104,6 +104,12 @@ v1beta1_pod_security_policy_t *v1beta1_pod_security_policy_parseFromJSON(cJSON *
 
     v1beta1_pod_security_policy_t *v1beta1_pod_security_policy_local_var = NULL;
 
+    // define the local variable for v1beta1_pod_security_policy->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_pod_security_policy->spec
+    v1beta1_pod_security_policy_spec_t *spec_local_nonprim = NULL;
+
     // v1beta1_pod_security_policy->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_security_policyJSON, "apiVersion");
     if (api_version) { 
@@ -124,14 +130,12 @@ v1beta1_pod_security_policy_t *v1beta1_pod_security_policy_parseFromJSON(cJSON *
 
     // v1beta1_pod_security_policy->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_security_policyJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1beta1_pod_security_policy->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_security_policyJSON, "spec");
-    v1beta1_pod_security_policy_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1beta1_pod_security_policy_spec_parseFromJSON(spec); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_pod_security_policy_list.c
+++ b/kubernetes/model/v1beta1_pod_security_policy_list.c
@@ -116,6 +116,9 @@ v1beta1_pod_security_policy_list_t *v1beta1_pod_security_policy_list_parseFromJS
 
     v1beta1_pod_security_policy_list_t *v1beta1_pod_security_policy_list_local_var = NULL;
 
+    // define the local variable for v1beta1_pod_security_policy_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1beta1_pod_security_policy_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_security_policy_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1beta1_pod_security_policy_list_t *v1beta1_pod_security_policy_list_parseFromJS
 
     // v1beta1_pod_security_policy_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_security_policy_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_pod_security_policy_spec.c
+++ b/kubernetes/model/v1beta1_pod_security_policy_spec.c
@@ -528,6 +528,24 @@ v1beta1_pod_security_policy_spec_t *v1beta1_pod_security_policy_spec_parseFromJS
 
     v1beta1_pod_security_policy_spec_t *v1beta1_pod_security_policy_spec_local_var = NULL;
 
+    // define the local variable for v1beta1_pod_security_policy_spec->fs_group
+    v1beta1_fs_group_strategy_options_t *fs_group_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_pod_security_policy_spec->run_as_group
+    v1beta1_run_as_group_strategy_options_t *run_as_group_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_pod_security_policy_spec->run_as_user
+    v1beta1_run_as_user_strategy_options_t *run_as_user_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_pod_security_policy_spec->runtime_class
+    v1beta1_runtime_class_strategy_options_t *runtime_class_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_pod_security_policy_spec->se_linux
+    v1beta1_se_linux_strategy_options_t *se_linux_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_pod_security_policy_spec->supplemental_groups
+    v1beta1_supplemental_groups_strategy_options_t *supplemental_groups_local_nonprim = NULL;
+
     // v1beta1_pod_security_policy_spec->allow_privilege_escalation
     cJSON *allow_privilege_escalation = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_security_policy_specJSON, "allowPrivilegeEscalation");
     if (allow_privilege_escalation) { 
@@ -718,7 +736,6 @@ v1beta1_pod_security_policy_spec_t *v1beta1_pod_security_policy_spec_parseFromJS
         goto end;
     }
 
-    v1beta1_fs_group_strategy_options_t *fs_group_local_nonprim = NULL;
     
     fs_group_local_nonprim = v1beta1_fs_group_strategy_options_parseFromJSON(fs_group); //nonprimitive
 
@@ -811,7 +828,6 @@ v1beta1_pod_security_policy_spec_t *v1beta1_pod_security_policy_spec_parseFromJS
 
     // v1beta1_pod_security_policy_spec->run_as_group
     cJSON *run_as_group = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_security_policy_specJSON, "runAsGroup");
-    v1beta1_run_as_group_strategy_options_t *run_as_group_local_nonprim = NULL;
     if (run_as_group) { 
     run_as_group_local_nonprim = v1beta1_run_as_group_strategy_options_parseFromJSON(run_as_group); //nonprimitive
     }
@@ -822,13 +838,11 @@ v1beta1_pod_security_policy_spec_t *v1beta1_pod_security_policy_spec_parseFromJS
         goto end;
     }
 
-    v1beta1_run_as_user_strategy_options_t *run_as_user_local_nonprim = NULL;
     
     run_as_user_local_nonprim = v1beta1_run_as_user_strategy_options_parseFromJSON(run_as_user); //nonprimitive
 
     // v1beta1_pod_security_policy_spec->runtime_class
     cJSON *runtime_class = cJSON_GetObjectItemCaseSensitive(v1beta1_pod_security_policy_specJSON, "runtimeClass");
-    v1beta1_runtime_class_strategy_options_t *runtime_class_local_nonprim = NULL;
     if (runtime_class) { 
     runtime_class_local_nonprim = v1beta1_runtime_class_strategy_options_parseFromJSON(runtime_class); //nonprimitive
     }
@@ -839,7 +853,6 @@ v1beta1_pod_security_policy_spec_t *v1beta1_pod_security_policy_spec_parseFromJS
         goto end;
     }
 
-    v1beta1_se_linux_strategy_options_t *se_linux_local_nonprim = NULL;
     
     se_linux_local_nonprim = v1beta1_se_linux_strategy_options_parseFromJSON(se_linux); //nonprimitive
 
@@ -849,7 +862,6 @@ v1beta1_pod_security_policy_spec_t *v1beta1_pod_security_policy_spec_parseFromJS
         goto end;
     }
 
-    v1beta1_supplemental_groups_strategy_options_t *supplemental_groups_local_nonprim = NULL;
     
     supplemental_groups_local_nonprim = v1beta1_supplemental_groups_strategy_options_parseFromJSON(supplemental_groups); //nonprimitive
 

--- a/kubernetes/model/v1beta1_priority_level_configuration.c
+++ b/kubernetes/model/v1beta1_priority_level_configuration.c
@@ -123,6 +123,15 @@ v1beta1_priority_level_configuration_t *v1beta1_priority_level_configuration_par
 
     v1beta1_priority_level_configuration_t *v1beta1_priority_level_configuration_local_var = NULL;
 
+    // define the local variable for v1beta1_priority_level_configuration->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_priority_level_configuration->spec
+    v1beta1_priority_level_configuration_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_priority_level_configuration->status
+    v1beta1_priority_level_configuration_status_t *status_local_nonprim = NULL;
+
     // v1beta1_priority_level_configuration->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_priority_level_configurationJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v1beta1_priority_level_configuration_t *v1beta1_priority_level_configuration_par
 
     // v1beta1_priority_level_configuration->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_priority_level_configurationJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1beta1_priority_level_configuration->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v1beta1_priority_level_configurationJSON, "spec");
-    v1beta1_priority_level_configuration_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v1beta1_priority_level_configuration_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v1beta1_priority_level_configuration->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v1beta1_priority_level_configurationJSON, "status");
-    v1beta1_priority_level_configuration_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v1beta1_priority_level_configuration_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_priority_level_configuration_list.c
+++ b/kubernetes/model/v1beta1_priority_level_configuration_list.c
@@ -116,6 +116,9 @@ v1beta1_priority_level_configuration_list_t *v1beta1_priority_level_configuratio
 
     v1beta1_priority_level_configuration_list_t *v1beta1_priority_level_configuration_list_local_var = NULL;
 
+    // define the local variable for v1beta1_priority_level_configuration_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1beta1_priority_level_configuration_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_priority_level_configuration_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1beta1_priority_level_configuration_list_t *v1beta1_priority_level_configuratio
 
     // v1beta1_priority_level_configuration_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_priority_level_configuration_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_priority_level_configuration_spec.c
+++ b/kubernetes/model/v1beta1_priority_level_configuration_spec.c
@@ -73,9 +73,11 @@ v1beta1_priority_level_configuration_spec_t *v1beta1_priority_level_configuratio
 
     v1beta1_priority_level_configuration_spec_t *v1beta1_priority_level_configuration_spec_local_var = NULL;
 
+    // define the local variable for v1beta1_priority_level_configuration_spec->limited
+    v1beta1_limited_priority_level_configuration_t *limited_local_nonprim = NULL;
+
     // v1beta1_priority_level_configuration_spec->limited
     cJSON *limited = cJSON_GetObjectItemCaseSensitive(v1beta1_priority_level_configuration_specJSON, "limited");
-    v1beta1_limited_priority_level_configuration_t *limited_local_nonprim = NULL;
     if (limited) { 
     limited_local_nonprim = v1beta1_limited_priority_level_configuration_parseFromJSON(limited); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_runtime_class.c
+++ b/kubernetes/model/v1beta1_runtime_class.c
@@ -139,6 +139,15 @@ v1beta1_runtime_class_t *v1beta1_runtime_class_parseFromJSON(cJSON *v1beta1_runt
 
     v1beta1_runtime_class_t *v1beta1_runtime_class_local_var = NULL;
 
+    // define the local variable for v1beta1_runtime_class->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_runtime_class->overhead
+    v1beta1_overhead_t *overhead_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_runtime_class->scheduling
+    v1beta1_scheduling_t *scheduling_local_nonprim = NULL;
+
     // v1beta1_runtime_class->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_runtime_classJSON, "apiVersion");
     if (api_version) { 
@@ -171,21 +180,18 @@ v1beta1_runtime_class_t *v1beta1_runtime_class_parseFromJSON(cJSON *v1beta1_runt
 
     // v1beta1_runtime_class->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_runtime_classJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v1beta1_runtime_class->overhead
     cJSON *overhead = cJSON_GetObjectItemCaseSensitive(v1beta1_runtime_classJSON, "overhead");
-    v1beta1_overhead_t *overhead_local_nonprim = NULL;
     if (overhead) { 
     overhead_local_nonprim = v1beta1_overhead_parseFromJSON(overhead); //nonprimitive
     }
 
     // v1beta1_runtime_class->scheduling
     cJSON *scheduling = cJSON_GetObjectItemCaseSensitive(v1beta1_runtime_classJSON, "scheduling");
-    v1beta1_scheduling_t *scheduling_local_nonprim = NULL;
     if (scheduling) { 
     scheduling_local_nonprim = v1beta1_scheduling_parseFromJSON(scheduling); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_runtime_class_list.c
+++ b/kubernetes/model/v1beta1_runtime_class_list.c
@@ -116,6 +116,9 @@ v1beta1_runtime_class_list_t *v1beta1_runtime_class_list_parseFromJSON(cJSON *v1
 
     v1beta1_runtime_class_list_t *v1beta1_runtime_class_list_local_var = NULL;
 
+    // define the local variable for v1beta1_runtime_class_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v1beta1_runtime_class_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v1beta1_runtime_class_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v1beta1_runtime_class_list_t *v1beta1_runtime_class_list_parseFromJSON(cJSON *v1
 
     // v1beta1_runtime_class_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v1beta1_runtime_class_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_se_linux_strategy_options.c
+++ b/kubernetes/model/v1beta1_se_linux_strategy_options.c
@@ -73,6 +73,9 @@ v1beta1_se_linux_strategy_options_t *v1beta1_se_linux_strategy_options_parseFrom
 
     v1beta1_se_linux_strategy_options_t *v1beta1_se_linux_strategy_options_local_var = NULL;
 
+    // define the local variable for v1beta1_se_linux_strategy_options->se_linux_options
+    v1_se_linux_options_t *se_linux_options_local_nonprim = NULL;
+
     // v1beta1_se_linux_strategy_options->rule
     cJSON *rule = cJSON_GetObjectItemCaseSensitive(v1beta1_se_linux_strategy_optionsJSON, "rule");
     if (!rule) {
@@ -87,7 +90,6 @@ v1beta1_se_linux_strategy_options_t *v1beta1_se_linux_strategy_options_parseFrom
 
     // v1beta1_se_linux_strategy_options->se_linux_options
     cJSON *se_linux_options = cJSON_GetObjectItemCaseSensitive(v1beta1_se_linux_strategy_optionsJSON, "seLinuxOptions");
-    v1_se_linux_options_t *se_linux_options_local_nonprim = NULL;
     if (se_linux_options) { 
     se_linux_options_local_nonprim = v1_se_linux_options_parseFromJSON(se_linux_options); //nonprimitive
     }

--- a/kubernetes/model/v1beta1_subject.c
+++ b/kubernetes/model/v1beta1_subject.c
@@ -111,9 +111,17 @@ v1beta1_subject_t *v1beta1_subject_parseFromJSON(cJSON *v1beta1_subjectJSON){
 
     v1beta1_subject_t *v1beta1_subject_local_var = NULL;
 
+    // define the local variable for v1beta1_subject->group
+    v1beta1_group_subject_t *group_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_subject->service_account
+    v1beta1_service_account_subject_t *service_account_local_nonprim = NULL;
+
+    // define the local variable for v1beta1_subject->user
+    v1beta1_user_subject_t *user_local_nonprim = NULL;
+
     // v1beta1_subject->group
     cJSON *group = cJSON_GetObjectItemCaseSensitive(v1beta1_subjectJSON, "group");
-    v1beta1_group_subject_t *group_local_nonprim = NULL;
     if (group) { 
     group_local_nonprim = v1beta1_group_subject_parseFromJSON(group); //nonprimitive
     }
@@ -132,14 +140,12 @@ v1beta1_subject_t *v1beta1_subject_parseFromJSON(cJSON *v1beta1_subjectJSON){
 
     // v1beta1_subject->service_account
     cJSON *service_account = cJSON_GetObjectItemCaseSensitive(v1beta1_subjectJSON, "serviceAccount");
-    v1beta1_service_account_subject_t *service_account_local_nonprim = NULL;
     if (service_account) { 
     service_account_local_nonprim = v1beta1_service_account_subject_parseFromJSON(service_account); //nonprimitive
     }
 
     // v1beta1_subject->user
     cJSON *user = cJSON_GetObjectItemCaseSensitive(v1beta1_subjectJSON, "user");
-    v1beta1_user_subject_t *user_local_nonprim = NULL;
     if (user) { 
     user_local_nonprim = v1beta1_user_subject_parseFromJSON(user); //nonprimitive
     }

--- a/kubernetes/model/v2beta1_external_metric_source.c
+++ b/kubernetes/model/v2beta1_external_metric_source.c
@@ -101,6 +101,9 @@ v2beta1_external_metric_source_t *v2beta1_external_metric_source_parseFromJSON(c
 
     v2beta1_external_metric_source_t *v2beta1_external_metric_source_local_var = NULL;
 
+    // define the local variable for v2beta1_external_metric_source->metric_selector
+    v1_label_selector_t *metric_selector_local_nonprim = NULL;
+
     // v2beta1_external_metric_source->metric_name
     cJSON *metric_name = cJSON_GetObjectItemCaseSensitive(v2beta1_external_metric_sourceJSON, "metricName");
     if (!metric_name) {
@@ -115,7 +118,6 @@ v2beta1_external_metric_source_t *v2beta1_external_metric_source_parseFromJSON(c
 
     // v2beta1_external_metric_source->metric_selector
     cJSON *metric_selector = cJSON_GetObjectItemCaseSensitive(v2beta1_external_metric_sourceJSON, "metricSelector");
-    v1_label_selector_t *metric_selector_local_nonprim = NULL;
     if (metric_selector) { 
     metric_selector_local_nonprim = v1_label_selector_parseFromJSON(metric_selector); //nonprimitive
     }

--- a/kubernetes/model/v2beta1_external_metric_status.c
+++ b/kubernetes/model/v2beta1_external_metric_status.c
@@ -103,6 +103,9 @@ v2beta1_external_metric_status_t *v2beta1_external_metric_status_parseFromJSON(c
 
     v2beta1_external_metric_status_t *v2beta1_external_metric_status_local_var = NULL;
 
+    // define the local variable for v2beta1_external_metric_status->metric_selector
+    v1_label_selector_t *metric_selector_local_nonprim = NULL;
+
     // v2beta1_external_metric_status->current_average_value
     cJSON *current_average_value = cJSON_GetObjectItemCaseSensitive(v2beta1_external_metric_statusJSON, "currentAverageValue");
     if (current_average_value) { 
@@ -138,7 +141,6 @@ v2beta1_external_metric_status_t *v2beta1_external_metric_status_parseFromJSON(c
 
     // v2beta1_external_metric_status->metric_selector
     cJSON *metric_selector = cJSON_GetObjectItemCaseSensitive(v2beta1_external_metric_statusJSON, "metricSelector");
-    v1_label_selector_t *metric_selector_local_nonprim = NULL;
     if (metric_selector) { 
     metric_selector_local_nonprim = v1_label_selector_parseFromJSON(metric_selector); //nonprimitive
     }

--- a/kubernetes/model/v2beta1_horizontal_pod_autoscaler.c
+++ b/kubernetes/model/v2beta1_horizontal_pod_autoscaler.c
@@ -123,6 +123,15 @@ v2beta1_horizontal_pod_autoscaler_t *v2beta1_horizontal_pod_autoscaler_parseFrom
 
     v2beta1_horizontal_pod_autoscaler_t *v2beta1_horizontal_pod_autoscaler_local_var = NULL;
 
+    // define the local variable for v2beta1_horizontal_pod_autoscaler->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_horizontal_pod_autoscaler->spec
+    v2beta1_horizontal_pod_autoscaler_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_horizontal_pod_autoscaler->status
+    v2beta1_horizontal_pod_autoscaler_status_t *status_local_nonprim = NULL;
+
     // v2beta1_horizontal_pod_autoscaler->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v2beta1_horizontal_pod_autoscalerJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v2beta1_horizontal_pod_autoscaler_t *v2beta1_horizontal_pod_autoscaler_parseFrom
 
     // v2beta1_horizontal_pod_autoscaler->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v2beta1_horizontal_pod_autoscalerJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v2beta1_horizontal_pod_autoscaler->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v2beta1_horizontal_pod_autoscalerJSON, "spec");
-    v2beta1_horizontal_pod_autoscaler_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v2beta1_horizontal_pod_autoscaler_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v2beta1_horizontal_pod_autoscaler->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v2beta1_horizontal_pod_autoscalerJSON, "status");
-    v2beta1_horizontal_pod_autoscaler_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v2beta1_horizontal_pod_autoscaler_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v2beta1_horizontal_pod_autoscaler_list.c
+++ b/kubernetes/model/v2beta1_horizontal_pod_autoscaler_list.c
@@ -116,6 +116,9 @@ v2beta1_horizontal_pod_autoscaler_list_t *v2beta1_horizontal_pod_autoscaler_list
 
     v2beta1_horizontal_pod_autoscaler_list_t *v2beta1_horizontal_pod_autoscaler_list_local_var = NULL;
 
+    // define the local variable for v2beta1_horizontal_pod_autoscaler_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v2beta1_horizontal_pod_autoscaler_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v2beta1_horizontal_pod_autoscaler_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v2beta1_horizontal_pod_autoscaler_list_t *v2beta1_horizontal_pod_autoscaler_list
 
     // v2beta1_horizontal_pod_autoscaler_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v2beta1_horizontal_pod_autoscaler_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v2beta1_horizontal_pod_autoscaler_spec.c
+++ b/kubernetes/model/v2beta1_horizontal_pod_autoscaler_spec.c
@@ -110,6 +110,9 @@ v2beta1_horizontal_pod_autoscaler_spec_t *v2beta1_horizontal_pod_autoscaler_spec
 
     v2beta1_horizontal_pod_autoscaler_spec_t *v2beta1_horizontal_pod_autoscaler_spec_local_var = NULL;
 
+    // define the local variable for v2beta1_horizontal_pod_autoscaler_spec->scale_target_ref
+    v2beta1_cross_version_object_reference_t *scale_target_ref_local_nonprim = NULL;
+
     // v2beta1_horizontal_pod_autoscaler_spec->max_replicas
     cJSON *max_replicas = cJSON_GetObjectItemCaseSensitive(v2beta1_horizontal_pod_autoscaler_specJSON, "maxReplicas");
     if (!max_replicas) {
@@ -159,7 +162,6 @@ v2beta1_horizontal_pod_autoscaler_spec_t *v2beta1_horizontal_pod_autoscaler_spec
         goto end;
     }
 
-    v2beta1_cross_version_object_reference_t *scale_target_ref_local_nonprim = NULL;
     
     scale_target_ref_local_nonprim = v2beta1_cross_version_object_reference_parseFromJSON(scale_target_ref); //nonprimitive
 

--- a/kubernetes/model/v2beta1_metric_spec.c
+++ b/kubernetes/model/v2beta1_metric_spec.c
@@ -149,37 +149,47 @@ v2beta1_metric_spec_t *v2beta1_metric_spec_parseFromJSON(cJSON *v2beta1_metric_s
 
     v2beta1_metric_spec_t *v2beta1_metric_spec_local_var = NULL;
 
+    // define the local variable for v2beta1_metric_spec->container_resource
+    v2beta1_container_resource_metric_source_t *container_resource_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_metric_spec->external
+    v2beta1_external_metric_source_t *external_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_metric_spec->object
+    v2beta1_object_metric_source_t *object_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_metric_spec->pods
+    v2beta1_pods_metric_source_t *pods_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_metric_spec->resource
+    v2beta1_resource_metric_source_t *resource_local_nonprim = NULL;
+
     // v2beta1_metric_spec->container_resource
     cJSON *container_resource = cJSON_GetObjectItemCaseSensitive(v2beta1_metric_specJSON, "containerResource");
-    v2beta1_container_resource_metric_source_t *container_resource_local_nonprim = NULL;
     if (container_resource) { 
     container_resource_local_nonprim = v2beta1_container_resource_metric_source_parseFromJSON(container_resource); //nonprimitive
     }
 
     // v2beta1_metric_spec->external
     cJSON *external = cJSON_GetObjectItemCaseSensitive(v2beta1_metric_specJSON, "external");
-    v2beta1_external_metric_source_t *external_local_nonprim = NULL;
     if (external) { 
     external_local_nonprim = v2beta1_external_metric_source_parseFromJSON(external); //nonprimitive
     }
 
     // v2beta1_metric_spec->object
     cJSON *object = cJSON_GetObjectItemCaseSensitive(v2beta1_metric_specJSON, "object");
-    v2beta1_object_metric_source_t *object_local_nonprim = NULL;
     if (object) { 
     object_local_nonprim = v2beta1_object_metric_source_parseFromJSON(object); //nonprimitive
     }
 
     // v2beta1_metric_spec->pods
     cJSON *pods = cJSON_GetObjectItemCaseSensitive(v2beta1_metric_specJSON, "pods");
-    v2beta1_pods_metric_source_t *pods_local_nonprim = NULL;
     if (pods) { 
     pods_local_nonprim = v2beta1_pods_metric_source_parseFromJSON(pods); //nonprimitive
     }
 
     // v2beta1_metric_spec->resource
     cJSON *resource = cJSON_GetObjectItemCaseSensitive(v2beta1_metric_specJSON, "resource");
-    v2beta1_resource_metric_source_t *resource_local_nonprim = NULL;
     if (resource) { 
     resource_local_nonprim = v2beta1_resource_metric_source_parseFromJSON(resource); //nonprimitive
     }

--- a/kubernetes/model/v2beta1_metric_status.c
+++ b/kubernetes/model/v2beta1_metric_status.c
@@ -149,37 +149,47 @@ v2beta1_metric_status_t *v2beta1_metric_status_parseFromJSON(cJSON *v2beta1_metr
 
     v2beta1_metric_status_t *v2beta1_metric_status_local_var = NULL;
 
+    // define the local variable for v2beta1_metric_status->container_resource
+    v2beta1_container_resource_metric_status_t *container_resource_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_metric_status->external
+    v2beta1_external_metric_status_t *external_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_metric_status->object
+    v2beta1_object_metric_status_t *object_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_metric_status->pods
+    v2beta1_pods_metric_status_t *pods_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_metric_status->resource
+    v2beta1_resource_metric_status_t *resource_local_nonprim = NULL;
+
     // v2beta1_metric_status->container_resource
     cJSON *container_resource = cJSON_GetObjectItemCaseSensitive(v2beta1_metric_statusJSON, "containerResource");
-    v2beta1_container_resource_metric_status_t *container_resource_local_nonprim = NULL;
     if (container_resource) { 
     container_resource_local_nonprim = v2beta1_container_resource_metric_status_parseFromJSON(container_resource); //nonprimitive
     }
 
     // v2beta1_metric_status->external
     cJSON *external = cJSON_GetObjectItemCaseSensitive(v2beta1_metric_statusJSON, "external");
-    v2beta1_external_metric_status_t *external_local_nonprim = NULL;
     if (external) { 
     external_local_nonprim = v2beta1_external_metric_status_parseFromJSON(external); //nonprimitive
     }
 
     // v2beta1_metric_status->object
     cJSON *object = cJSON_GetObjectItemCaseSensitive(v2beta1_metric_statusJSON, "object");
-    v2beta1_object_metric_status_t *object_local_nonprim = NULL;
     if (object) { 
     object_local_nonprim = v2beta1_object_metric_status_parseFromJSON(object); //nonprimitive
     }
 
     // v2beta1_metric_status->pods
     cJSON *pods = cJSON_GetObjectItemCaseSensitive(v2beta1_metric_statusJSON, "pods");
-    v2beta1_pods_metric_status_t *pods_local_nonprim = NULL;
     if (pods) { 
     pods_local_nonprim = v2beta1_pods_metric_status_parseFromJSON(pods); //nonprimitive
     }
 
     // v2beta1_metric_status->resource
     cJSON *resource = cJSON_GetObjectItemCaseSensitive(v2beta1_metric_statusJSON, "resource");
-    v2beta1_resource_metric_status_t *resource_local_nonprim = NULL;
     if (resource) { 
     resource_local_nonprim = v2beta1_resource_metric_status_parseFromJSON(resource); //nonprimitive
     }

--- a/kubernetes/model/v2beta1_object_metric_source.c
+++ b/kubernetes/model/v2beta1_object_metric_source.c
@@ -124,6 +124,12 @@ v2beta1_object_metric_source_t *v2beta1_object_metric_source_parseFromJSON(cJSON
 
     v2beta1_object_metric_source_t *v2beta1_object_metric_source_local_var = NULL;
 
+    // define the local variable for v2beta1_object_metric_source->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_object_metric_source->target
+    v2beta1_cross_version_object_reference_t *target_local_nonprim = NULL;
+
     // v2beta1_object_metric_source->average_value
     cJSON *average_value = cJSON_GetObjectItemCaseSensitive(v2beta1_object_metric_sourceJSON, "averageValue");
     if (average_value) { 
@@ -147,7 +153,6 @@ v2beta1_object_metric_source_t *v2beta1_object_metric_source_parseFromJSON(cJSON
 
     // v2beta1_object_metric_source->selector
     cJSON *selector = cJSON_GetObjectItemCaseSensitive(v2beta1_object_metric_sourceJSON, "selector");
-    v1_label_selector_t *selector_local_nonprim = NULL;
     if (selector) { 
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
     }
@@ -158,7 +163,6 @@ v2beta1_object_metric_source_t *v2beta1_object_metric_source_parseFromJSON(cJSON
         goto end;
     }
 
-    v2beta1_cross_version_object_reference_t *target_local_nonprim = NULL;
     
     target_local_nonprim = v2beta1_cross_version_object_reference_parseFromJSON(target); //nonprimitive
 

--- a/kubernetes/model/v2beta1_object_metric_status.c
+++ b/kubernetes/model/v2beta1_object_metric_status.c
@@ -124,6 +124,12 @@ v2beta1_object_metric_status_t *v2beta1_object_metric_status_parseFromJSON(cJSON
 
     v2beta1_object_metric_status_t *v2beta1_object_metric_status_local_var = NULL;
 
+    // define the local variable for v2beta1_object_metric_status->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
+    // define the local variable for v2beta1_object_metric_status->target
+    v2beta1_cross_version_object_reference_t *target_local_nonprim = NULL;
+
     // v2beta1_object_metric_status->average_value
     cJSON *average_value = cJSON_GetObjectItemCaseSensitive(v2beta1_object_metric_statusJSON, "averageValue");
     if (average_value) { 
@@ -159,7 +165,6 @@ v2beta1_object_metric_status_t *v2beta1_object_metric_status_parseFromJSON(cJSON
 
     // v2beta1_object_metric_status->selector
     cJSON *selector = cJSON_GetObjectItemCaseSensitive(v2beta1_object_metric_statusJSON, "selector");
-    v1_label_selector_t *selector_local_nonprim = NULL;
     if (selector) { 
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
     }
@@ -170,7 +175,6 @@ v2beta1_object_metric_status_t *v2beta1_object_metric_status_parseFromJSON(cJSON
         goto end;
     }
 
-    v2beta1_cross_version_object_reference_t *target_local_nonprim = NULL;
     
     target_local_nonprim = v2beta1_cross_version_object_reference_parseFromJSON(target); //nonprimitive
 

--- a/kubernetes/model/v2beta1_pods_metric_source.c
+++ b/kubernetes/model/v2beta1_pods_metric_source.c
@@ -89,6 +89,9 @@ v2beta1_pods_metric_source_t *v2beta1_pods_metric_source_parseFromJSON(cJSON *v2
 
     v2beta1_pods_metric_source_t *v2beta1_pods_metric_source_local_var = NULL;
 
+    // define the local variable for v2beta1_pods_metric_source->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
     // v2beta1_pods_metric_source->metric_name
     cJSON *metric_name = cJSON_GetObjectItemCaseSensitive(v2beta1_pods_metric_sourceJSON, "metricName");
     if (!metric_name) {
@@ -103,7 +106,6 @@ v2beta1_pods_metric_source_t *v2beta1_pods_metric_source_parseFromJSON(cJSON *v2
 
     // v2beta1_pods_metric_source->selector
     cJSON *selector = cJSON_GetObjectItemCaseSensitive(v2beta1_pods_metric_sourceJSON, "selector");
-    v1_label_selector_t *selector_local_nonprim = NULL;
     if (selector) { 
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
     }

--- a/kubernetes/model/v2beta1_pods_metric_status.c
+++ b/kubernetes/model/v2beta1_pods_metric_status.c
@@ -89,6 +89,9 @@ v2beta1_pods_metric_status_t *v2beta1_pods_metric_status_parseFromJSON(cJSON *v2
 
     v2beta1_pods_metric_status_t *v2beta1_pods_metric_status_local_var = NULL;
 
+    // define the local variable for v2beta1_pods_metric_status->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
     // v2beta1_pods_metric_status->current_average_value
     cJSON *current_average_value = cJSON_GetObjectItemCaseSensitive(v2beta1_pods_metric_statusJSON, "currentAverageValue");
     if (!current_average_value) {
@@ -115,7 +118,6 @@ v2beta1_pods_metric_status_t *v2beta1_pods_metric_status_parseFromJSON(cJSON *v2
 
     // v2beta1_pods_metric_status->selector
     cJSON *selector = cJSON_GetObjectItemCaseSensitive(v2beta1_pods_metric_statusJSON, "selector");
-    v1_label_selector_t *selector_local_nonprim = NULL;
     if (selector) { 
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
     }

--- a/kubernetes/model/v2beta2_container_resource_metric_source.c
+++ b/kubernetes/model/v2beta2_container_resource_metric_source.c
@@ -91,6 +91,9 @@ v2beta2_container_resource_metric_source_t *v2beta2_container_resource_metric_so
 
     v2beta2_container_resource_metric_source_t *v2beta2_container_resource_metric_source_local_var = NULL;
 
+    // define the local variable for v2beta2_container_resource_metric_source->target
+    v2beta2_metric_target_t *target_local_nonprim = NULL;
+
     // v2beta2_container_resource_metric_source->container
     cJSON *container = cJSON_GetObjectItemCaseSensitive(v2beta2_container_resource_metric_sourceJSON, "container");
     if (!container) {
@@ -121,7 +124,6 @@ v2beta2_container_resource_metric_source_t *v2beta2_container_resource_metric_so
         goto end;
     }
 
-    v2beta2_metric_target_t *target_local_nonprim = NULL;
     
     target_local_nonprim = v2beta2_metric_target_parseFromJSON(target); //nonprimitive
 

--- a/kubernetes/model/v2beta2_container_resource_metric_status.c
+++ b/kubernetes/model/v2beta2_container_resource_metric_status.c
@@ -91,6 +91,9 @@ v2beta2_container_resource_metric_status_t *v2beta2_container_resource_metric_st
 
     v2beta2_container_resource_metric_status_t *v2beta2_container_resource_metric_status_local_var = NULL;
 
+    // define the local variable for v2beta2_container_resource_metric_status->current
+    v2beta2_metric_value_status_t *current_local_nonprim = NULL;
+
     // v2beta2_container_resource_metric_status->container
     cJSON *container = cJSON_GetObjectItemCaseSensitive(v2beta2_container_resource_metric_statusJSON, "container");
     if (!container) {
@@ -109,7 +112,6 @@ v2beta2_container_resource_metric_status_t *v2beta2_container_resource_metric_st
         goto end;
     }
 
-    v2beta2_metric_value_status_t *current_local_nonprim = NULL;
     
     current_local_nonprim = v2beta2_metric_value_status_parseFromJSON(current); //nonprimitive
 

--- a/kubernetes/model/v2beta2_external_metric_source.c
+++ b/kubernetes/model/v2beta2_external_metric_source.c
@@ -80,13 +80,18 @@ v2beta2_external_metric_source_t *v2beta2_external_metric_source_parseFromJSON(c
 
     v2beta2_external_metric_source_t *v2beta2_external_metric_source_local_var = NULL;
 
+    // define the local variable for v2beta2_external_metric_source->metric
+    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_external_metric_source->target
+    v2beta2_metric_target_t *target_local_nonprim = NULL;
+
     // v2beta2_external_metric_source->metric
     cJSON *metric = cJSON_GetObjectItemCaseSensitive(v2beta2_external_metric_sourceJSON, "metric");
     if (!metric) {
         goto end;
     }
 
-    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
     
     metric_local_nonprim = v2beta2_metric_identifier_parseFromJSON(metric); //nonprimitive
 
@@ -96,7 +101,6 @@ v2beta2_external_metric_source_t *v2beta2_external_metric_source_parseFromJSON(c
         goto end;
     }
 
-    v2beta2_metric_target_t *target_local_nonprim = NULL;
     
     target_local_nonprim = v2beta2_metric_target_parseFromJSON(target); //nonprimitive
 

--- a/kubernetes/model/v2beta2_external_metric_status.c
+++ b/kubernetes/model/v2beta2_external_metric_status.c
@@ -80,13 +80,18 @@ v2beta2_external_metric_status_t *v2beta2_external_metric_status_parseFromJSON(c
 
     v2beta2_external_metric_status_t *v2beta2_external_metric_status_local_var = NULL;
 
+    // define the local variable for v2beta2_external_metric_status->current
+    v2beta2_metric_value_status_t *current_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_external_metric_status->metric
+    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
+
     // v2beta2_external_metric_status->current
     cJSON *current = cJSON_GetObjectItemCaseSensitive(v2beta2_external_metric_statusJSON, "current");
     if (!current) {
         goto end;
     }
 
-    v2beta2_metric_value_status_t *current_local_nonprim = NULL;
     
     current_local_nonprim = v2beta2_metric_value_status_parseFromJSON(current); //nonprimitive
 
@@ -96,7 +101,6 @@ v2beta2_external_metric_status_t *v2beta2_external_metric_status_parseFromJSON(c
         goto end;
     }
 
-    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
     
     metric_local_nonprim = v2beta2_metric_identifier_parseFromJSON(metric); //nonprimitive
 

--- a/kubernetes/model/v2beta2_horizontal_pod_autoscaler.c
+++ b/kubernetes/model/v2beta2_horizontal_pod_autoscaler.c
@@ -123,6 +123,15 @@ v2beta2_horizontal_pod_autoscaler_t *v2beta2_horizontal_pod_autoscaler_parseFrom
 
     v2beta2_horizontal_pod_autoscaler_t *v2beta2_horizontal_pod_autoscaler_local_var = NULL;
 
+    // define the local variable for v2beta2_horizontal_pod_autoscaler->metadata
+    v1_object_meta_t *metadata_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_horizontal_pod_autoscaler->spec
+    v2beta2_horizontal_pod_autoscaler_spec_t *spec_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_horizontal_pod_autoscaler->status
+    v2beta2_horizontal_pod_autoscaler_status_t *status_local_nonprim = NULL;
+
     // v2beta2_horizontal_pod_autoscaler->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v2beta2_horizontal_pod_autoscalerJSON, "apiVersion");
     if (api_version) { 
@@ -143,21 +152,18 @@ v2beta2_horizontal_pod_autoscaler_t *v2beta2_horizontal_pod_autoscaler_parseFrom
 
     // v2beta2_horizontal_pod_autoscaler->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v2beta2_horizontal_pod_autoscalerJSON, "metadata");
-    v1_object_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_object_meta_parseFromJSON(metadata); //nonprimitive
     }
 
     // v2beta2_horizontal_pod_autoscaler->spec
     cJSON *spec = cJSON_GetObjectItemCaseSensitive(v2beta2_horizontal_pod_autoscalerJSON, "spec");
-    v2beta2_horizontal_pod_autoscaler_spec_t *spec_local_nonprim = NULL;
     if (spec) { 
     spec_local_nonprim = v2beta2_horizontal_pod_autoscaler_spec_parseFromJSON(spec); //nonprimitive
     }
 
     // v2beta2_horizontal_pod_autoscaler->status
     cJSON *status = cJSON_GetObjectItemCaseSensitive(v2beta2_horizontal_pod_autoscalerJSON, "status");
-    v2beta2_horizontal_pod_autoscaler_status_t *status_local_nonprim = NULL;
     if (status) { 
     status_local_nonprim = v2beta2_horizontal_pod_autoscaler_status_parseFromJSON(status); //nonprimitive
     }

--- a/kubernetes/model/v2beta2_horizontal_pod_autoscaler_behavior.c
+++ b/kubernetes/model/v2beta2_horizontal_pod_autoscaler_behavior.c
@@ -76,16 +76,20 @@ v2beta2_horizontal_pod_autoscaler_behavior_t *v2beta2_horizontal_pod_autoscaler_
 
     v2beta2_horizontal_pod_autoscaler_behavior_t *v2beta2_horizontal_pod_autoscaler_behavior_local_var = NULL;
 
+    // define the local variable for v2beta2_horizontal_pod_autoscaler_behavior->scale_down
+    v2beta2_hpa_scaling_rules_t *scale_down_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_horizontal_pod_autoscaler_behavior->scale_up
+    v2beta2_hpa_scaling_rules_t *scale_up_local_nonprim = NULL;
+
     // v2beta2_horizontal_pod_autoscaler_behavior->scale_down
     cJSON *scale_down = cJSON_GetObjectItemCaseSensitive(v2beta2_horizontal_pod_autoscaler_behaviorJSON, "scaleDown");
-    v2beta2_hpa_scaling_rules_t *scale_down_local_nonprim = NULL;
     if (scale_down) { 
     scale_down_local_nonprim = v2beta2_hpa_scaling_rules_parseFromJSON(scale_down); //nonprimitive
     }
 
     // v2beta2_horizontal_pod_autoscaler_behavior->scale_up
     cJSON *scale_up = cJSON_GetObjectItemCaseSensitive(v2beta2_horizontal_pod_autoscaler_behaviorJSON, "scaleUp");
-    v2beta2_hpa_scaling_rules_t *scale_up_local_nonprim = NULL;
     if (scale_up) { 
     scale_up_local_nonprim = v2beta2_hpa_scaling_rules_parseFromJSON(scale_up); //nonprimitive
     }

--- a/kubernetes/model/v2beta2_horizontal_pod_autoscaler_list.c
+++ b/kubernetes/model/v2beta2_horizontal_pod_autoscaler_list.c
@@ -116,6 +116,9 @@ v2beta2_horizontal_pod_autoscaler_list_t *v2beta2_horizontal_pod_autoscaler_list
 
     v2beta2_horizontal_pod_autoscaler_list_t *v2beta2_horizontal_pod_autoscaler_list_local_var = NULL;
 
+    // define the local variable for v2beta2_horizontal_pod_autoscaler_list->metadata
+    v1_list_meta_t *metadata_local_nonprim = NULL;
+
     // v2beta2_horizontal_pod_autoscaler_list->api_version
     cJSON *api_version = cJSON_GetObjectItemCaseSensitive(v2beta2_horizontal_pod_autoscaler_listJSON, "apiVersion");
     if (api_version) { 
@@ -161,7 +164,6 @@ v2beta2_horizontal_pod_autoscaler_list_t *v2beta2_horizontal_pod_autoscaler_list
 
     // v2beta2_horizontal_pod_autoscaler_list->metadata
     cJSON *metadata = cJSON_GetObjectItemCaseSensitive(v2beta2_horizontal_pod_autoscaler_listJSON, "metadata");
-    v1_list_meta_t *metadata_local_nonprim = NULL;
     if (metadata) { 
     metadata_local_nonprim = v1_list_meta_parseFromJSON(metadata); //nonprimitive
     }

--- a/kubernetes/model/v2beta2_horizontal_pod_autoscaler_spec.c
+++ b/kubernetes/model/v2beta2_horizontal_pod_autoscaler_spec.c
@@ -129,9 +129,14 @@ v2beta2_horizontal_pod_autoscaler_spec_t *v2beta2_horizontal_pod_autoscaler_spec
 
     v2beta2_horizontal_pod_autoscaler_spec_t *v2beta2_horizontal_pod_autoscaler_spec_local_var = NULL;
 
+    // define the local variable for v2beta2_horizontal_pod_autoscaler_spec->behavior
+    v2beta2_horizontal_pod_autoscaler_behavior_t *behavior_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_horizontal_pod_autoscaler_spec->scale_target_ref
+    v2beta2_cross_version_object_reference_t *scale_target_ref_local_nonprim = NULL;
+
     // v2beta2_horizontal_pod_autoscaler_spec->behavior
     cJSON *behavior = cJSON_GetObjectItemCaseSensitive(v2beta2_horizontal_pod_autoscaler_specJSON, "behavior");
-    v2beta2_horizontal_pod_autoscaler_behavior_t *behavior_local_nonprim = NULL;
     if (behavior) { 
     behavior_local_nonprim = v2beta2_horizontal_pod_autoscaler_behavior_parseFromJSON(behavior); //nonprimitive
     }
@@ -185,7 +190,6 @@ v2beta2_horizontal_pod_autoscaler_spec_t *v2beta2_horizontal_pod_autoscaler_spec
         goto end;
     }
 
-    v2beta2_cross_version_object_reference_t *scale_target_ref_local_nonprim = NULL;
     
     scale_target_ref_local_nonprim = v2beta2_cross_version_object_reference_parseFromJSON(scale_target_ref); //nonprimitive
 

--- a/kubernetes/model/v2beta2_metric_identifier.c
+++ b/kubernetes/model/v2beta2_metric_identifier.c
@@ -73,6 +73,9 @@ v2beta2_metric_identifier_t *v2beta2_metric_identifier_parseFromJSON(cJSON *v2be
 
     v2beta2_metric_identifier_t *v2beta2_metric_identifier_local_var = NULL;
 
+    // define the local variable for v2beta2_metric_identifier->selector
+    v1_label_selector_t *selector_local_nonprim = NULL;
+
     // v2beta2_metric_identifier->name
     cJSON *name = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_identifierJSON, "name");
     if (!name) {
@@ -87,7 +90,6 @@ v2beta2_metric_identifier_t *v2beta2_metric_identifier_parseFromJSON(cJSON *v2be
 
     // v2beta2_metric_identifier->selector
     cJSON *selector = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_identifierJSON, "selector");
-    v1_label_selector_t *selector_local_nonprim = NULL;
     if (selector) { 
     selector_local_nonprim = v1_label_selector_parseFromJSON(selector); //nonprimitive
     }

--- a/kubernetes/model/v2beta2_metric_spec.c
+++ b/kubernetes/model/v2beta2_metric_spec.c
@@ -149,37 +149,47 @@ v2beta2_metric_spec_t *v2beta2_metric_spec_parseFromJSON(cJSON *v2beta2_metric_s
 
     v2beta2_metric_spec_t *v2beta2_metric_spec_local_var = NULL;
 
+    // define the local variable for v2beta2_metric_spec->container_resource
+    v2beta2_container_resource_metric_source_t *container_resource_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_metric_spec->external
+    v2beta2_external_metric_source_t *external_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_metric_spec->object
+    v2beta2_object_metric_source_t *object_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_metric_spec->pods
+    v2beta2_pods_metric_source_t *pods_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_metric_spec->resource
+    v2beta2_resource_metric_source_t *resource_local_nonprim = NULL;
+
     // v2beta2_metric_spec->container_resource
     cJSON *container_resource = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_specJSON, "containerResource");
-    v2beta2_container_resource_metric_source_t *container_resource_local_nonprim = NULL;
     if (container_resource) { 
     container_resource_local_nonprim = v2beta2_container_resource_metric_source_parseFromJSON(container_resource); //nonprimitive
     }
 
     // v2beta2_metric_spec->external
     cJSON *external = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_specJSON, "external");
-    v2beta2_external_metric_source_t *external_local_nonprim = NULL;
     if (external) { 
     external_local_nonprim = v2beta2_external_metric_source_parseFromJSON(external); //nonprimitive
     }
 
     // v2beta2_metric_spec->object
     cJSON *object = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_specJSON, "object");
-    v2beta2_object_metric_source_t *object_local_nonprim = NULL;
     if (object) { 
     object_local_nonprim = v2beta2_object_metric_source_parseFromJSON(object); //nonprimitive
     }
 
     // v2beta2_metric_spec->pods
     cJSON *pods = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_specJSON, "pods");
-    v2beta2_pods_metric_source_t *pods_local_nonprim = NULL;
     if (pods) { 
     pods_local_nonprim = v2beta2_pods_metric_source_parseFromJSON(pods); //nonprimitive
     }
 
     // v2beta2_metric_spec->resource
     cJSON *resource = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_specJSON, "resource");
-    v2beta2_resource_metric_source_t *resource_local_nonprim = NULL;
     if (resource) { 
     resource_local_nonprim = v2beta2_resource_metric_source_parseFromJSON(resource); //nonprimitive
     }

--- a/kubernetes/model/v2beta2_metric_status.c
+++ b/kubernetes/model/v2beta2_metric_status.c
@@ -149,37 +149,47 @@ v2beta2_metric_status_t *v2beta2_metric_status_parseFromJSON(cJSON *v2beta2_metr
 
     v2beta2_metric_status_t *v2beta2_metric_status_local_var = NULL;
 
+    // define the local variable for v2beta2_metric_status->container_resource
+    v2beta2_container_resource_metric_status_t *container_resource_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_metric_status->external
+    v2beta2_external_metric_status_t *external_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_metric_status->object
+    v2beta2_object_metric_status_t *object_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_metric_status->pods
+    v2beta2_pods_metric_status_t *pods_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_metric_status->resource
+    v2beta2_resource_metric_status_t *resource_local_nonprim = NULL;
+
     // v2beta2_metric_status->container_resource
     cJSON *container_resource = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_statusJSON, "containerResource");
-    v2beta2_container_resource_metric_status_t *container_resource_local_nonprim = NULL;
     if (container_resource) { 
     container_resource_local_nonprim = v2beta2_container_resource_metric_status_parseFromJSON(container_resource); //nonprimitive
     }
 
     // v2beta2_metric_status->external
     cJSON *external = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_statusJSON, "external");
-    v2beta2_external_metric_status_t *external_local_nonprim = NULL;
     if (external) { 
     external_local_nonprim = v2beta2_external_metric_status_parseFromJSON(external); //nonprimitive
     }
 
     // v2beta2_metric_status->object
     cJSON *object = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_statusJSON, "object");
-    v2beta2_object_metric_status_t *object_local_nonprim = NULL;
     if (object) { 
     object_local_nonprim = v2beta2_object_metric_status_parseFromJSON(object); //nonprimitive
     }
 
     // v2beta2_metric_status->pods
     cJSON *pods = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_statusJSON, "pods");
-    v2beta2_pods_metric_status_t *pods_local_nonprim = NULL;
     if (pods) { 
     pods_local_nonprim = v2beta2_pods_metric_status_parseFromJSON(pods); //nonprimitive
     }
 
     // v2beta2_metric_status->resource
     cJSON *resource = cJSON_GetObjectItemCaseSensitive(v2beta2_metric_statusJSON, "resource");
-    v2beta2_resource_metric_status_t *resource_local_nonprim = NULL;
     if (resource) { 
     resource_local_nonprim = v2beta2_resource_metric_status_parseFromJSON(resource); //nonprimitive
     }

--- a/kubernetes/model/v2beta2_object_metric_source.c
+++ b/kubernetes/model/v2beta2_object_metric_source.c
@@ -101,13 +101,21 @@ v2beta2_object_metric_source_t *v2beta2_object_metric_source_parseFromJSON(cJSON
 
     v2beta2_object_metric_source_t *v2beta2_object_metric_source_local_var = NULL;
 
+    // define the local variable for v2beta2_object_metric_source->described_object
+    v2beta2_cross_version_object_reference_t *described_object_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_object_metric_source->metric
+    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_object_metric_source->target
+    v2beta2_metric_target_t *target_local_nonprim = NULL;
+
     // v2beta2_object_metric_source->described_object
     cJSON *described_object = cJSON_GetObjectItemCaseSensitive(v2beta2_object_metric_sourceJSON, "describedObject");
     if (!described_object) {
         goto end;
     }
 
-    v2beta2_cross_version_object_reference_t *described_object_local_nonprim = NULL;
     
     described_object_local_nonprim = v2beta2_cross_version_object_reference_parseFromJSON(described_object); //nonprimitive
 
@@ -117,7 +125,6 @@ v2beta2_object_metric_source_t *v2beta2_object_metric_source_parseFromJSON(cJSON
         goto end;
     }
 
-    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
     
     metric_local_nonprim = v2beta2_metric_identifier_parseFromJSON(metric); //nonprimitive
 
@@ -127,7 +134,6 @@ v2beta2_object_metric_source_t *v2beta2_object_metric_source_parseFromJSON(cJSON
         goto end;
     }
 
-    v2beta2_metric_target_t *target_local_nonprim = NULL;
     
     target_local_nonprim = v2beta2_metric_target_parseFromJSON(target); //nonprimitive
 

--- a/kubernetes/model/v2beta2_object_metric_status.c
+++ b/kubernetes/model/v2beta2_object_metric_status.c
@@ -101,13 +101,21 @@ v2beta2_object_metric_status_t *v2beta2_object_metric_status_parseFromJSON(cJSON
 
     v2beta2_object_metric_status_t *v2beta2_object_metric_status_local_var = NULL;
 
+    // define the local variable for v2beta2_object_metric_status->current
+    v2beta2_metric_value_status_t *current_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_object_metric_status->described_object
+    v2beta2_cross_version_object_reference_t *described_object_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_object_metric_status->metric
+    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
+
     // v2beta2_object_metric_status->current
     cJSON *current = cJSON_GetObjectItemCaseSensitive(v2beta2_object_metric_statusJSON, "current");
     if (!current) {
         goto end;
     }
 
-    v2beta2_metric_value_status_t *current_local_nonprim = NULL;
     
     current_local_nonprim = v2beta2_metric_value_status_parseFromJSON(current); //nonprimitive
 
@@ -117,7 +125,6 @@ v2beta2_object_metric_status_t *v2beta2_object_metric_status_parseFromJSON(cJSON
         goto end;
     }
 
-    v2beta2_cross_version_object_reference_t *described_object_local_nonprim = NULL;
     
     described_object_local_nonprim = v2beta2_cross_version_object_reference_parseFromJSON(described_object); //nonprimitive
 
@@ -127,7 +134,6 @@ v2beta2_object_metric_status_t *v2beta2_object_metric_status_parseFromJSON(cJSON
         goto end;
     }
 
-    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
     
     metric_local_nonprim = v2beta2_metric_identifier_parseFromJSON(metric); //nonprimitive
 

--- a/kubernetes/model/v2beta2_pods_metric_source.c
+++ b/kubernetes/model/v2beta2_pods_metric_source.c
@@ -80,13 +80,18 @@ v2beta2_pods_metric_source_t *v2beta2_pods_metric_source_parseFromJSON(cJSON *v2
 
     v2beta2_pods_metric_source_t *v2beta2_pods_metric_source_local_var = NULL;
 
+    // define the local variable for v2beta2_pods_metric_source->metric
+    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_pods_metric_source->target
+    v2beta2_metric_target_t *target_local_nonprim = NULL;
+
     // v2beta2_pods_metric_source->metric
     cJSON *metric = cJSON_GetObjectItemCaseSensitive(v2beta2_pods_metric_sourceJSON, "metric");
     if (!metric) {
         goto end;
     }
 
-    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
     
     metric_local_nonprim = v2beta2_metric_identifier_parseFromJSON(metric); //nonprimitive
 
@@ -96,7 +101,6 @@ v2beta2_pods_metric_source_t *v2beta2_pods_metric_source_parseFromJSON(cJSON *v2
         goto end;
     }
 
-    v2beta2_metric_target_t *target_local_nonprim = NULL;
     
     target_local_nonprim = v2beta2_metric_target_parseFromJSON(target); //nonprimitive
 

--- a/kubernetes/model/v2beta2_pods_metric_status.c
+++ b/kubernetes/model/v2beta2_pods_metric_status.c
@@ -80,13 +80,18 @@ v2beta2_pods_metric_status_t *v2beta2_pods_metric_status_parseFromJSON(cJSON *v2
 
     v2beta2_pods_metric_status_t *v2beta2_pods_metric_status_local_var = NULL;
 
+    // define the local variable for v2beta2_pods_metric_status->current
+    v2beta2_metric_value_status_t *current_local_nonprim = NULL;
+
+    // define the local variable for v2beta2_pods_metric_status->metric
+    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
+
     // v2beta2_pods_metric_status->current
     cJSON *current = cJSON_GetObjectItemCaseSensitive(v2beta2_pods_metric_statusJSON, "current");
     if (!current) {
         goto end;
     }
 
-    v2beta2_metric_value_status_t *current_local_nonprim = NULL;
     
     current_local_nonprim = v2beta2_metric_value_status_parseFromJSON(current); //nonprimitive
 
@@ -96,7 +101,6 @@ v2beta2_pods_metric_status_t *v2beta2_pods_metric_status_parseFromJSON(cJSON *v2
         goto end;
     }
 
-    v2beta2_metric_identifier_t *metric_local_nonprim = NULL;
     
     metric_local_nonprim = v2beta2_metric_identifier_parseFromJSON(metric); //nonprimitive
 

--- a/kubernetes/model/v2beta2_resource_metric_source.c
+++ b/kubernetes/model/v2beta2_resource_metric_source.c
@@ -75,6 +75,9 @@ v2beta2_resource_metric_source_t *v2beta2_resource_metric_source_parseFromJSON(c
 
     v2beta2_resource_metric_source_t *v2beta2_resource_metric_source_local_var = NULL;
 
+    // define the local variable for v2beta2_resource_metric_source->target
+    v2beta2_metric_target_t *target_local_nonprim = NULL;
+
     // v2beta2_resource_metric_source->name
     cJSON *name = cJSON_GetObjectItemCaseSensitive(v2beta2_resource_metric_sourceJSON, "name");
     if (!name) {
@@ -93,7 +96,6 @@ v2beta2_resource_metric_source_t *v2beta2_resource_metric_source_parseFromJSON(c
         goto end;
     }
 
-    v2beta2_metric_target_t *target_local_nonprim = NULL;
     
     target_local_nonprim = v2beta2_metric_target_parseFromJSON(target); //nonprimitive
 

--- a/kubernetes/model/v2beta2_resource_metric_status.c
+++ b/kubernetes/model/v2beta2_resource_metric_status.c
@@ -75,13 +75,15 @@ v2beta2_resource_metric_status_t *v2beta2_resource_metric_status_parseFromJSON(c
 
     v2beta2_resource_metric_status_t *v2beta2_resource_metric_status_local_var = NULL;
 
+    // define the local variable for v2beta2_resource_metric_status->current
+    v2beta2_metric_value_status_t *current_local_nonprim = NULL;
+
     // v2beta2_resource_metric_status->current
     cJSON *current = cJSON_GetObjectItemCaseSensitive(v2beta2_resource_metric_statusJSON, "current");
     if (!current) {
         goto end;
     }
 
-    v2beta2_metric_value_status_t *current_local_nonprim = NULL;
     
     current_local_nonprim = v2beta2_metric_value_status_parseFromJSON(current); //nonprimitive
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes-client/c/issues/89

As suggested by @brendandburns, define and initialize non-primitive variables at the beginning of function to avoid freeing invalid variables.

The fix is actually made in https://github.com/OpenAPITools/openapi-generator/pull/10756, now re-generate the client to merge the fix.