### PR TITLE
Eliminate some compiler warnings

### DIFF
--- a/kubernetes/include/apiClient.h
+++ b/kubernetes/include/apiClient.h
@@ -40,7 +40,7 @@ apiClient_t* apiClient_create_with_base_path(const char *basePath
 
 void apiClient_free(apiClient_t *apiClient);
 
-void apiClient_invoke(apiClient_t *apiClient,char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, char *bodyParameters, char *requestType);
+void apiClient_invoke(apiClient_t *apiClient,const char* operationParameter, list_t *queryParameters, list_t *headerParameters, list_t *formParameters,list_t *headerType,list_t *contentType, const char *bodyParameters, const char *requestType);
 
 sslConfig_t *sslConfig_create(const char *clientCertFile, const char *clientKeyFile, const char *CACertFile, int insecureSkipTlsVerify);
 

--- a/kubernetes/src/apiClient.c
+++ b/kubernetes/src/apiClient.c
@@ -119,8 +119,8 @@ void replaceSpaceWithPlus(char *stringToProcess) {
     }
 }
 
-char *assembleTargetUrl(char    *basePath,
-                        char    *operationParameter,
+char *assembleTargetUrl(const char  *basePath,
+                        const char  *operationParameter,
                         list_t    *queryParameters) {
     int neededBufferSizeForQueryParameters = 0;
     listEntry_t *listEntry;
@@ -182,7 +182,7 @@ char *assembleHeaderField(char *key, char *value) {
     return header;
 }
 
-void postData(CURL *handle, char *bodyParameters) {
+void postData(CURL *handle, const char *bodyParameters) {
     curl_easy_setopt(handle, CURLOPT_POSTFIELDS, bodyParameters);
     curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE_LARGE,
                      strlen(bodyParameters));
@@ -201,14 +201,14 @@ int lengthOfKeyPair(keyValuePair_t *keyPair) {
 
 
 void apiClient_invoke(apiClient_t    *apiClient,
-                      char        *operationParameter,
+                      const char    *operationParameter,
                       list_t        *queryParameters,
                       list_t        *headerParameters,
                       list_t        *formParameters,
                       list_t        *headerType,
                       list_t        *contentType,
-                      char        *bodyParameters,
-                      char        *requestType) {
+                      const char    *bodyParameters,
+                      const char    *requestType) {
     CURL *handle = curl_easy_init();
     CURLcode res;
 

--- a/settings
+++ b/settings
@@ -1,9 +1,9 @@
 # Kubernetes branch/tag to get the OpenAPI spec from.
-export KUBERNETES_BRANCH="v1.22.1"
+export KUBERNETES_BRANCH="v1.23.5"
 
 # client version for packaging and releasing. It can
 # be different than SPEC_VERSION.
-export CLIENT_VERSION="0.1.0"
+export CLIENT_VERSION="0.3.0"
 
 # Name of the release package
 export PACKAGE_NAME="client"


### PR DESCRIPTION
- Merge https://github.com/OpenAPITools/openapi-generator/pull/12260 to eliminate some compiler warnings
- Update the file `settings` that I forgot to commit when bumping forward to Kubernetes v1.23.5 https://github.com/kubernetes-client/c/pull/117