### PR TITLE
Wait for the pod to terminate cleanly after deleting the pod during testing

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -31,6 +31,7 @@ test:
 	kubectl wait --for=condition=ready --all pod -n default --timeout=60s
 	cd list_pod; make test
 	cd delete_pod; make test
+	kubectl wait --for=delete pod/test-pod-6 -n default --timeout=120s
 	cd list_secret; make test
 	cd configmap; make test
 	cd generic; make test
@@ -44,6 +45,7 @@ memcheck:
 	kubectl wait --for=condition=ready --all pod -n default --timeout=60s
 	cd list_pod; make memcheck
 	cd delete_pod; make memcheck
+	kubectl wait --for=delete pod/test-pod-6 -n default --timeout=120s
 	cd list_secret; make memcheck
 	cd configmap; make memcheck
 	cd generic; make memcheck


### PR DESCRIPTION
When the `delete_pod` example executes, it does not wait for the pod to terminate, but returns directly. 
Sometimes, this will cause the following tests during Github Action example test/memcheck to fail.  e.g. https://github.com/kubernetes-client/c/runs/7882712017?check_suite_focus=true

This PR adds a "wait" for pod deletion.