### PR TITLE
Add queryParameters to generic create api

### DIFF
--- a/examples/generic/main.c
+++ b/examples/generic/main.c
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
     genericClient = genericClient_create(apiClient, "", "v1", "namespaces");
 
     const char *body = "{\"apiVersion\": \"v1\", \"kind\": \"Namespace\", \"metadata\": { \"name\": \"test\" } }";
-    char *create = Generic_createResource(genericClient, body);
+    char *create = Generic_createResource(genericClient, body, NULL);
     printf("%s\n", create);
     free(create);
 

--- a/kubernetes/include/generic.h
+++ b/kubernetes/include/generic.h
@@ -26,8 +26,8 @@ char* Generic_list(genericClient_t *client, list_t *queryParameters);
 char* Generic_deleteNamespacedResource(genericClient_t *client, const char *ns, const char *name, const char* body);
 char* Generic_deleteResource(genericClient_t *client, const char* name, const char* body);
 
-char* Generic_createNamespacedResource(genericClient_t *client, const char *ns, const char* body);
-char* Generic_createResource(genericClient_t *client, const char* body);
+char* Generic_createNamespacedResource(genericClient_t *client, const char *ns, const char* body, list_t *queryParameters);
+char* Generic_createResource(genericClient_t *client, const char* body, list_t *queryParameters);
 
 char* Generic_replaceNamespacedResource(genericClient_t *client, const char *ns, const char *name, const char* body);
 char* Generic_replaceResource(genericClient_t *client, const char *name, const char* body);

--- a/kubernetes/src/generic.c
+++ b/kubernetes/src/generic.c
@@ -135,16 +135,16 @@ char* Generic_deleteResource(genericClient_t *client, const char* name, const ch
     return callSimplifiedInternal(client, path, "DELETE", body, NULL);
 }
 
-char* Generic_createNamespacedResource(genericClient_t *client, const char *ns, const char* body) {
+char* Generic_createNamespacedResource(genericClient_t *client, const char *ns, const char* body, list_t *queryParameters) {
     char path[128];
     makeNamespacedResourcePath(path, client, ns, "");
-    return callSimplifiedInternal(client, path, "POST", body, NULL);
+    return callSimplifiedInternal(client, path, "POST", body, queryParameters);
 }
 
-char* Generic_createResource(genericClient_t *client, const char* body) {
+char* Generic_createResource(genericClient_t *client, const char* body, list_t *queryParameters) {
     char path[128];
     makeResourcePath(path, client, "");
-    return callSimplifiedInternal(client, path, "POST", body, NULL);
+    return callSimplifiedInternal(client, path, "POST", body, queryParameters);
 }
 
 char* Generic_replaceNamespacedResource(genericClient_t *client, const char *ns, const char *name, const char* body) {


### PR DESCRIPTION
Hello,

Another simple PR that will add the possibility to include queryParameters in the generic_create* APIs.
This will let people use the dryRun, for example.

Thanks!

hirishh