### PR TITLE
Add examples that uses bazel c kubernetes library

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,6 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake", "make")
+
 cmake(
     name = "kube_c",
     build_args = [
@@ -10,4 +10,26 @@ cmake(
     ],
     lib_source = "//:kubernetes",
     out_shared_libs = ["libkubernetes.so"],
+)
+
+# create lib files (.so or .a)
+# Example: bazel build list_pod_lib
+cc_library(
+    name = "list_pod_lib",
+    srcs = ["bazel/list_pod.c"],
+    deps = [":kube_c"],
+)
+
+# create and run executable file.
+# Example: bazel run list_pod
+cc_binary(
+    name = "list_pod",
+    srcs = ["bazel/list_pod.c"],
+    deps = [":kube_c"],
+)
+
+cc_binary(
+    name = "create_pod",
+    srcs = ["bazel/create_pod.c"],
+    deps = [":kube_c"],
 )

--- a/examples/bazel/create_pod.c
+++ b/examples/bazel/create_pod.c
@@ -1,0 +1,103 @@
+
+#include "kubernetes/config/kube_config.h"
+#include "kubernetes/include/apiClient.h"
+#include "kubernetes/api/CoreV1API.h"
+#include <malloc.h>
+#include <stdio.h>
+#include <errno.h>
+
+void create_a_pod(apiClient_t * apiClient)
+{
+    char *namespace = "default";
+
+    v1_pod_t *podinfo = calloc(1, sizeof(v1_pod_t));
+    podinfo->api_version = strdup("v1");
+    podinfo->kind = strdup("Pod");
+    podinfo->spec = calloc(1, sizeof(v1_pod_spec_t));
+
+    podinfo->metadata = calloc(1, sizeof(v1_object_meta_t));
+    /* set pod name */
+    podinfo->metadata->name = strdup("test-pod-6");
+
+    /* set containers for pod */
+    list_t *containerlist = list_createList();
+    v1_container_t *con = calloc(1, sizeof(v1_container_t));
+    con->name = strdup("my-container");
+    con->image = strdup("ubuntu:latest");
+    con->image_pull_policy = strdup("IfNotPresent");
+
+    /* set command for container */
+    list_t *commandlist = list_createList();
+    char *cmd = strdup("sleep");
+    list_addElement(commandlist, cmd);
+    con->command = commandlist;
+
+    list_t *arglist = list_createList();
+    char *arg1 = strdup("3600");
+    list_addElement(arglist, arg1);
+    con->args = arglist;
+
+    /* set volume mounts for container  */
+    list_t *volumemounts = list_createList();
+    v1_volume_mount_t *volmou = calloc(1, sizeof(v1_volume_mount_t));
+    volmou->mount_path = strdup("/test");
+    volmou->name = strdup("test");
+    list_addElement(volumemounts, volmou);
+    con->volume_mounts = volumemounts;
+
+    list_addElement(containerlist, con);
+    podinfo->spec->containers = containerlist;
+
+    /* set volumes for pod */
+    list_t *volumelist = list_createList();
+    v1_volume_t *volume = calloc(1, sizeof(v1_volume_t));
+    volume->name = strdup("test");
+
+    v1_host_path_volume_source_t *hostPath = calloc(1, sizeof(v1_host_path_volume_source_t));
+    hostPath->path = strdup("/test");
+    volume->host_path = hostPath;
+
+    list_addElement(volumelist, volume);
+    podinfo->spec->volumes = volumelist;
+
+    /* call API in libkubernetes to create pod */
+    v1_pod_t *apod = CoreV1API_createNamespacedPod(apiClient, namespace, podinfo, NULL, NULL, NULL, NULL);
+    printf("code=%ld\n", apiClient->response_code);
+
+    v1_pod_free(apod);
+    v1_pod_free(podinfo);
+}
+
+int main(int argc, char *argv[])
+{
+
+    int rc = 0;
+
+    char *baseName = NULL;
+    sslConfig_t *sslConfig = NULL;
+    list_t *apiKeys = NULL;
+    apiClient_t *k8sApiClient = NULL;
+
+    rc = load_kube_config(&baseName, &sslConfig, &apiKeys, NULL);
+    if (0 == rc) {
+        k8sApiClient = apiClient_create_with_base_path(baseName, sslConfig, apiKeys);
+    } else {
+        printf("Cannot load kubernetes configuration.\n");
+        return -1;
+    }
+
+    if (k8sApiClient) {
+        create_a_pod(k8sApiClient);
+    }
+
+    free_client_config(baseName, sslConfig, apiKeys);
+    baseName = NULL;
+    sslConfig = NULL;
+    apiKeys = NULL;
+
+    apiClient_free(k8sApiClient);
+    k8sApiClient = NULL;
+    apiClient_unsetupGlobalEnv();
+
+    return 0;
+}

--- a/examples/bazel/list_pod.c
+++ b/examples/bazel/list_pod.c
@@ -1,0 +1,64 @@
+#include "kubernetes/config/kube_config.h"
+#include "kubernetes/api/CoreV1API.h"
+#include "stdio.h"
+
+void list_pod(apiClient_t * apiClient)
+{
+    v1_pod_list_t *pod_list = NULL;
+    pod_list = CoreV1API_listNamespacedPod(apiClient, "default",    /*namespace */
+                                           NULL,    /* pretty */
+                                           NULL,    /* allowWatchBookmarks */
+                                           NULL,    /* continue */
+                                           NULL,    /* fieldSelector */
+                                           NULL,    /* labelSelector */
+                                           NULL,    /* limit */
+                                           NULL,    /* resourceVersion */
+                                           NULL,    /* resourceVersionMatch */
+                                           NULL,    /* sendInitialEvents */
+                                           NULL,    /* timeoutSeconds */
+                                           NULL /* watch */
+        );
+    printf("The return code of HTTP request=%ld\n", apiClient->response_code);
+    if (pod_list) {
+        printf("Get pod list:\n");
+        listEntry_t *listEntry = NULL;
+        v1_pod_t *pod = NULL;
+        list_ForEach(listEntry, pod_list->items) {
+            pod = listEntry->data;
+            printf("\tThe pod name: %s\n", pod->metadata->name);
+        }
+        v1_pod_list_free(pod_list);
+        pod_list = NULL;
+    } else {
+        printf("Cannot get any pod.\n");
+    }
+}
+
+int main()
+{
+    char *basePath = NULL;
+    sslConfig_t *sslConfig = NULL;
+    list_t *apiKeys = NULL;
+    int rc = load_kube_config(&basePath, &sslConfig, &apiKeys, NULL);   /* NULL means loading configuration from $HOME/.kube/config */
+    if (rc != 0) {
+        printf("Cannot load kubernetes configuration.\n");
+        return -1;
+    }
+    apiClient_t *apiClient = apiClient_create_with_base_path(basePath, sslConfig, apiKeys);
+    if (!apiClient) {
+        printf("Cannot create a kubernetes client.\n");
+        return -1;
+    }
+
+    list_pod(apiClient);
+
+    apiClient_free(apiClient);
+    apiClient = NULL;
+    free_client_config(basePath, sslConfig, apiKeys);
+    basePath = NULL;
+    sslConfig = NULL;
+    apiKeys = NULL;
+    apiClient_unsetupGlobalEnv();
+
+    return 0;
+}


### PR DESCRIPTION
In this PR, I added examples that use the Bazel populated K8s C client library `kube_c` as a dependency to run some of the existing examples.