### PR TITLE
Support pure C compiler build

### DIFF
--- a/kubernetes/CMakeLists.txt
+++ b/kubernetes/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required (VERSION 2.6...3.10.2)
 project (CGenerator C)
 
-enable_language(C)
-enable_language(CXX)
-
 cmake_policy(SET CMP0063 NEW)
 
 set(CMAKE_C_VISIBILITY_PRESET default)

--- a/kubernetes/ConfigureChecks.cmake
+++ b/kubernetes/ConfigureChecks.cmake
@@ -1,5 +1,5 @@
-include(CheckCXXSymbolExists)
+include(CheckSymbolExists)
 
-check_cxx_symbol_exists(strndup "string.h" HAVE_STRNDUP)
-check_cxx_symbol_exists(secure_getenv "stdlib.h" HAVE_SECURE_GETENV)
-check_cxx_symbol_exists(getenv "stdlib.h" HAVE_GETENV)
+check_symbol_exists(strndup "string.h" HAVE_STRNDUP)
+check_symbol_exists(secure_getenv "stdlib.h" HAVE_SECURE_GETENV)
+check_symbol_exists(getenv "stdlib.h" HAVE_GETENV)


### PR DESCRIPTION
Because the upstream repo  changes the compiler to C by https://github.com/OpenAPITools/openapi-generator/pull/20289 , the build failed by default:

```
CMake Error at /usr/local/share/cmake-3.31/Modules/CheckSymbolExists.cmake:163 (try_compile):
  Unknown extension ".cxx" for file

    /home/runner/work/c/c/kubernetes/build/CMakeFiles/CMakeScratch/TryCompile-NwLhCQ/CheckSymbolExists.cxx

  try_compile() works only for enabled languages.  Currently these are:

    C
```

We can fix the build error by the following 2 solutions:

1.  Add C++ support to CMakeList.txt

```
enable_language(CXX)
``` 
This change needs to be committed to the upstream repository. Otherwise it will be overwritten every time this client is regenerated.

2. Change the `CheckCXXSymbolExists` to `CheckSymbolExists` to support C compiler.

Now, I would recommend solution 2, since we can support C compiler to compile this project.
