### PR TITLE
Add body to generic delete api

### DIFF
--- a/examples/generic/main.c
+++ b/examples/generic/main.c
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
     list_freeList(contentType);
     free(patch);
 
-    char *del = Generic_deleteResource(genericClient, "test");
+    char *del = Generic_deleteResource(genericClient, "test", NULL);
     printf("%s\n", del);
     free(del);
 

--- a/kubernetes/include/generic.h
+++ b/kubernetes/include/generic.h
@@ -23,8 +23,8 @@ char* Generic_readResource(genericClient_t *client, const char *name);
 char* Generic_listNamespaced(genericClient_t *client, const char *ns, list_t *queryParameters);
 char* Generic_list(genericClient_t *client, list_t *queryParameters);
 
-char* Generic_deleteNamespacedResource(genericClient_t *client, const char *ns, const char *name);
-char* Generic_deleteResource(genericClient_t *client, const char* name);
+char* Generic_deleteNamespacedResource(genericClient_t *client, const char *ns, const char *name, const char* body);
+char* Generic_deleteResource(genericClient_t *client, const char* name, const char* body);
 
 char* Generic_createNamespacedResource(genericClient_t *client, const char *ns, const char* body);
 char* Generic_createResource(genericClient_t *client, const char* body);

--- a/kubernetes/src/generic.c
+++ b/kubernetes/src/generic.c
@@ -123,16 +123,16 @@ char *Generic_list(genericClient_t *client, list_t *queryParameters) {
     return callSimplifiedInternal(client, path, "GET", NULL, queryParameters);
 }
 
-char* Generic_deleteNamespacedResource(genericClient_t *client, const char *namespace, const char *name) {
+char* Generic_deleteNamespacedResource(genericClient_t *client, const char *namespace, const char *name, const char* body) {
     char path[128];
     makeNamespacedResourcePath(path, client, namespace, name);
-    return callSimplifiedInternal(client, path, "DELETE", NULL, NULL);
+    return callSimplifiedInternal(client, path, "DELETE", body, NULL);
 }
 
-char* Generic_deleteResource(genericClient_t *client, const char* name) {
+char* Generic_deleteResource(genericClient_t *client, const char* name, const char* body) {
     char path[128];
     makeResourcePath(path, client, name);
-    return callSimplifiedInternal(client, path, "DELETE", NULL, NULL);
+    return callSimplifiedInternal(client, path, "DELETE", body, NULL);
 }
 
 char* Generic_createNamespacedResource(genericClient_t *client, const char *ns, const char* body) {


### PR DESCRIPTION
Hello,

This simple PR will add the possibility to include a body in the generic_delete* APIs.
This will let people use the DeleteOptions and change the propagationPolicy (https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/)

Thanks!

hirishh