### PR TITLE
Setup Java environment for openapi-generator in the github action

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -25,6 +25,10 @@ jobs:
     steps:
       - name: Checkout C
         uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+          with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: Checkout Gen
         run: |
           git clone https://github.com/kubernetes-client/gen


### PR DESCRIPTION
Try to fix the following issue:

```bash
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-release-plugin/2.5.3/maven-release-plugin-2.5.3.jar (53 kB at 1.0 MB/s)
Error:  Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.3.0:enforce (enforce-maven) on project openapi-generator-project: 
Error:  Rule 0: org.apache.maven.enforcer.rules.version.RequireJavaVersion failed with message:
Error:  Detected JDK version 1.8.0-302 (JAVA_HOME=/usr/local/openjdk-8/jre) is not in the allowed range [1.11.0,).
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
The command '/bin/sh -c chmod -R go+rwx /root && umask 0 && cd /source/openapi-generator &&     mvn install -DskipTests -Dmaven.test.skip=true -pl modules/openapi-generator-maven-plugin -am &&     cp -r /root/.m2/* /usr/share/maven/ref' returned a non-zero code: 1
Error: Process completed with exit code 1.
```