### PR TITLE
Add libwebsockets to configuration template

### DIFF
--- a/kubernetes/Config.cmake.in
+++ b/kubernetes/Config.cmake.in
@@ -1,5 +1,6 @@
 find_package(OpenSSL REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(yaml CONFIG REQUIRED)
+find_package(libwebsockets CONFIG REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@pkgName@Targets.cmake")


### PR DESCRIPTION
It currently works on Linux just because we are installing libwebsockets under /usr/...
If you try installing it inside vcpkg for example, libwebsockets will not be found when building an app that uses this library.