### PR TITLE
Fixed pod logs core api request errors.

### DIFF
--- a/kubernetes/api/CoreV1API.c
+++ b/kubernetes/api/CoreV1API.c
@@ -35170,7 +35170,7 @@ CoreV1API_readNamespacedPodLog(apiClient_t *apiClient, char *name, char *_namesp
         keyPairQuery_timestamps = keyValuePair_create(keyQuery_timestamps, valueQuery_timestamps);
         list_addElement(localVarQueryParameters,keyPairQuery_timestamps);
     }
-    list_addElement(localVarHeaderType,"text/plain"); //produces
+    //list_addElement(localVarHeaderType,"text/plain"); //produces  removed text/plain as it is rejected
     list_addElement(localVarHeaderType,"application/json"); //produces
     list_addElement(localVarHeaderType,"application/yaml"); //produces
     list_addElement(localVarHeaderType,"application/vnd.kubernetes.protobuf"); //produces
@@ -35193,9 +35193,11 @@ CoreV1API_readNamespacedPodLog(apiClient_t *apiClient, char *name, char *_namesp
     //    printf("%s\n","Unauthorized");
     //}
     //primitive return type simple
-    char* elementToReturn =  strdup((char*)apiClient->dataReceived);
+    char* elementToReturn = NULL;
 
     if (apiClient->dataReceived) {
+        // moved strdup inside the guard to prevent segfaults on NULL dataReceived
+        elementToReturn = strdup((char*)apiClient->dataReceived);
         free(apiClient->dataReceived);
         apiClient->dataReceived = NULL;
         apiClient->dataReceivedLen = 0;


### PR DESCRIPTION
1. This fix drops the text/plain header as it was causing the requests to fail entirely.
2. This fix also moves the strdup inside the guard to prevent segfaults on null dataReceived (which I experienced and traced with gdb).

This fix is for issue #222 
