### PR TITLE
Increase buffer size

### DIFF
--- a/kubernetes/config/exec_provider.c
+++ b/kubernetes/config/exec_provider.c
@@ -5,9 +5,9 @@
 #include <errno.h>
 
 #define ARGS_DELIM " "
-#define KUBECONFIG_EXEC_ARGS_BUFFER_SIZE 1024
-#define KUBECONFIG_EXEC_COMMAND_BUFFER_SIZE 1024
-#define KUBECONFIG_STRING_BUFFER_SIZE 1024
+#define KUBECONFIG_EXEC_ARGS_BUFFER_SIZE 4096
+#define KUBECONFIG_EXEC_COMMAND_BUFFER_SIZE 4096
+#define KUBECONFIG_STRING_BUFFER_SIZE 4096
 #define KUBECONFIG_EXEC_RESULT_BUFFER_SIZE 4096
 
 int kube_exec_and_get_result(ExecCredential_t * exec_credential, const kubeconfig_property_t * exec)
@@ -69,7 +69,7 @@ int kube_exec_and_get_result(ExecCredential_t * exec_credential, const kubeconfi
 #ifndef _WIN32
     fp = popen(command_string, "r");    /* r means read from stdout */
 #else
-    fp = _popen(command_string, "r");    /* r means read from stdout */
+    fp = _popen(command_string, "r");   /* r means read from stdout */
 #endif
     if (fp) {
         result_string = calloc(1, KUBECONFIG_EXEC_RESULT_BUFFER_SIZE);

--- a/kubernetes/config/kube_config.c
+++ b/kubernetes/config/kube_config.c
@@ -93,6 +93,10 @@ static int setApiKeys(list_t ** pApiKeys, const char *token)
         return -1;
     }
 
+    if (strlen(BEARER_TOKEN_TEMPLATE) + strlen(token) >= BEARER_TOKEN_BUFFER_SIZE) {
+        fprintf(stderr, "%s: The buffer for bearer token is insufficient.\n", fname);
+        return -1;
+    }
     char tokenValue[BEARER_TOKEN_BUFFER_SIZE];
     memset(tokenValue, 0, sizeof(tokenValue));
     snprintf(tokenValue, BEARER_TOKEN_BUFFER_SIZE, BEARER_TOKEN_TEMPLATE, token);

--- a/kubernetes/config/kube_config_common.h
+++ b/kubernetes/config/kube_config_common.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #define AUTH_TOKEN_KEY "Authorization"
 #define BEARER_TOKEN_TEMPLATE "Bearer %s"
-#define BEARER_TOKEN_BUFFER_SIZE 2048
+#define BEARER_TOKEN_BUFFER_SIZE 4096
 #define BASIC_TOKEN_TEMPLATE "Basic %s"
 #define BASIC_TOKEN_BUFFER_SIZE 1024
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes-client/c/issues/177

1. Increase the buffer size for bearer token and exec-provider.
2. Check the buffer size for bearer token before use.