### PR TITLE
fix([README.md]): typos in README.md causes installation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ git clone https://libwebsockets.org/repo/libwebsockets --depth 1 --branch v4.2-s
 cd libwebsockets
 mkdir build
 cd build
-cmake -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON-DLWS_WITHOUT_TEST_SERVER_EXTPOLL=ON \
+cmake -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON -DLWS_WITHOUT_TEST_SERVER_EXTPOLL=ON \
       -DLWS_WITHOUT_TEST_PING=ON -DLWS_WITHOUT_TEST_CLIENT=ON -DCMAKE_C_FLAGS="-fpic" -DCMAKE_INSTALL_PREFIX=/usr/local ..
 make
 sudo make install


### PR DESCRIPTION
### Summary

The following description in README.md might causes ambiguous parsing during cmake code building:
```
cmake -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON-DLWS_WITHOUT_TEST_SERVER_EXTPOLL=ON.
```
### What is the behavior?

While copying above commands to Dockerfile, error was encountered. 

The code is built in Docker under CentOS Linux release 7.7.1908 (Core) with cmake version 3.6.2.

```
Dockerfile:3
--------------------
   2 |     ADD cbrs /opt/app
  17 | >>>     RUN cd /opt/app/ && \
  18 | >>>     # Install pre-requisites
  19 | >>>     yum install -y openssl-devel libcurl-devel uncrustify && \
  20 | >>>     # Build pre-requisite: libwebsockets
  21 | >>>     git clone https://libwebsockets.org/repo/libwebsockets --depth 1 --branch v4.2-stable && \
  22 | >>>     cd libwebsockets && mkdir build && cd build && \
  23 | >>>     cmake -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON-DLWS_WITHOUT_TEST_SERVER_EXTPOLL=ON \
  24 | >>>        -DLWS_WITHOUT_TEST_PING=ON -DLWS_WITHOUT_TEST_CLIENT=ON -DCMAKE_C_FLAGS="-fpic" -DCMAKE_INSTALL_PREFIX=/usr/local ..
--------------------
ERROR: failed to solve: process "/bin/sh -c cd /opt/app/ &&     yum install -y libssl-dev libcurl4-openssl-dev uncrustify &&     git clone https://libwebsockets.org/repo/libwebsockets --depth 1 --branch v4.2-stable &&     cd libwebsockets && mkdir build && cd build &&     cmake -DLWS_WITHOUT_TESTAPPS=ON        -DLWS_WITHOUT_TEST_SERVER=ON-DLWS_WITHOUT_TEST_SERVER_EXTPOLL=ON        -DLWS_WITHOUT_TEST_PING=ON        -DLWS_WITHOUT_TEST_CLIENT=ON        -DCMAKE_C_FLAGS=\"-fpic\" .." did not complete successfully: exit code: 1
ERROR: Service 'app' failed to build
```
### Advise

A _maybe_ nicer description would be splitting _-D_ from _SERVER=ON_, which makes the command less ambiguous.

/label ~bug ~reproduced ~needs-investigation