### PR TITLE
Implement curl KeepAlive for watch connections

### DIFF
--- a/examples/watch_list_pod/main.c
+++ b/examples/watch_list_pod/main.c
@@ -75,6 +75,7 @@ void watch_list_pod(apiClient_t * apiClient)
     int watch = 1;
     int timeoutSeconds = 30;    /* Watch for 30 seconds */
     // int timeoutSeconds = 0;  /* Set timeoutSeconds to 0 to keep watching and not exit */
+    // apiClient->curlConfig->keepalive = 1; /* Enable keepalive */
     CoreV1API_listNamespacedPod(apiClient, "default",   /*namespace */
                                 NULL,   /* pretty */
                                 NULL,   /* allowWatchBookmarks */

--- a/kubernetes/include/apiClient.h
+++ b/kubernetes/include/apiClient.h
@@ -19,9 +19,19 @@ typedef struct sslConfig_t {
                                   /* 1 -- skip ssl verify for server certificate */
 } sslConfig_t;
 
+typedef struct curl_config_t {
+    int keepalive;  /* 0 -- disable keepalive */
+                    /* 1 -- enable keepalive */
+    long keepidle;  /* keep-alive idle time: default to 120 seconds */
+    long keepintvl; /* interval time between keep-alive probes: default to 60 seconds */
+} curl_config_t;
+
+bool isWatchCall(list_t *queryParameters);
+
 typedef struct apiClient_t {
     char *basePath;
     sslConfig_t *sslConfig;
+    curl_config_t *curlConfig;
     void *dataReceived;
     long dataReceivedLen;
     void (*data_callback_func)(void **, long *);


### PR DESCRIPTION
Hello,

I've implemented a simple way to enable keepalive as suggested in https://github.com/kubernetes-client/c/issues/202#issuecomment-1690255940

I'm activating it only if "watch=1" is passed as queryParameters and keepalive is enabled in the clientApi configuration.
If you want this to be different, please advice, and I will change the implementation.

I've tested it with `watch_list_pod` example and using wireshark:

<img width="913" height="99" alt="keepalive" src="https://github.com/user-attachments/assets/577e3e9a-5834-4ac5-9d9f-2dd15aca05f2" />


Best,

hirishh



