### PR TITLE
Update the documents of the release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,11 +4,12 @@ The Kubernetes C Client Project is released on an as-needed basis. The process i
 
 1. An issue is proposing a new release with a changelog since the last release
 1. All [OWNERS](OWNERS) must LGTM this release
-1. An OWNER runs `git tag -s $VERSION` or `git tag -a $VERSION` (If GPG-signed tag is not required) and inserts the changelog and pushes the tag with `git push $VERSION`
+1. An OWNER runs `git tag -s $VERSION` or `git tag -a $VERSION` (If GPG-signed tag is not required) and inserts the changelog and pushes the tag with `git push origin $VERSION`
 
     e.g
     ```shell
     git tag -a v0.1.0 -m "version 0.1.0"
+    git push origin v0.1.0
     ```
 
 1. The release issue is closed

--- a/docs/how-to-regenerate-the-c-client.md
+++ b/docs/how-to-regenerate-the-c-client.md
@@ -52,7 +52,7 @@ cd $GEN_REPO_ROOT/openapi
 ./c.sh $OUTPUT_DIR $SETTING_FILE
 ```
 
-Optionally, delete the old model/api/unit-test files in the C client because some of them are deprecated in the new Kubernetes spec:
+Delete the old model/api/unit-test files in the C client because some of them are deprecated in the new Kubernetes spec:
 
 ```bash
 cd $CLIENT_REPO_ROOT/kubernetes
@@ -67,6 +67,17 @@ Copy the generated files to overwrite the files in the C client:
 ```bash
 cp -rf $OUTPUT_DIR/* $CLIENT_REPO_ROOT/kubernetes/
 ```
+
+Update the version in $CLIENT_REPO_ROOT/kubernetes/PreTarget.cmake if needed:
+
+e.g.
+```cmake
+set(PROJECT_VERSION_MAJOR 0)
+set(PROJECT_VERSION_MINOR 1)
+set(PROJECT_VERSION_PATCH 0)
+```
+
+Update [Versioning and Compatibility](versioning-and-compatibility.md) if needed.
 
 Check the new/changed/deleted files:
 


### PR DESCRIPTION
1.  Add the command to manully push tags.
2.  Update the version when regenerating the client.