### PR TITLE
Bump helm/kind-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         cd examples/
         make
     - name: Create k8s kind cluster
-      uses: helm/kind-action@v1.2.0
+      uses: helm/kind-action@v1.4.0
     - name: Test examples
       run: |
         kubectl cluster-info --context kind-chart-testing


### PR DESCRIPTION
Fixes the warning:

[build-library-and-examples](https://github.com/kubernetes-client/c/actions/runs/4611310229/jobs/8207141907)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: helm/kind-action@v1.2.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.