### PR TITLE
Update k8s git robot for GitHub Actions

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Commit and push
         run: |
           # Commit and push
-          git config user.email "k8s.ci.robot@gmail.com"
-          git config user.name "Kubernetes Prow Robot"
+          git config user.email "k8s-publishing-bot@users.noreply.github.com"
+          git config user.name "Kubernetes Publisher"
           git checkout -b "$BRANCH"
           git add .
           git commit -s -m 'Automated openapi generation from ${{ github.event.inputs.kubernetesBranch }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
           cat OWNERS | grep ${{ github.actor }}
       - name: Prepare
         run: |
-          git config user.email "k8s.ci.robot@gmail.com"
-          git config user.name "Kubernetes Prow Robot"
+          git config user.email "k8s-publishing-bot@users.noreply.github.com"
+          git config user.name "Kubernetes Publisher"
       - name: Release Prepare
         run: |
           git tag -a v${{ github.event.inputs.releaseVersion }} -m "version ${{ github.event.inputs.releaseVersion }}"


### PR DESCRIPTION
as old robot lost "push" permissions:

```bash
remote: Permission to kubernetes-client/c.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/kubernetes-client/c/': The requested URL returned error: 403
```