### PR TITLE
Fix Potential Handler Leaks in the c/kubernetes/config/

### DIFF
--- a/kubernetes/config/exec_provider.c
+++ b/kubernetes/config/exec_provider.c
@@ -75,6 +75,11 @@ int kube_exec_and_get_result(ExecCredential_t * exec_credential, const kubeconfi
         result_string = calloc(1, KUBECONFIG_EXEC_RESULT_BUFFER_SIZE);
         if (!result_string) {
             fprintf(stderr, "%s: Cannot allocate memory for command result.[%s]\n", fname, strerror(errno));
+#ifndef _WIN32
+            pclose(fp);
+#else
+            _pclose(fp);
+#endif
             return -1;
         }
         int result_string_remaining_size = KUBECONFIG_EXEC_RESULT_BUFFER_SIZE - 1;
@@ -85,6 +90,11 @@ int kube_exec_and_get_result(ExecCredential_t * exec_credential, const kubeconfi
             if (result_string_remaining_size <= 0) {
                 fprintf(stderr, "%s: The buffer for exec result is not sufficient.\n", fname);
                 rc = -1;
+#ifndef _WIN32
+                pclose(fp);
+#else
+                _pclose(fp);
+#endif
                 goto end;
             }
             strncat(result_string, string_buf, strlen(string_buf));

--- a/kubernetes/config/kube_config_yaml.c
+++ b/kubernetes/config/kube_config_yaml.c
@@ -1065,6 +1065,7 @@ int kubeyaml_save_kubeconfig(const kubeconfig_t * kubeconfig)
     /* Initialize the emitter object. */
     if (!yaml_emitter_initialize(&emitter)) {
         fprintf(stderr, "%s: Could not initialize the emitter object\n", fname);
+        fclose(output);
         return -1;
     }
 


### PR DESCRIPTION
This fix is for issue #243

1. Add `pclose` to `config/exec_provider.c` before `kube_exec_and_get_result` is returned by the exception handling.
2. Add `fclose` to `config/kube_config_yaml.c` before `kubeyaml_save_kubeconfig` is returned by the exception handling.