### PR TITLE
Add check for the presence of secure_getenv

### DIFF
--- a/kubernetes/ConfigureChecks.cmake
+++ b/kubernetes/ConfigureChecks.cmake
@@ -1,3 +1,4 @@
 include(CheckFunctionExists)
 
 check_function_exists(strndup HAVE_STRNDUP)
+check_function_exists(secure_getenv HAVE_SECURE_GETENV)

--- a/kubernetes/config.h.in
+++ b/kubernetes/config.h.in
@@ -1,2 +1,3 @@
 /* Define to 1 if you have the `strndup' function. */
 #cmakedefine HAVE_STRNDUP 1
+#cmakedefine HAVE_SECURE_GETENV 1

--- a/kubernetes/config/incluster_config.c
+++ b/kubernetes/config/incluster_config.c
@@ -45,7 +45,7 @@ static int setBasePathInCluster(char **pBasePath)
 {
     static char fname[] = "setBasePathInCluster()";
 
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || defined(__APPLE__)
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || defined(__APPLE__) || !defined(HAVE_SECURE_GETENV)
     const char *service_host_env = getenv(SERVICE_HOST_ENV_NAME);
 #elif __linux || defined(__EMSCRIPTEN__)
     const char *service_host_env = secure_getenv(SERVICE_HOST_ENV_NAME);
@@ -54,7 +54,7 @@ static int setBasePathInCluster(char **pBasePath)
         fprintf(stderr, "%s: Cannot retrieve the kubernetes service host inside a pod by the env %s.\n", fname, SERVICE_HOST_ENV_NAME);
         return -1;
     }
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || defined(__APPLE__)
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || defined(__APPLE__) || !defined(HAVE_SECURE_GETENV)
     const char *service_port_env = getenv(SERVICE_PORT_ENV_NAME);
 #elif __linux || defined(__EMSCRIPTEN__)
     const char *service_port_env = secure_getenv(SERVICE_PORT_ENV_NAME);

--- a/kubernetes/config/kube_config.c
+++ b/kubernetes/config/kube_config.c
@@ -111,7 +111,7 @@ static char *getWorkingConfigFile(const char *configFileNamePassedIn)
         configFileName = strdup(configFileNamePassedIn);
     } else {
 
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || defined(__APPLE__)
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || defined(__APPLE__) || !defined(HAVE_SECURE_GETENV)
         kubeconfig_env = getenv(ENV_KUBECONFIG);
 #elif __linux || defined(__EMSCRIPTEN__)
         kubeconfig_env = secure_getenv(ENV_KUBECONFIG);
@@ -119,7 +119,7 @@ static char *getWorkingConfigFile(const char *configFileNamePassedIn)
         if (kubeconfig_env) {
             configFileName = strdup(kubeconfig_env);
         } else {
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || defined(__APPLE__)
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__) || defined(__APPLE__) || !defined(HAVE_SECURE_GETENV)
             homedir_env = getenv(ENV_HOME);
 #elif __linux || defined(__EMSCRIPTEN__)
             homedir_env = secure_getenv(ENV_HOME);


### PR DESCRIPTION
This change introduces support for glibc versions older than 2.17 where secure_getenv was introduced.