### PR TITLE
Use the libwebsockets-dev package provided by the operating system

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,15 +5,7 @@ ARG VARIANT="jammy"
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
 RUN apt-get update && \
-    apt-get install -qq -y git libssl-dev libcurl4-openssl-dev uncrustify cmake g++
-
-RUN git clone https://github.com/warmcat/libwebsockets --depth 1 --branch v4.2-stable && \
-    cd libwebsockets && \
-    mkdir build && \
-    cd build && \
-    cmake -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON-DLWS_WITHOUT_TEST_SERVER_EXTPOLL=ON \
-      -DLWS_WITHOUT_TEST_PING=ON -DLWS_WITHOUT_TEST_CLIENT=ON -DCMAKE_C_FLAGS="-fpic" -DCMAKE_INSTALL_PREFIX=/usr/local .. && \
-    make && make install
+    apt-get install -qq -y git libssl-dev libcurl4-openssl-dev libwebsockets-dev uncrustify cmake g++
 
 # Build pre-requisite: libyaml
 RUN git clone https://github.com/yaml/libyaml --depth 1 --branch release/0.2.5 && \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,17 +15,7 @@ jobs:
     - name: Prepare
       run: |
         sudo apt-get update
-        sudo apt-get install -y libssl-dev libcurl4-openssl-dev uncrustify valgrind
-    - name: Prepare libwebsockets
-      run: |
-        git clone https://github.com/warmcat/libwebsockets --depth 1 --branch v4.2-stable
-        cd libwebsockets
-        mkdir build
-        cd build
-        cmake .. -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON-DLWS_WITHOUT_TEST_SERVER_EXTPOLL=ON \
-              -DLWS_WITHOUT_TEST_PING=ON -DLWS_WITHOUT_TEST_CLIENT=ON -DCMAKE_C_FLAGS="-fpic"
-        make -j $(cat /proc/cpuinfo | grep processor | wc -l)
-        sudo make install
+        sudo apt-get install -y libssl-dev libcurl4-openssl-dev libwebsockets-dev uncrustify valgrind
     - name: Prepare libyaml
       run: |
         git clone https://github.com/yaml/libyaml --depth 1 --branch release/0.2.5

--- a/README.md
+++ b/README.md
@@ -14,17 +14,7 @@ git clone https://github.com/kubernetes-client/c
 CLIENT_REPO_ROOT=${PWD}/c
 
 # Install pre-requisites
-sudo apt-get install libssl-dev libcurl4-openssl-dev uncrustify
-
-# Build pre-requisite: libwebsockets
-git clone https://github.com/warmcat/libwebsockets --depth 1 --branch v4.2-stable
-cd libwebsockets
-mkdir build
-cd build
-cmake -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON -DLWS_WITHOUT_TEST_SERVER_EXTPOLL=ON \
-      -DLWS_WITHOUT_TEST_PING=ON -DLWS_WITHOUT_TEST_CLIENT=ON -DCMAKE_C_FLAGS="-fpic" -DCMAKE_INSTALL_PREFIX=/usr/local ..
-make
-sudo make install
+sudo apt-get install libssl-dev libcurl4-openssl-dev libwebsockets-dev uncrustify
 
 # Build pre-requisite: libyaml
 git clone https://github.com/yaml/libyaml --depth 1 --branch release/0.2.5

--- a/kubernetes/Config.cmake.in
+++ b/kubernetes/Config.cmake.in
@@ -1,6 +1,6 @@
 find_package(OpenSSL REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(yaml CONFIG REQUIRED)
-find_package(libwebsockets CONFIG REQUIRED)
+find_package(Libwebsockets CONFIG REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@pkgName@Targets.cmake")

--- a/kubernetes/PreTarget.cmake
+++ b/kubernetes/PreTarget.cmake
@@ -44,5 +44,5 @@ list(APPEND HDRS
         include/generic.h
         include/utils.h)
 
-find_package(libwebsockets CONFIG REQUIRED)
+find_package(Libwebsockets CONFIG REQUIRED)
 find_package(yaml CONFIG REQUIRED)


### PR DESCRIPTION
Prior to the release of Ubuntu 22.04 LTS, the libwebsockets-dev package in the Ubuntu/Debian apt repository was incompatible with the C client library. So we have to build `libwebsockets v4.2` from source.

But after the release of Ubuntu 22.04 LTS, we can use the libwebsockets-dev package in apt repo to compile this C client library.

Thanks to @Jeansen @homer6 and @rishithaminol for investigating and pushing.