### PR TITLE
feature: Add control flag for static compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ cd ${CLIENT_REPO_ROOT}/kubernetes
 mkdir build
 cd build
 # If you don't need to debug the C client library:
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=ON ..
+# If you don't want to build a shared but a static library:
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=OFF ..
+
 # If you want to use `gdb` to debug the C client library, add `-DCMAKE_BUILD_TYPE=Debug` to the cmake command line, e.g.
 # cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local ..
 make

--- a/kubernetes/CMakeLists.txt
+++ b/kubernetes/CMakeLists.txt
@@ -1583,7 +1583,13 @@ include(PreTarget.cmake OPTIONAL)
 set(PROJECT_VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 
 # Add library with project file with project name as library name
-add_library(${pkgName} ${SRCS} ${HDRS})
+if(NOT BUILD_SHARED_LIBS)
+    add_library(${pkgName} ${SRCS} ${HDRS})
+else()
+    add_library(${pkgName} STATIC ${SRCS} ${HDRS})
+endif()
+
+
 # Link dependent libraries
 if(NOT CMAKE_VERSION VERSION_LESS 3.4)
     target_link_libraries(${pkgName} PRIVATE OpenSSL::SSL OpenSSL::Crypto)


### PR DESCRIPTION
Similar to  https://github.com/yaml/libyaml, this PR adds a flag BUILD_SHARED_LIBS to build a statically linked library of kubernetes-client.

