### PR TITLE
Update config.h.in to be more clear

### DIFF
--- a/kubernetes/config.h.in
+++ b/kubernetes/config.h.in
@@ -1,3 +1,2 @@
-/* Define to 1 if you have the `strndup' function. */
-#cmakedefine HAVE_STRNDUP 1
-#cmakedefine HAVE_SECURE_GETENV 1
+#cmakedefine HAVE_STRNDUP
+#cmakedefine HAVE_SECURE_GETENV


### PR DESCRIPTION
config.h.in
```cmake
/* Define to 1 if you have the `strndup' function. */
#cmakedefine HAVE_STRNDUP 1
#cmakedefine HAVE_SECURE_GETENV 1
```

- The comment should be removed and
- `HAVE_STRNDUP` and `HAVE_SECURE_GETENV` don't  need to be cmakedefined to any value because they are defined/undefined by https://github.com/kubernetes-client/c/blob/master/kubernetes/ConfigureChecks.cmake

```cmake
check_function_exists(strndup HAVE_STRNDUP)
check_function_exists(secure_getenv HAVE_SECURE_GETENV)
```