### PR TITLE
Add support for IPv6 addresses in the in-cluster resolution

### DIFF
--- a/kubernetes/config/incluster_config.c
+++ b/kubernetes/config/incluster_config.c
@@ -65,13 +65,24 @@ static int setBasePathInCluster(char **pBasePath)
     }
 
     int basePathSize = strlen(SERVICE_HTTPS_PREFIX) + strlen(service_host_env) + strlen(service_port_env) + 2 /* 1 for ':', 1 for '\0' */ ;
+    bool isIPv6 = false;
+    if (strchr(service_host_env, ':') == NULL)
+    {
+        isIPv6 = true;
+        // Takes into account the square brackets to escape the IP v6 address.
+        basePathSize += 2;
+    }
     char *basePath = calloc(basePathSize, sizeof(char));
     if (!basePath) {
         fprintf(stderr, "%s: Cannot allocate the memory for base path for kubernetes service.\n", fname);
         return -1;
     }
 
-    snprintf(basePath, basePathSize, "%s%s:%s", SERVICE_HTTPS_PREFIX, service_host_env, service_port_env);
+    if (isIPv6) {
+        snprintf(basePath, basePathSize, "%s[%s]:%s", SERVICE_HTTPS_PREFIX, service_host_env, service_port_env);
+    } else {
+        snprintf(basePath, basePathSize, "%s%s:%s", SERVICE_HTTPS_PREFIX, service_host_env, service_port_env);
+    }
     *pBasePath = basePath;
     return 0;
 }

--- a/kubernetes/config/incluster_config.c
+++ b/kubernetes/config/incluster_config.c
@@ -66,8 +66,7 @@ static int setBasePathInCluster(char **pBasePath)
 
     int basePathSize = strlen(SERVICE_HTTPS_PREFIX) + strlen(service_host_env) + strlen(service_port_env) + 2 /* 1 for ':', 1 for '\0' */ ;
     bool isIPv6 = false;
-    if (strchr(service_host_env, ':') == NULL)
-    {
+    if (strchr(service_host_env, ':') != NULL) {
         isIPv6 = true;
         // Takes into account the square brackets to escape the IP v6 address.
         basePathSize += 2;


### PR DESCRIPTION
This change adds support for kubernetes services with cluster IPs v6 for the in cluster resolution. Previously, the IP v6 addresses were not wrapped in square brackets when forming the Apiserver URL.