### PR TITLE
Support free-form objects

### DIFF
--- a/kubernetes/model/object.c
+++ b/kubernetes/model/object.c
@@ -28,7 +28,7 @@ cJSON *object_convertToJSON(object_t *object) {
     }
 
     if (!object->temporary) {
-        return cJSON_Parse("{}");
+        return cJSON_Parse("null");
     }
 
     return cJSON_Parse(object->temporary);

--- a/kubernetes/model/object.c
+++ b/kubernetes/model/object.c
@@ -4,28 +4,48 @@
 #include "object.h"
 
 object_t *object_create() {
-    object_t *object = malloc(sizeof(object_t));
+    object_t *object = calloc(1, sizeof(object_t));
 
     return object;
 }
 
 void object_free(object_t *object) {
+    if (!object) {
+        return ;
+    }
+
+    if (object->temporary) {
+        free(object->temporary);
+        object->temporary = NULL;
+    }
+
     free (object);
 }
 
 cJSON *object_convertToJSON(object_t *object) {
-    cJSON *item = cJSON_CreateObject();
+    if (!object) {
+        return NULL;
+    }
 
-    return item;
-fail:
-    cJSON_Delete(item);
-    return NULL;
+    if (!object->temporary) {
+        return cJSON_Parse("{}");
+    }
+
+    return cJSON_Parse(object->temporary);
 }
 
-object_t *object_parseFromJSON(char *jsonString){
-    object_t *object = NULL;
+object_t *object_parseFromJSON(cJSON *json){
+    if (!json) {
+        goto end;
+    }
 
+    object_t *object = object_create();
+    if (!object) {
+        goto end;
+    }
+    object->temporary = cJSON_Print(json);
     return object;
+
 end:
     return NULL;
 }

--- a/kubernetes/model/object.h
+++ b/kubernetes/model/object.h
@@ -20,7 +20,7 @@ object_t *object_create();
 
 void object_free(object_t *object);
 
-object_t *object_parseFromJSON(char *jsonString);
+object_t *object_parseFromJSON(cJSON *json);
 
 cJSON *object_convertToJSON(object_t *object);
 


### PR DESCRIPTION
This PR merges the upstream PR https://github.com/OpenAPITools/openapi-generator/pull/12557 to support `free-form` objects.

And fixes https://github.com/kubernetes-client/c/issues/123